### PR TITLE
v0: core mount + compile contract ABI (WASM)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,12 @@
 version = 4
 
 [[package]]
+name = "carreltex-core"
+version = "0.1.0"
+
+[[package]]
 name = "carreltex-wasm-smoke"
 version = "0.1.0"
+dependencies = [
+ "carreltex-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [workspace]
 members = [
   "crates/carreltex-wasm-smoke",
+  "crates/carreltex-core",
 ]
 resolver = "2"
 
 [workspace.package]
 edition = "2021"
 license = "MIT"
-

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Browser-first WASM LaTeX/typesetting engine (WIP).
 
 - Always buildable for `wasm32-unknown-unknown` (WASM viability gate).
 - Fail-closed by default.
+- No silent “simplified” semantics.
 - Determinism is a first-class constraint (`SOURCE_DATE_EPOCH`, pinned toolchains).
 
 ## Proof (WASM viability gate)
@@ -18,4 +19,10 @@ scripts/wasm_smoke_build.sh
 
 ```bash
 scripts/proof_wasm_smoke.sh
+```
+
+## Proof (v0 bundle)
+
+```bash
+scripts/proof_v0.sh
 ```

--- a/crates/carreltex-core/Cargo.toml
+++ b/crates/carreltex-core/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "carreltex-core"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]

--- a/crates/carreltex-core/src/compile.rs
+++ b/crates/carreltex-core/src/compile.rs
@@ -1,0 +1,126 @@
+use crate::mount::{Error, Mount};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompileStatus {
+    Ok = 0,
+    InvalidInput = 1,
+    NotImplemented = 2,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompileReport {
+    pub status: CompileStatus,
+    pub missing_components: &'static [&'static str],
+}
+
+impl CompileReport {
+    pub fn to_canonical_json(&self) -> String {
+        // Manual canonical JSON (stable key order, no serde dependency).
+        // Keys are always: status, missing_components.
+        let status_str = match self.status {
+            CompileStatus::Ok => "OK",
+            CompileStatus::InvalidInput => "INVALID_INPUT",
+            CompileStatus::NotImplemented => "NOT_IMPLEMENTED",
+        };
+
+        let mut out = String::new();
+        out.push('{');
+        out.push_str("\"missing_components\":[");
+        for (idx, comp) in self.missing_components.iter().enumerate() {
+            if idx != 0 {
+                out.push(',');
+            }
+            out.push('"');
+            out.push_str(&escape_json_string(comp));
+            out.push('"');
+        }
+        out.push_str("],\"status\":\"");
+        out.push_str(status_str);
+        out.push_str("\"}");
+        out
+    }
+}
+
+pub fn compile_main_v0(mount: &mut Mount) -> (CompileStatus, CompileReport) {
+    if mount.finalize().is_err() {
+        return (
+            CompileStatus::InvalidInput,
+            CompileReport {
+                status: CompileStatus::InvalidInput,
+                missing_components: &[],
+            },
+        );
+    }
+
+    (
+        CompileStatus::NotImplemented,
+        CompileReport {
+            status: CompileStatus::NotImplemented,
+            missing_components: &["tex-engine"],
+        },
+    )
+}
+
+fn escape_json_string(value: &str) -> String {
+    // Minimal, fail-closed escaping: reject control chars by escaping them.
+    let mut out = String::new();
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => {
+                use core::fmt::Write;
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+pub fn validate_compile_report_json(report_json: &str) -> Result<(), Error> {
+    // Very small guard: ensure it is non-empty UTF-8 and contains required keys.
+    // The full JSON parsing contract is enforced by the JS proof (Leaf 24).
+    if report_json.trim().is_empty() {
+        return Err(Error::InvalidInput);
+    }
+    if !report_json.contains("\"status\"") {
+        return Err(Error::InvalidInput);
+    }
+    if !report_json.contains("\"missing_components\"") {
+        return Err(Error::InvalidInput);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{compile_main_v0, CompileStatus};
+    use crate::mount::Mount;
+
+    #[test]
+    fn compile_requires_valid_mount() {
+        let mut mount = Mount::default();
+        let (status, report) = compile_main_v0(&mut mount);
+        assert_eq!(status, CompileStatus::InvalidInput);
+        assert_eq!(report.status, CompileStatus::InvalidInput);
+    }
+
+    #[test]
+    fn compile_returns_not_implemented_when_mount_valid() {
+        let mut mount = Mount::default();
+        let main = b"\\documentclass{article}\n\\begin{document}\nHi\n\\end{document}\n";
+        assert!(mount.add_file(b"main.tex", main).is_ok());
+
+        let (status, report) = compile_main_v0(&mut mount);
+        assert_eq!(status, CompileStatus::NotImplemented);
+        let json = report.to_canonical_json();
+        assert!(json.contains("\"status\":\"NOT_IMPLEMENTED\""));
+        assert!(json.contains("\"missing_components\""));
+        assert!(json.contains("tex-engine"));
+    }
+}
+

--- a/crates/carreltex-core/src/lib.rs
+++ b/crates/carreltex-core/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod compile;
+pub mod mount;
+
+pub use compile::{compile_main_v0, validate_compile_report_json, CompileReport, CompileStatus};
+pub use mount::{
+    validate_main_tex, Error, Mount, MAIN_TEX_MAX_BYTES, MAX_FILES, MAX_FILE_BYTES, MAX_PATH_LEN,
+    MAX_TOTAL_BYTES,
+};

--- a/crates/carreltex-core/src/mount.rs
+++ b/crates/carreltex-core/src/mount.rs
@@ -1,0 +1,255 @@
+use std::collections::BTreeMap;
+
+pub const MAIN_TEX_MAX_BYTES: usize = 1 * 1024 * 1024;
+pub const MAX_FILES: usize = 64;
+pub const MAX_TOTAL_BYTES: usize = 4 * 1024 * 1024;
+pub const MAX_PATH_LEN: usize = 256;
+pub const MAX_FILE_BYTES: usize = 1 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Error {
+    InvalidInput,
+    InvalidUtf8,
+    InvalidPath,
+    PathTooLong,
+    DuplicatePath,
+    TooManyFiles,
+    FileTooLarge,
+    TotalBytesExceeded,
+    MissingMainTex,
+    InvalidMainTex,
+}
+
+#[derive(Default, Debug)]
+pub struct Mount {
+    files: BTreeMap<String, Vec<u8>>,
+    total_bytes: usize,
+    finalized: bool,
+}
+
+impl Mount {
+    pub fn reset(&mut self) {
+        self.files.clear();
+        self.total_bytes = 0;
+        self.finalized = false;
+    }
+
+    pub fn add_file(&mut self, path_bytes: &[u8], data: &[u8]) -> Result<(), Error> {
+        if self.finalized {
+            return Err(Error::InvalidInput);
+        }
+        if data.is_empty() {
+            return Err(Error::InvalidInput);
+        }
+        if data.len() > MAX_FILE_BYTES {
+            return Err(Error::FileTooLarge);
+        }
+
+        let path = normalize_path(path_bytes)?;
+
+        if self.files.len() >= MAX_FILES {
+            return Err(Error::TooManyFiles);
+        }
+        if self.files.contains_key(path) {
+            return Err(Error::DuplicatePath);
+        }
+
+        let next_total = self
+            .total_bytes
+            .checked_add(data.len())
+            .ok_or(Error::TotalBytesExceeded)?;
+        if next_total > MAX_TOTAL_BYTES {
+            return Err(Error::TotalBytesExceeded);
+        }
+
+        self.files.insert(path.to_owned(), data.to_vec());
+        self.total_bytes = next_total;
+        Ok(())
+    }
+
+    pub fn has_file(&self, path_bytes: &[u8]) -> Result<bool, Error> {
+        let path = normalize_path(path_bytes)?;
+        Ok(self.files.contains_key(path))
+    }
+
+    pub fn is_finalized(&self) -> bool {
+        self.finalized
+    }
+
+    pub fn finalize(&mut self) -> Result<(), Error> {
+        if self.finalized {
+            return Ok(());
+        }
+        if self.total_bytes > MAX_TOTAL_BYTES {
+            return Err(Error::TotalBytesExceeded);
+        }
+        let main_tex = self.files.get("main.tex").ok_or(Error::MissingMainTex)?;
+        validate_main_tex(main_tex).map_err(|_| Error::InvalidMainTex)?;
+        self.finalized = true;
+        Ok(())
+    }
+
+    pub fn read_file(&self, path: &str) -> Option<&[u8]> {
+        self.files.get(path).map(|bytes| bytes.as_slice())
+    }
+}
+
+pub fn validate_main_tex(bytes: &[u8]) -> Result<(), Error> {
+    if bytes.is_empty() || bytes.len() > MAIN_TEX_MAX_BYTES {
+        return Err(Error::InvalidInput);
+    }
+    if bytes.iter().any(|byte| *byte == 0) {
+        return Err(Error::InvalidInput);
+    }
+    let text = core::str::from_utf8(bytes).map_err(|_| Error::InvalidUtf8)?;
+    if text.trim().is_empty() {
+        return Err(Error::InvalidInput);
+    }
+    Ok(())
+}
+
+fn normalize_path(path_bytes: &[u8]) -> Result<&str, Error> {
+    if path_bytes.is_empty() {
+        return Err(Error::InvalidInput);
+    }
+    if path_bytes.len() > MAX_PATH_LEN {
+        return Err(Error::PathTooLong);
+    }
+    if path_bytes.iter().any(|byte| *byte == 0 || *byte == b'\\') {
+        return Err(Error::InvalidPath);
+    }
+
+    let path = core::str::from_utf8(path_bytes).map_err(|_| Error::InvalidUtf8)?;
+    if path.starts_with('/') {
+        return Err(Error::InvalidPath);
+    }
+
+    let mut saw_segment = false;
+    for segment in path.split('/') {
+        if segment.is_empty() || segment == ".." {
+            return Err(Error::InvalidPath);
+        }
+        saw_segment = true;
+    }
+
+    if !saw_segment {
+        return Err(Error::InvalidPath);
+    }
+
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_main_tex, Error, Mount, MAX_FILES, MAX_FILE_BYTES, MAX_PATH_LEN};
+
+    fn valid_main() -> Vec<u8> {
+        b"\\documentclass{article}\n\\begin{document}\nHello\n\\end{document}\n".to_vec()
+    }
+
+    #[test]
+    fn path_policy_rejects_invalid_paths() {
+        let mut mount = Mount::default();
+        let bytes = valid_main();
+
+        let invalid_paths = [
+            "/abs.tex",
+            "../up.tex",
+            "a/../b.tex",
+            "a\\b.tex",
+            "",
+            "a//b.tex",
+            "a/b/",
+        ];
+
+        for path in invalid_paths {
+            let result = mount.add_file(path.as_bytes(), &bytes);
+            assert!(result.is_err(), "expected path to fail: {path}");
+        }
+    }
+
+    #[test]
+    fn duplicate_path_rejected() {
+        let mut mount = Mount::default();
+        let bytes = valid_main();
+        assert!(mount.add_file(b"dup.tex", &bytes).is_ok());
+        assert_eq!(
+            mount.add_file(b"dup.tex", &bytes),
+            Err(Error::DuplicatePath)
+        );
+    }
+
+    #[test]
+    fn finalize_requires_main_tex() {
+        let mut mount = Mount::default();
+        assert!(mount.add_file(b"sub.tex", b"sub").is_ok());
+        assert_eq!(mount.finalize(), Err(Error::MissingMainTex));
+    }
+
+    #[test]
+    fn finalize_rejects_invalid_main_tex() {
+        let mut mount = Mount::default();
+        assert!(mount.add_file(b"main.tex", b" \n\t ").is_ok());
+        assert_eq!(mount.finalize(), Err(Error::InvalidMainTex));
+    }
+
+    #[test]
+    fn finalize_sets_finalized_and_blocks_additional_files() {
+        let mut mount = Mount::default();
+        let main = valid_main();
+        assert!(mount.add_file(b"main.tex", &main).is_ok());
+        assert!(mount.finalize().is_ok());
+        assert!(mount.is_finalized());
+        assert_eq!(mount.add_file(b"later.tex", b"x"), Err(Error::InvalidInput));
+    }
+
+    #[test]
+    fn caps_enforced_for_file_size_and_path_len() {
+        let mut mount = Mount::default();
+        let oversize_file = vec![b'a'; MAX_FILE_BYTES + 1];
+        assert_eq!(
+            mount.add_file(b"big.tex", &oversize_file),
+            Err(Error::FileTooLarge)
+        );
+
+        let long_path = vec![b'a'; MAX_PATH_LEN + 1];
+        assert_eq!(
+            mount.add_file(&long_path, b"x"),
+            Err(Error::PathTooLong)
+        );
+    }
+
+    #[test]
+    fn caps_enforced_for_max_files() {
+        let mut mount = Mount::default();
+        for index in 0..MAX_FILES {
+            let path = format!("f{index}.tex");
+            assert!(mount.add_file(path.as_bytes(), b"x").is_ok());
+        }
+        assert_eq!(
+            mount.add_file(b"overflow.tex", b"x"),
+            Err(Error::TooManyFiles)
+        );
+    }
+
+    #[test]
+    fn has_file_and_finalize_success() {
+        let mut mount = Mount::default();
+        let main = valid_main();
+        assert!(mount.add_file(b"main.tex", &main).is_ok());
+        assert!(mount.add_file(b"sub.tex", b"sub").is_ok());
+
+        assert_eq!(mount.has_file(b"main.tex"), Ok(true));
+        assert_eq!(mount.has_file(b"missing.tex"), Ok(false));
+        assert!(mount.finalize().is_ok());
+        assert_eq!(mount.read_file("main.tex").unwrap(), main.as_slice());
+    }
+
+    #[test]
+    fn validate_main_tex_checks_utf8_and_nul() {
+        assert!(validate_main_tex(&valid_main()).is_ok());
+        assert_eq!(validate_main_tex(&[0]), Err(Error::InvalidInput));
+        assert_eq!(validate_main_tex(&[0xff]), Err(Error::InvalidUtf8));
+    }
+}
+

--- a/crates/carreltex-wasm-smoke/Cargo.toml
+++ b/crates/carreltex-wasm-smoke/Cargo.toml
@@ -8,4 +8,4 @@ license.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-
+carreltex-core = { path = "../carreltex-core" }

--- a/crates/carreltex-wasm-smoke/src/lib.rs
+++ b/crates/carreltex-wasm-smoke/src/lib.rs
@@ -1,5 +1,192 @@
+use std::sync::{Mutex, OnceLock};
+
+use carreltex_core::{
+    compile_main_v0, validate_compile_report_json, validate_main_tex, CompileStatus, Mount,
+    MAIN_TEX_MAX_BYTES,
+};
+
 #[no_mangle]
-pub extern "C" fn carreltex_wasm_smoke_add(a: u32, b: u32) -> u32 {
-    a.wrapping_add(b)
+pub extern "C" fn carreltex_wasm_smoke_add(left: i32, right: i32) -> i32 {
+    left + right
+}
+
+fn mount_state() -> &'static Mutex<Mount> {
+    static STATE: OnceLock<Mutex<Mount>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(Mount::default()))
+}
+
+fn last_report_state() -> &'static Mutex<Vec<u8>> {
+    static STATE: OnceLock<Mutex<Vec<u8>>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn read_input_bytes<'a>(ptr: *const u8, len: usize) -> Option<&'a [u8]> {
+    if ptr.is_null() || len == 0 {
+        return None;
+    }
+    Some(unsafe { core::slice::from_raw_parts(ptr, len) })
+}
+
+#[no_mangle]
+pub extern "C" fn carreltex_wasm_alloc(size: usize) -> *mut u8 {
+    if size == 0 || size > MAIN_TEX_MAX_BYTES {
+        return core::ptr::null_mut();
+    }
+
+    let mut buffer = Vec::<u8>::with_capacity(size);
+    let ptr = buffer.as_mut_ptr();
+    core::mem::forget(buffer);
+    ptr
+}
+
+#[no_mangle]
+pub extern "C" fn carreltex_wasm_dealloc(ptr: *mut u8, size: usize) {
+    if ptr.is_null() || size == 0 || size > MAIN_TEX_MAX_BYTES {
+        return;
+    }
+
+    unsafe {
+        drop(Vec::<u8>::from_raw_parts(ptr, 0, size));
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn carreltex_wasm_validate_main_tex(ptr: *const u8, len: usize) -> i32 {
+    let bytes = match read_input_bytes(ptr, len) {
+        Some(bytes) => bytes,
+        None => return 1,
+    };
+
+    if validate_main_tex(bytes).is_ok() {
+        0
+    } else {
+        1
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn carreltex_wasm_mount_reset() -> i32 {
+    let mut mount = match mount_state().lock() {
+        Ok(guard) => guard,
+        Err(_) => return 1,
+    };
+    mount.reset();
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn carreltex_wasm_mount_add_file(
+    path_ptr: *const u8,
+    path_len: usize,
+    data_ptr: *const u8,
+    data_len: usize,
+) -> i32 {
+    let path_bytes = match read_input_bytes(path_ptr, path_len) {
+        Some(bytes) => bytes,
+        None => return 1,
+    };
+    let data_bytes = match read_input_bytes(data_ptr, data_len) {
+        Some(bytes) => bytes,
+        None => return 1,
+    };
+
+    let mut mount = match mount_state().lock() {
+        Ok(guard) => guard,
+        Err(_) => return 1,
+    };
+
+    if mount.add_file(path_bytes, data_bytes).is_ok() {
+        0
+    } else {
+        1
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn carreltex_wasm_mount_finalize() -> i32 {
+    let mut mount = match mount_state().lock() {
+        Ok(guard) => guard,
+        Err(_) => return 1,
+    };
+    if mount.finalize().is_ok() {
+        0
+    } else {
+        1
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn carreltex_wasm_mount_has_file(path_ptr: *const u8, path_len: usize) -> i32 {
+    let path_bytes = match read_input_bytes(path_ptr, path_len) {
+        Some(bytes) => bytes,
+        None => return 1,
+    };
+    let mount = match mount_state().lock() {
+        Ok(guard) => guard,
+        Err(_) => return 1,
+    };
+
+    match mount.has_file(path_bytes) {
+        Ok(true) => 0,
+        _ => 1,
+    }
+}
+
+fn set_last_report_bytes(report_json: &str) {
+    let mut last = match last_report_state().lock() {
+        Ok(guard) => guard,
+        Err(_) => return,
+    };
+    last.clear();
+    last.extend_from_slice(report_json.as_bytes());
+}
+
+#[no_mangle]
+pub extern "C" fn carreltex_wasm_compile_main_v0() -> i32 {
+    let mut mount = match mount_state().lock() {
+        Ok(guard) => guard,
+        Err(_) => {
+            set_last_report_bytes("{\"missing_components\":[],\"status\":\"INVALID_INPUT\"}");
+            return CompileStatus::InvalidInput as i32;
+        }
+    };
+
+    let (status, report) = compile_main_v0(&mut mount);
+    let json = report.to_canonical_json();
+    // Fail-closed: if the report is malformed, degrade to INVALID_INPUT.
+    if validate_compile_report_json(&json).is_err() {
+        set_last_report_bytes("{\"missing_components\":[],\"status\":\"INVALID_INPUT\"}");
+        return CompileStatus::InvalidInput as i32;
+    }
+
+    set_last_report_bytes(&json);
+    status as i32
+}
+
+#[no_mangle]
+pub extern "C" fn carreltex_wasm_compile_report_len_v0() -> usize {
+    let last = match last_report_state().lock() {
+        Ok(guard) => guard,
+        Err(_) => return 0,
+    };
+    last.len()
+}
+
+#[no_mangle]
+pub extern "C" fn carreltex_wasm_compile_report_copy_v0(out_ptr: *mut u8, out_len: usize) -> usize {
+    if out_ptr.is_null() || out_len == 0 {
+        return 0;
+    }
+    let last = match last_report_state().lock() {
+        Ok(guard) => guard,
+        Err(_) => return 0,
+    };
+    if out_len < last.len() {
+        return 0;
+    }
+    unsafe {
+        core::ptr::copy_nonoverlapping(last.as_ptr(), out_ptr, last.len());
+    }
+    last.len()
 }
 

--- a/scripts/proof_v0.sh
+++ b/scripts/proof_v0.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cargo test --manifest-path "$ROOT_DIR/crates/carreltex-core/Cargo.toml"
+"$ROOT_DIR/scripts/proof_wasm_smoke.sh"
+
+echo "PASS: carreltex v0 proof bundle"
+

--- a/scripts/proof_wasm_smoke.sh
+++ b/scripts/proof_wasm_smoke.sh
@@ -11,4 +11,3 @@ if ! command -v node >/dev/null 2>&1; then
 fi
 
 node "$ROOT_DIR/scripts/wasm_smoke_js_proof.mjs"
-

--- a/scripts/wasm_smoke_js_proof.mjs
+++ b/scripts/wasm_smoke_js_proof.mjs
@@ -24,5 +24,151 @@ if (result !== 3) {
   throw new Error(`Unexpected result: ${result}`);
 }
 
-console.log('PASS: JS loaded WASM and called export (1+2=3)');
+const { memory } = instance.exports;
+if (!(memory instanceof WebAssembly.Memory)) {
+  throw new Error('Missing export: memory');
+}
 
+const alloc = instance.exports.carreltex_wasm_alloc;
+const dealloc = instance.exports.carreltex_wasm_dealloc;
+const validate = instance.exports.carreltex_wasm_validate_main_tex;
+const mountReset = instance.exports.carreltex_wasm_mount_reset;
+const mountAddFile = instance.exports.carreltex_wasm_mount_add_file;
+const mountFinalize = instance.exports.carreltex_wasm_mount_finalize;
+const mountHasFile = instance.exports.carreltex_wasm_mount_has_file;
+const compileMain = instance.exports.carreltex_wasm_compile_main_v0;
+const reportLen = instance.exports.carreltex_wasm_compile_report_len_v0;
+const reportCopy = instance.exports.carreltex_wasm_compile_report_copy_v0;
+
+for (const [name, fn] of [
+  ['carreltex_wasm_alloc', alloc],
+  ['carreltex_wasm_dealloc', dealloc],
+  ['carreltex_wasm_validate_main_tex', validate],
+  ['carreltex_wasm_mount_reset', mountReset],
+  ['carreltex_wasm_mount_add_file', mountAddFile],
+  ['carreltex_wasm_mount_finalize', mountFinalize],
+  ['carreltex_wasm_mount_has_file', mountHasFile],
+  ['carreltex_wasm_compile_main_v0', compileMain],
+  ['carreltex_wasm_compile_report_len_v0', reportLen],
+  ['carreltex_wasm_compile_report_copy_v0', reportCopy],
+]) {
+  if (typeof fn !== 'function') {
+    throw new Error(`Missing export: ${name}`);
+  }
+}
+
+function allocBytes(value, field) {
+  const ptr = alloc(value.byteLength);
+  if (!Number.isInteger(ptr) || ptr <= 0) {
+    throw new Error(`alloc failed (${field}), ptr=${ptr}`);
+  }
+  new Uint8Array(memory.buffer, ptr, value.byteLength).set(value);
+  return ptr;
+}
+
+function callWithBytes(value, field, callback) {
+  const ptr = allocBytes(value, field);
+  try {
+    return callback(ptr, value.byteLength);
+  } finally {
+    dealloc(ptr, value.byteLength);
+  }
+}
+
+function addMountedFile(pathValue, dataValue, label) {
+  const pathBytes = new TextEncoder().encode(pathValue);
+  if (pathBytes.byteLength === 0) {
+    return callWithBytes(dataValue, `${label}_data`, (dataPtr, dataLen) => {
+      return mountAddFile(0, 0, dataPtr, dataLen);
+    });
+  }
+  return callWithBytes(pathBytes, `${label}_path`, (pathPtr, pathLen) => {
+    return callWithBytes(dataValue, `${label}_data`, (dataPtr, dataLen) => {
+      return mountAddFile(pathPtr, pathLen, dataPtr, dataLen);
+    });
+  });
+}
+
+function expectInvalid(value, label) {
+  if (value !== 1) {
+    throw new Error(`${label} expected invalid(1), got ${value}`);
+  }
+}
+
+const mainTex = '\\documentclass{article}\\n\\\\begin{document}\\nHello.\\n\\\\end{document}\\n';
+const mainBytes = new TextEncoder().encode(mainTex);
+const ok = callWithBytes(mainBytes, 'main_tex', (ptr, len) => validate(ptr, len));
+if (ok !== 0) {
+  throw new Error(`validate failed, code=${ok}`);
+}
+
+if (mountReset() !== 0) {
+  throw new Error('mount_reset failed');
+}
+
+const subTexBytes = new TextEncoder().encode('Included file.\\n');
+if (addMountedFile('main.tex', mainBytes, 'main') !== 0) {
+  throw new Error('mount_add_file(main.tex) failed');
+}
+if (addMountedFile('sub.tex', subTexBytes, 'sub') !== 0) {
+  throw new Error('mount_add_file(sub.tex) failed');
+}
+if (mountFinalize() !== 0) {
+  throw new Error('mount_finalize failed');
+}
+
+const hasMain = callWithBytes(new TextEncoder().encode('main.tex'), 'has_main_path', (ptr, len) => mountHasFile(ptr, len));
+if (hasMain !== 0) {
+  throw new Error(`mount_has_file(main.tex) expected 0, got ${hasMain}`);
+}
+
+const hasMissing = callWithBytes(new TextEncoder().encode('missing.tex'), 'has_missing_path', (ptr, len) => mountHasFile(ptr, len));
+if (hasMissing !== 1) {
+  throw new Error(`mount_has_file(missing.tex) expected 1, got ${hasMissing}`);
+}
+
+const compileCode = compileMain();
+if (compileCode !== 2) {
+  throw new Error(`compile_main_v0 expected NOT_IMPLEMENTED(2), got ${compileCode}`);
+}
+
+const jsonLen = reportLen();
+if (!Number.isInteger(jsonLen) || jsonLen <= 0 || jsonLen > 4096) {
+  throw new Error(`report_len_v0 unexpected: ${jsonLen}`);
+}
+
+const outPtr = alloc(jsonLen);
+if (!Number.isInteger(outPtr) || outPtr <= 0) {
+  throw new Error(`alloc failed for report, ptr=${outPtr}`);
+}
+try {
+  const written = reportCopy(outPtr, jsonLen);
+  if (written !== jsonLen) {
+    throw new Error(`report_copy_v0 expected ${jsonLen}, got ${written}`);
+  }
+  const outBytes = new Uint8Array(memory.buffer, outPtr, jsonLen);
+  const text = new TextDecoder().decode(outBytes);
+  const report = JSON.parse(text);
+  if (report.status !== 'NOT_IMPLEMENTED') {
+    throw new Error(`report.status expected NOT_IMPLEMENTED, got ${report.status}`);
+  }
+  if (!Array.isArray(report.missing_components) || report.missing_components.length === 0) {
+    throw new Error('report.missing_components expected non-empty array');
+  }
+} finally {
+  dealloc(outPtr, jsonLen);
+}
+
+if (mountReset() !== 0) {
+  throw new Error('mount_reset for negative cases failed');
+}
+
+expectInvalid(addMountedFile('/abs.tex', mainBytes, 'neg_abs'), 'mount_add_file(/abs.tex)');
+expectInvalid(addMountedFile('../up.tex', mainBytes, 'neg_up'), 'mount_add_file(../up.tex)');
+expectInvalid(addMountedFile('a/../b.tex', mainBytes, 'neg_traversal'), 'mount_add_file(a/../b.tex)');
+expectInvalid(addMountedFile('a\\\\b.tex', mainBytes, 'neg_backslash'), 'mount_add_file(a\\\\b.tex)');
+expectInvalid(addMountedFile('', mainBytes, 'neg_empty'), 'mount_add_file(empty)');
+expectInvalid(addMountedFile('a//b.tex', mainBytes, 'neg_empty_segment'), 'mount_add_file(a//b.tex)');
+expectInvalid(addMountedFile('a/b/', mainBytes, 'neg_trailing_slash'), 'mount_add_file(a/b/)');
+
+console.log('PASS: JS loaded WASM and exercised ABI (alloc/validate/mount/compile/report)');


### PR DESCRIPTION
Goal
- Continue standalone CarrelTeX rewrite (NO Carrel/LN‑DHL deploy coupling).
- Keep WASM-from-day-1 proofs green.

What shipped in this PR (v0 contract, fail-closed)
- New pure Rust core crate `crates/carreltex-core/`:
  - Mount/path policy + resource caps + `main.tex` validation.
  - Compile contract skeleton: `compile_main_v0` returns explicit `NOT_IMPLEMENTED` with machine-readable report.
- Extended `crates/carreltex-wasm-smoke/` WASM ABI:
  - alloc/dealloc + validate_main_tex
  - mount: reset/add_file/finalize/has_file
  - compile: `carreltex_wasm_compile_main_v0` + report len/copy
- Extended Node JS proof to exercise the ABI (happy path + negative path + compile report JSON parse).
- Added `scripts/proof_v0.sh` (runs core unit tests + wasm smoke proof).

Frozen head
- `c7e826d6f230224cb6c337be2d71bfd970131a95`

Proof
- `scripts/proof_v0.sh`
```text
PASS: JS loaded WASM and exercised ABI (alloc/validate/mount/compile/report)
PASS: carreltex v0 proof bundle
```
