### PR TITLE
Leaf 29: add bounded deterministic compile log surface v0

### DIFF
--- a/crates/carreltex-core/src/lib.rs
+++ b/crates/carreltex-core/src/lib.rs
@@ -2,8 +2,8 @@ pub mod compile;
 pub mod mount;
 
 pub use compile::{
-    build_compile_result_v0, validate_compile_report_json, CompileRequestV0, CompileResultV0,
-    CompileStatus, MAX_LOG_BYTES_V0,
+    build_compile_result_v0, truncate_log_bytes_v0, validate_compile_report_json, CompileRequestV0,
+    CompileResultV0, CompileStatus, MAX_LOG_BYTES_V0,
 };
 pub use mount::{
     validate_main_tex, Error, Mount, MAIN_TEX_MAX_BYTES, MAX_FILES, MAX_FILE_BYTES, MAX_PATH_LEN,

--- a/docs/LEDGER.md
+++ b/docs/LEDGER.md
@@ -6,7 +6,7 @@ Allowed status enum: `todo | stubbed | implemented | verified | skipped`.
 | --- | --- | --- | --- | --- | --- |
 | `crates/carreltex-core/src/mount.rs` | core | mount-policy | verified | `cargo test --manifest-path crates/carreltex-core/Cargo.toml` | Path policy, resource caps, finalize rules, and byte-level (non-UTF8 allowed) main.tex validation |
 | `crates/carreltex-core/src/compile.rs` | core | compile-contract-types-v0 | verified | `cargo test --manifest-path crates/carreltex-core/Cargo.toml` | Compile status/request/result types + canonical report builder/validator |
-| `crates/carreltex-engine/src/lib.rs` | engine | compile-seam-v0 | verified | `cargo test --manifest-path crates/carreltex-engine/Cargo.toml` | Compile behavior seam; validates mount/request and returns fail-closed status |
-| `crates/carreltex-wasm-smoke/src/lib.rs` | wasm-adapter | abi-v0 | verified | `./scripts/proof_v0.sh` | Thin ABI adapter over core+engine semantics, compile report copy-out |
+| `crates/carreltex-engine/src/lib.rs` | engine | compile-seam-v0 | verified | `cargo test --manifest-path crates/carreltex-engine/Cargo.toml` | Compile behavior seam; deterministic bounded compile logs with fail-closed status |
+| `crates/carreltex-wasm-smoke/src/lib.rs` | wasm-adapter | abi-v0 | verified | `./scripts/proof_v0.sh` | Thin ABI adapter over core+engine semantics, compile report/log copy-out |
 | `scripts/proof_v0.sh` | proof | v0-bundle | verified | `./scripts/proof_v0.sh` | Bundle gate: core tests + wasm smoke + ledger check |
 | `scripts/wasm_smoke_js_proof.mjs` | proof | wasm-js-smoke | verified | `./scripts/proof_wasm_smoke.sh` | JS ABI compatibility checks including compile-request path |


### PR DESCRIPTION
## Summary
- extend `CompileResultV0` with byte log payload (`log_bytes`) in core
- keep `report_json` canonical JSON unchanged (`status` + `missing_components` only)
- add core helper `truncate_log_bytes_v0` and unit tests for truncation + report stability
- implement deterministic compile logs in engine:
  - valid request => `NOT_IMPLEMENTED` + deterministic log prefix `NOT_IMPLEMENTED:`
  - invalid request => `INVALID_INPUT` + deterministic empty log
  - enforce `log_bytes.len() <= req.max_log_bytes`
- add wasm log surface:
  - `carreltex_wasm_compile_log_len_v0`
  - `carreltex_wasm_compile_log_copy_v0`
  - write `last_log_state` from compile paths; fail-closed to empty log on error fallback
- extend JS proof to verify compile logs on both compatibility and request paths, including truncation check
- update ledger notes for engine/wasm rows to reflect log surface coverage

## Hard-rule alignment
- no fake artifacts and no silent simplification
- statuses remain fail-closed (`INVALID_INPUT` / `NOT_IMPLEMENTED`)
- new output (log bytes) is deterministic and bounded

## Proof (full outputs)

1) `cargo test --manifest-path crates/carreltex-core/Cargo.toml`
```text
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests src/lib.rs (target/debug/deps/carreltex_core-45034f808cfda7bc)

running 16 tests
test compile::tests::compile_result_builder_escapes_json_string_content ... ok
test compile::tests::compile_request_struct_accepts_v0_fields ... ok
test compile::tests::compile_result_builder_uses_canonical_key_order ... ok
test compile::tests::validate_compile_report_json_rejects_missing_keys ... ok
test compile::tests::truncate_log_bytes_enforces_max ... ok
test compile::tests::max_log_bytes_constant_is_non_zero ... ok
test compile::tests::report_json_stays_stable_with_different_log_bytes ... ok
test mount::tests::duplicate_path_rejected ... ok
test mount::tests::finalize_rejects_invalid_main_tex ... ok
test mount::tests::caps_enforced_for_max_files ... ok
test mount::tests::finalize_sets_finalized_and_blocks_additional_files ... ok
test mount::tests::finalize_requires_main_tex ... ok
test mount::tests::caps_enforced_for_file_size_and_path_len ... ok
test mount::tests::has_file_and_finalize_success ... ok
test mount::tests::path_policy_rejects_invalid_paths ... ok
test mount::tests::validate_main_tex_checks_nul_and_non_whitespace_bytes ... ok

test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_core

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

2) `cargo test --manifest-path crates/carreltex-engine/Cargo.toml`
```text
   Compiling carreltex-engine v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-engine)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.12s
     Running unittests src/lib.rs (target/debug/deps/carreltex_engine-8c7f485924bd301b)

running 6 tests
test tests::compile_request_rejects_invalid_entrypoint ... ok
test tests::compile_requires_valid_mount ... ok
test tests::compile_request_log_is_truncated_by_max_log_bytes ... ok
test tests::compile_request_returns_not_implemented_when_valid ... ok
test tests::compile_request_rejects_zero_epoch_or_log_cap ... ok
test tests::compile_request_rejects_log_cap_above_limit ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_engine

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

3) `./scripts/proof_v0.sh`
```text
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests src/lib.rs (target/debug/deps/carreltex_core-45034f808cfda7bc)

running 16 tests
test compile::tests::compile_request_struct_accepts_v0_fields ... ok
test compile::tests::compile_result_builder_escapes_json_string_content ... ok
test compile::tests::compile_result_builder_uses_canonical_key_order ... ok
test compile::tests::max_log_bytes_constant_is_non_zero ... ok
test compile::tests::report_json_stays_stable_with_different_log_bytes ... ok
test compile::tests::truncate_log_bytes_enforces_max ... ok
test compile::tests::validate_compile_report_json_rejects_missing_keys ... ok
test mount::tests::duplicate_path_rejected ... ok
test mount::tests::finalize_rejects_invalid_main_tex ... ok
test mount::tests::finalize_requires_main_tex ... ok
test mount::tests::caps_enforced_for_max_files ... ok
test mount::tests::finalize_sets_finalized_and_blocks_additional_files ... ok
test mount::tests::has_file_and_finalize_success ... ok
test mount::tests::caps_enforced_for_file_size_and_path_len ... ok
test mount::tests::path_policy_rejects_invalid_paths ... ok
test mount::tests::validate_main_tex_checks_nul_and_non_whitespace_bytes ... ok

test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_core

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests src/lib.rs (target/debug/deps/carreltex_engine-8c7f485924bd301b)

running 6 tests
test tests::compile_request_rejects_log_cap_above_limit ... ok
test tests::compile_requires_valid_mount ... ok
test tests::compile_request_rejects_invalid_entrypoint ... ok
test tests::compile_request_rejects_zero_epoch_or_log_cap ... ok
test tests::compile_request_log_is_truncated_by_max_log_bytes ... ok
test tests::compile_request_returns_not_implemented_when_valid ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_engine

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Compiling carreltex-engine v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-engine)
   Compiling carreltex-wasm-smoke v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-wasm-smoke)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
PASS: JS loaded WASM and exercised ABI (alloc/validate/mount/compile/report)
PASS: ledger status validation passed (6 rows)
PASS: carreltex v0 proof bundle
```
