### PR TITLE
Leaf 28: make main.tex validation byte-level (non-UTF8 allowed)

### DIFF
--- a/docs/LEDGER.md
+++ b/docs/LEDGER.md
@@ -4,7 +4,7 @@ Allowed status enum: `todo | stubbed | implemented | verified | skipped`.
 
 | path | layer | component | status | proof | notes |
 | --- | --- | --- | --- | --- | --- |
-| `crates/carreltex-core/src/mount.rs` | core | mount-policy | verified | `cargo test --manifest-path crates/carreltex-core/Cargo.toml` | Path policy, resource caps, finalize rules with unit tests |
+| `crates/carreltex-core/src/mount.rs` | core | mount-policy | verified | `cargo test --manifest-path crates/carreltex-core/Cargo.toml` | Path policy, resource caps, finalize rules, and byte-level (non-UTF8 allowed) main.tex validation |
 | `crates/carreltex-core/src/compile.rs` | core | compile-contract-types-v0 | verified | `cargo test --manifest-path crates/carreltex-core/Cargo.toml` | Compile status/request/result types + canonical report builder/validator |
 | `crates/carreltex-engine/src/lib.rs` | engine | compile-seam-v0 | verified | `cargo test --manifest-path crates/carreltex-engine/Cargo.toml` | Compile behavior seam; validates mount/request and returns fail-closed status |
 | `crates/carreltex-wasm-smoke/src/lib.rs` | wasm-adapter | abi-v0 | verified | `./scripts/proof_v0.sh` | Thin ABI adapter over core+engine semantics, compile report copy-out |

--- a/scripts/wasm_smoke_js_proof.mjs
+++ b/scripts/wasm_smoke_js_proof.mjs
@@ -142,6 +142,12 @@ if (ok !== 0) {
   throw new Error(`validate failed, code=${ok}`);
 }
 
+const rawNonUtf8Main = Uint8Array.from([0xff, 0x0a, 0x58]);
+const rawNonUtf8Ok = callWithBytes(rawNonUtf8Main, 'main_tex_raw_non_utf8', (ptr, len) => validate(ptr, len));
+if (rawNonUtf8Ok !== 0) {
+  throw new Error(`validate(raw non-utf8 main.tex bytes) failed, code=${rawNonUtf8Ok}`);
+}
+
 if (mountReset() !== 0) {
   throw new Error('mount_reset failed');
 }


### PR DESCRIPTION
## Summary
- update `validate_main_tex(bytes)` to validate `main.tex` as bytes (TeX-like), not UTF-8 text
- keep fail-closed checks:
  - size caps
  - NUL rejection
  - reject whitespace-only payloads (bytes limited to space/tab/CR/LF)
- add JS proof coverage for raw non-UTF8 `main.tex` bytes through wasm ABI
- update ledger note for `mount.rs` to reflect byte-level validation

## Key behavior change
`validate_main_tex` no longer requires UTF-8 decoding. Non-UTF8 non-whitespace bytes are accepted.

## Proof (full outputs)

1) `cargo test --manifest-path crates/carreltex-core/Cargo.toml`
```text
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on shared package cache
    Blocking waiting for file lock on build directory
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.85s
     Running unittests src/lib.rs (target/debug/deps/carreltex_core-45034f808cfda7bc)

running 14 tests
test compile::tests::compile_request_struct_accepts_v0_fields ... ok
test compile::tests::max_log_bytes_constant_is_non_zero ... ok
test compile::tests::validate_compile_report_json_rejects_missing_keys ... ok
test compile::tests::compile_result_builder_escapes_json_string_content ... ok
test compile::tests::compile_result_builder_uses_canonical_key_order ... ok
test mount::tests::duplicate_path_rejected ... ok
test mount::tests::caps_enforced_for_max_files ... ok
test mount::tests::finalize_requires_main_tex ... ok
test mount::tests::finalize_sets_finalized_and_blocks_additional_files ... ok
test mount::tests::has_file_and_finalize_success ... ok
test mount::tests::finalize_rejects_invalid_main_tex ... ok
test mount::tests::validate_main_tex_checks_nul_and_non_whitespace_bytes ... ok
test mount::tests::caps_enforced_for_file_size_and_path_len ... ok
test mount::tests::path_policy_rejects_invalid_paths ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_core

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

2) `./scripts/proof_v0.sh`
```text
    Blocking waiting for file lock on package cache
   Compiling carreltex-core v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-core)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.80s
     Running unittests src/lib.rs (target/debug/deps/carreltex_core-45034f808cfda7bc)

running 14 tests
test compile::tests::compile_request_struct_accepts_v0_fields ... ok
test compile::tests::compile_result_builder_escapes_json_string_content ... ok
test compile::tests::compile_result_builder_uses_canonical_key_order ... ok
test compile::tests::max_log_bytes_constant_is_non_zero ... ok
test compile::tests::validate_compile_report_json_rejects_missing_keys ... ok
test mount::tests::finalize_rejects_invalid_main_tex ... ok
test mount::tests::duplicate_path_rejected ... ok
test mount::tests::caps_enforced_for_file_size_and_path_len ... ok
test mount::tests::finalize_requires_main_tex ... ok
test mount::tests::caps_enforced_for_max_files ... ok
test mount::tests::finalize_sets_finalized_and_blocks_additional_files ... ok
test mount::tests::has_file_and_finalize_success ... ok
test mount::tests::validate_main_tex_checks_nul_and_non_whitespace_bytes ... ok
test mount::tests::path_policy_rejects_invalid_paths ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_core

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Compiling carreltex-engine v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-engine)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.17s
     Running unittests src/lib.rs (target/debug/deps/carreltex_engine-8c7f485924bd301b)

running 5 tests
test tests::compile_request_returns_not_implemented_when_valid ... ok
test tests::compile_requires_valid_mount ... ok
test tests::compile_request_rejects_invalid_entrypoint ... ok
test tests::compile_request_rejects_log_cap_above_limit ... ok
test tests::compile_request_rejects_zero_epoch_or_log_cap ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_engine

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Compiling carreltex-core v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-core)
   Compiling carreltex-engine v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-engine)
   Compiling carreltex-wasm-smoke v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-wasm-smoke)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.70s
PASS: JS loaded WASM and exercised ABI (alloc/validate/mount/compile/report)
PASS: ledger status validation passed (6 rows)
PASS: carreltex v0 proof bundle
```
