### PR TITLE
Leaf 25: add strict compile-request v0 surface (still fail-closed)

### DIFF
--- a/crates/carreltex-core/src/lib.rs
+++ b/crates/carreltex-core/src/lib.rs
@@ -1,7 +1,10 @@
 pub mod compile;
 pub mod mount;
 
-pub use compile::{compile_main_v0, validate_compile_report_json, CompileReport, CompileStatus};
+pub use compile::{
+    compile_main_v0, compile_request_v0, validate_compile_report_json, CompileRequestV0,
+    CompileResultV0, CompileStatus, MAX_LOG_BYTES_V0,
+};
 pub use mount::{
     validate_main_tex, Error, Mount, MAIN_TEX_MAX_BYTES, MAX_FILES, MAX_FILE_BYTES, MAX_PATH_LEN,
     MAX_TOTAL_BYTES,

--- a/crates/carreltex-wasm-smoke/src/lib.rs
+++ b/crates/carreltex-wasm-smoke/src/lib.rs
@@ -1,8 +1,8 @@
 use std::sync::{Mutex, OnceLock};
 
 use carreltex_core::{
-    compile_main_v0, validate_compile_report_json, validate_main_tex, CompileStatus, Mount,
-    MAIN_TEX_MAX_BYTES,
+    compile_main_v0, compile_request_v0, validate_compile_report_json, validate_main_tex,
+    CompileRequestV0, CompileStatus, Mount, MAIN_TEX_MAX_BYTES, MAX_LOG_BYTES_V0,
 };
 
 #[no_mangle]
@@ -18,6 +18,18 @@ fn mount_state() -> &'static Mutex<Mount> {
 fn last_report_state() -> &'static Mutex<Vec<u8>> {
     static STATE: OnceLock<Mutex<Vec<u8>>> = OnceLock::new();
     STATE.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+#[derive(Default)]
+struct CompileRequestState {
+    entrypoint: Option<String>,
+    source_date_epoch: Option<u64>,
+    max_log_bytes: Option<u32>,
+}
+
+fn compile_request_state() -> &'static Mutex<CompileRequestState> {
+    static STATE: OnceLock<Mutex<CompileRequestState>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(CompileRequestState::default()))
 }
 
 fn read_input_bytes<'a>(ptr: *const u8, len: usize) -> Option<&'a [u8]> {
@@ -141,26 +153,135 @@ fn set_last_report_bytes(report_json: &str) {
     last.extend_from_slice(report_json.as_bytes());
 }
 
+fn write_report_for_status(status: CompileStatus) {
+    let fallback = match status {
+        CompileStatus::Ok => "{\"status\":\"OK\",\"missing_components\":[]}",
+        CompileStatus::InvalidInput => "{\"status\":\"INVALID_INPUT\",\"missing_components\":[]}",
+        CompileStatus::NotImplemented => {
+            "{\"status\":\"NOT_IMPLEMENTED\",\"missing_components\":[\"tex-engine\"]}"
+        }
+    };
+    set_last_report_bytes(fallback);
+}
+
 #[no_mangle]
 pub extern "C" fn carreltex_wasm_compile_main_v0() -> i32 {
     let mut mount = match mount_state().lock() {
         Ok(guard) => guard,
         Err(_) => {
-            set_last_report_bytes("{\"missing_components\":[],\"status\":\"INVALID_INPUT\"}");
+            write_report_for_status(CompileStatus::InvalidInput);
             return CompileStatus::InvalidInput as i32;
         }
     };
 
-    let (status, report) = compile_main_v0(&mut mount);
-    let json = report.to_canonical_json();
+    let result = compile_main_v0(&mut mount);
+    let json = result.report_json;
     // Fail-closed: if the report is malformed, degrade to INVALID_INPUT.
     if validate_compile_report_json(&json).is_err() {
-        set_last_report_bytes("{\"missing_components\":[],\"status\":\"INVALID_INPUT\"}");
+        write_report_for_status(CompileStatus::InvalidInput);
         return CompileStatus::InvalidInput as i32;
     }
 
     set_last_report_bytes(&json);
-    status as i32
+    result.status as i32
+}
+
+#[no_mangle]
+pub extern "C" fn carreltex_wasm_compile_request_reset_v0() -> i32 {
+    let mut state = match compile_request_state().lock() {
+        Ok(guard) => guard,
+        Err(_) => return 1,
+    };
+    state.entrypoint = None;
+    state.source_date_epoch = None;
+    state.max_log_bytes = None;
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn carreltex_wasm_compile_request_set_entrypoint_v0(
+    ptr: *const u8,
+    len: usize,
+) -> i32 {
+    let bytes = match read_input_bytes(ptr, len) {
+        Some(bytes) => bytes,
+        None => return 1,
+    };
+    let text = match core::str::from_utf8(bytes) {
+        Ok(text) => text,
+        Err(_) => return 1,
+    };
+    if text != "main.tex" {
+        return 1;
+    }
+
+    let mut state = match compile_request_state().lock() {
+        Ok(guard) => guard,
+        Err(_) => return 1,
+    };
+    state.entrypoint = Some(text.to_owned());
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn carreltex_wasm_compile_request_set_source_date_epoch_v0(epoch: u64) -> i32 {
+    if epoch == 0 {
+        return 1;
+    }
+    let mut state = match compile_request_state().lock() {
+        Ok(guard) => guard,
+        Err(_) => return 1,
+    };
+    state.source_date_epoch = Some(epoch);
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn carreltex_wasm_compile_request_set_max_log_bytes_v0(value: u32) -> i32 {
+    if value == 0 || value > MAX_LOG_BYTES_V0 {
+        return 1;
+    }
+    let mut state = match compile_request_state().lock() {
+        Ok(guard) => guard,
+        Err(_) => return 1,
+    };
+    state.max_log_bytes = Some(value);
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn carreltex_wasm_compile_run_v0() -> i32 {
+    let request = {
+        let state = match compile_request_state().lock() {
+            Ok(guard) => guard,
+            Err(_) => {
+                write_report_for_status(CompileStatus::InvalidInput);
+                return CompileStatus::InvalidInput as i32;
+            }
+        };
+        CompileRequestV0 {
+            entrypoint: state.entrypoint.clone().unwrap_or_default(),
+            source_date_epoch: state.source_date_epoch.unwrap_or(0),
+            max_log_bytes: state.max_log_bytes.unwrap_or(0),
+        }
+    };
+
+    let mut mount = match mount_state().lock() {
+        Ok(guard) => guard,
+        Err(_) => {
+            write_report_for_status(CompileStatus::InvalidInput);
+            return CompileStatus::InvalidInput as i32;
+        }
+    };
+
+    let result = compile_request_v0(&mut mount, &request);
+    if validate_compile_report_json(&result.report_json).is_err() {
+        write_report_for_status(CompileStatus::InvalidInput);
+        return CompileStatus::InvalidInput as i32;
+    }
+
+    set_last_report_bytes(&result.report_json);
+    result.status as i32
 }
 
 #[no_mangle]
@@ -189,4 +310,3 @@ pub extern "C" fn carreltex_wasm_compile_report_copy_v0(out_ptr: *mut u8, out_le
     }
     last.len()
 }
-


### PR DESCRIPTION
## Summary
- add request-based compile contract in `carreltex-core`:
  - `CompileRequestV0 { entrypoint, source_date_epoch, max_log_bytes }`
  - `CompileResultV0 { status, report_json }`
  - `compile_request_v0(mount, req)` with strict request + mount validation
- keep compile semantics fail-closed: valid requests still return `NOT_IMPLEMENTED` with non-empty `missing_components`
- preserve compatibility path `carreltex_wasm_compile_main_v0()`
- extend wasm ABI with request setters + run entrypoint:
  - `carreltex_wasm_compile_request_reset_v0`
  - `carreltex_wasm_compile_request_set_entrypoint_v0`
  - `carreltex_wasm_compile_request_set_source_date_epoch_v0`
  - `carreltex_wasm_compile_request_set_max_log_bytes_v0`
  - `carreltex_wasm_compile_run_v0`
- extend JS proof to cover:
  - old `compile_main_v0` compatibility path
  - request-based happy path (`main.tex`, non-zero epoch, non-zero max_log_bytes)
  - request setter negatives (`other.tex`, epoch=0, max_log_bytes=0)

## Hard rule alignment
- no simplified semantics introduced
- out-of-scope remains explicit fail-closed (`NOT_IMPLEMENTED` / `INVALID_INPUT`)
- no fake artifacts

## Proof (full outputs)

1) `cargo test --manifest-path crates/carreltex-core/Cargo.toml`
```text
   Compiling carreltex-core v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-core)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.79s
     Running unittests src/lib.rs (target/debug/deps/carreltex_core-45034f808cfda7bc)

running 14 tests
test compile::tests::compile_request_rejects_log_cap_above_limit ... ok
test compile::tests::compile_requires_valid_mount ... ok
test compile::tests::compile_request_rejects_zero_epoch_or_log_cap ... ok
test compile::tests::compile_request_returns_not_implemented_when_valid ... ok
test compile::tests::compile_request_rejects_invalid_entrypoint ... ok
test mount::tests::duplicate_path_rejected ... ok
test mount::tests::finalize_rejects_invalid_main_tex ... ok
test mount::tests::finalize_requires_main_tex ... ok
test mount::tests::caps_enforced_for_max_files ... ok
test mount::tests::finalize_sets_finalized_and_blocks_additional_files ... ok
test mount::tests::caps_enforced_for_file_size_and_path_len ... ok
test mount::tests::has_file_and_finalize_success ... ok
test mount::tests::path_policy_rejects_invalid_paths ... ok
test mount::tests::validate_main_tex_checks_utf8_and_nul ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_core

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

2) `./scripts/proof_v0.sh`
```text
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests src/lib.rs (target/debug/deps/carreltex_core-45034f808cfda7bc)

running 14 tests
test compile::tests::compile_request_rejects_zero_epoch_or_log_cap ... ok
test compile::tests::compile_request_rejects_invalid_entrypoint ... ok
test compile::tests::compile_requires_valid_mount ... ok
test compile::tests::compile_request_returns_not_implemented_when_valid ... ok
test compile::tests::compile_request_rejects_log_cap_above_limit ... ok
test mount::tests::duplicate_path_rejected ... ok
test mount::tests::finalize_rejects_invalid_main_tex ... ok
test mount::tests::finalize_requires_main_tex ... ok
test mount::tests::finalize_sets_finalized_and_blocks_additional_files ... ok
test mount::tests::caps_enforced_for_max_files ... ok
test mount::tests::has_file_and_finalize_success ... ok
test mount::tests::caps_enforced_for_file_size_and_path_len ... ok
test mount::tests::path_policy_rejects_invalid_paths ... ok
test mount::tests::validate_main_tex_checks_utf8_and_nul ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_core

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.00s
PASS: JS loaded WASM and exercised ABI (alloc/validate/mount/compile/report)
PASS: carreltex v0 proof bundle
```
