### PR TITLE
Leaf 30: add explicit main.xdv artifact seam v0

### DIFF
--- a/crates/carreltex-engine/src/lib.rs
+++ b/crates/carreltex-engine/src/lib.rs
@@ -22,6 +22,7 @@ pub fn compile_request_v0(mount: &mut Mount, req: &CompileRequestV0) -> CompileR
             CompileStatus::InvalidInput,
             &[],
             truncate_log_bytes_v0(INVALID_INPUT_LOG_BYTES, req.max_log_bytes),
+            vec![],
         );
     }
 
@@ -30,6 +31,7 @@ pub fn compile_request_v0(mount: &mut Mount, req: &CompileRequestV0) -> CompileR
             CompileStatus::InvalidInput,
             &[],
             truncate_log_bytes_v0(INVALID_INPUT_LOG_BYTES, req.max_log_bytes),
+            vec![],
         );
     }
     if req.max_log_bytes > MAX_LOG_BYTES_V0 {
@@ -37,6 +39,7 @@ pub fn compile_request_v0(mount: &mut Mount, req: &CompileRequestV0) -> CompileR
             CompileStatus::InvalidInput,
             &[],
             truncate_log_bytes_v0(INVALID_INPUT_LOG_BYTES, req.max_log_bytes),
+            vec![],
         );
     }
 
@@ -44,6 +47,7 @@ pub fn compile_request_v0(mount: &mut Mount, req: &CompileRequestV0) -> CompileR
         CompileStatus::NotImplemented,
         MISSING_COMPONENTS_V0,
         truncate_log_bytes_v0(NOT_IMPLEMENTED_LOG_BYTES, req.max_log_bytes),
+        vec![],
     )
 }
 
@@ -85,6 +89,7 @@ mod tests {
         assert!(!result.log_bytes.is_empty());
         assert!(result.log_bytes.starts_with(b"NOT_IMPLEMENTED:"));
         assert!(result.log_bytes.len() <= valid_request().max_log_bytes as usize);
+        assert!(result.main_xdv_bytes.is_empty());
     }
 
     #[test]
@@ -96,6 +101,7 @@ mod tests {
         request.entrypoint = "other.tex".to_owned();
         let result = compile_request_v0(&mut mount, &request);
         assert_eq!(result.status, CompileStatus::InvalidInput);
+        assert!(result.main_xdv_bytes.is_empty());
     }
 
     #[test]
@@ -107,11 +113,13 @@ mod tests {
         request.source_date_epoch = 0;
         let result = compile_request_v0(&mut mount, &request);
         assert_eq!(result.status, CompileStatus::InvalidInput);
+        assert!(result.main_xdv_bytes.is_empty());
 
         request = valid_request();
         request.max_log_bytes = 0;
         let result = compile_request_v0(&mut mount, &request);
         assert_eq!(result.status, CompileStatus::InvalidInput);
+        assert!(result.main_xdv_bytes.is_empty());
     }
 
     #[test]
@@ -123,6 +131,7 @@ mod tests {
         request.max_log_bytes = MAX_LOG_BYTES_V0 + 1;
         let result = compile_request_v0(&mut mount, &request);
         assert_eq!(result.status, CompileStatus::InvalidInput);
+        assert!(result.main_xdv_bytes.is_empty());
     }
 
     #[test]
@@ -136,5 +145,6 @@ mod tests {
         assert_eq!(result.status, CompileStatus::NotImplemented);
         assert_eq!(result.log_bytes.len(), 8);
         assert_eq!(result.log_bytes, b"NOT_IMPL".to_vec());
+        assert!(result.main_xdv_bytes.is_empty());
     }
 }

--- a/docs/LEDGER.md
+++ b/docs/LEDGER.md
@@ -6,7 +6,7 @@ Allowed status enum: `todo | stubbed | implemented | verified | skipped`.
 | --- | --- | --- | --- | --- | --- |
 | `crates/carreltex-core/src/mount.rs` | core | mount-policy | verified | `cargo test --manifest-path crates/carreltex-core/Cargo.toml` | Path policy, resource caps, finalize rules, and byte-level (non-UTF8 allowed) main.tex validation |
 | `crates/carreltex-core/src/compile.rs` | core | compile-contract-types-v0 | verified | `cargo test --manifest-path crates/carreltex-core/Cargo.toml` | Compile status/request/result types + canonical report builder/validator |
-| `crates/carreltex-engine/src/lib.rs` | engine | compile-seam-v0 | verified | `cargo test --manifest-path crates/carreltex-engine/Cargo.toml` | Compile behavior seam; deterministic bounded compile logs with fail-closed status |
-| `crates/carreltex-wasm-smoke/src/lib.rs` | wasm-adapter | abi-v0 | verified | `./scripts/proof_v0.sh` | Thin ABI adapter over core+engine semantics, compile report/log copy-out |
+| `crates/carreltex-engine/src/lib.rs` | engine | compile-seam-v0 | verified | `cargo test --manifest-path crates/carreltex-engine/Cargo.toml` | Compile behavior seam; deterministic bounded compile logs + explicit `main.xdv` artifact seam (empty until engine wired) |
+| `crates/carreltex-wasm-smoke/src/lib.rs` | wasm-adapter | abi-v0 | verified | `./scripts/proof_v0.sh` | Thin ABI adapter over core+engine semantics, compile report/log and `main.xdv` artifact copy-out |
 | `scripts/proof_v0.sh` | proof | v0-bundle | verified | `./scripts/proof_v0.sh` | Bundle gate: core tests + wasm smoke + ledger check |
 | `scripts/wasm_smoke_js_proof.mjs` | proof | wasm-js-smoke | verified | `./scripts/proof_wasm_smoke.sh` | JS ABI compatibility checks including compile-request path |


### PR DESCRIPTION
## Summary
- add explicit `main.xdv` artifact seam to compile result and wasm ABI while keeping compile status fail-closed
- extend `CompileResultV0` with `main_xdv_bytes: Vec<u8>`
- keep canonical `report_json` unchanged (`status` + `missing_components` only)
- engine remains `INVALID_INPUT`/`NOT_IMPLEMENTED`; both paths now explicitly return empty `main_xdv_bytes`
- wasm adapter now stores/copies last `main.xdv` bytes via new exports:
  - `carreltex_wasm_artifact_main_xdv_len_v0`
  - `carreltex_wasm_artifact_main_xdv_copy_v0`
- JS proof verifies artifact seam remains empty on NOT_IMPLEMENTED paths (no fake outputs)
- ledger notes updated for artifact seam coverage

## Hard-rule alignment
- no fake artifacts introduced (`main_xdv_bytes` stays empty until real engine wiring)
- deterministic, bounded, fail-closed behavior preserved

## Proof (full outputs)

1) `cargo test --manifest-path crates/carreltex-core/Cargo.toml`
```text
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on shared package cache
   Compiling carreltex-core v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-core)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.61s
     Running unittests src/lib.rs (target/debug/deps/carreltex_core-45034f808cfda7bc)

running 17 tests
test compile::tests::compile_result_builder_escapes_json_string_content ... ok
test compile::tests::compile_result_builder_keeps_artifact_bytes_exact ... ok
test compile::tests::report_json_stays_stable_with_different_log_bytes ... ok
test compile::tests::compile_result_builder_uses_canonical_key_order ... ok
test compile::tests::max_log_bytes_constant_is_non_zero ... ok
test compile::tests::compile_request_struct_accepts_v0_fields ... ok
test compile::tests::validate_compile_report_json_rejects_missing_keys ... ok
test compile::tests::truncate_log_bytes_enforces_max ... ok
test mount::tests::finalize_rejects_invalid_main_tex ... ok
test mount::tests::duplicate_path_rejected ... ok
test mount::tests::finalize_requires_main_tex ... ok
test mount::tests::finalize_sets_finalized_and_blocks_additional_files ... ok
test mount::tests::has_file_and_finalize_success ... ok
test mount::tests::caps_enforced_for_max_files ... ok
test mount::tests::caps_enforced_for_file_size_and_path_len ... ok
test mount::tests::validate_main_tex_checks_nul_and_non_whitespace_bytes ... ok
test mount::tests::path_policy_rejects_invalid_paths ... ok

test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_core

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

2) `cargo test --manifest-path crates/carreltex-engine/Cargo.toml`
```text
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on build directory
   Compiling carreltex-engine v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-engine)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.78s
     Running unittests src/lib.rs (target/debug/deps/carreltex_engine-8c7f485924bd301b)

running 6 tests
test tests::compile_request_rejects_invalid_entrypoint ... ok
test tests::compile_request_rejects_zero_epoch_or_log_cap ... ok
test tests::compile_request_rejects_log_cap_above_limit ... ok
test tests::compile_request_log_is_truncated_by_max_log_bytes ... ok
test tests::compile_request_returns_not_implemented_when_valid ... ok
test tests::compile_requires_valid_mount ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_engine

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

3) `./scripts/proof_v0.sh`
```text
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests src/lib.rs (target/debug/deps/carreltex_core-45034f808cfda7bc)

running 17 tests
test compile::tests::compile_request_struct_accepts_v0_fields ... ok
test compile::tests::compile_result_builder_escapes_json_string_content ... ok
test compile::tests::compile_result_builder_uses_canonical_key_order ... ok
test compile::tests::max_log_bytes_constant_is_non_zero ... ok
test compile::tests::report_json_stays_stable_with_different_log_bytes ... ok
test compile::tests::truncate_log_bytes_enforces_max ... ok
test compile::tests::validate_compile_report_json_rejects_missing_keys ... ok
test mount::tests::duplicate_path_rejected ... ok
test mount::tests::finalize_requires_main_tex ... ok
test mount::tests::finalize_rejects_invalid_main_tex ... ok
test mount::tests::caps_enforced_for_max_files ... ok
test mount::tests::finalize_sets_finalized_and_blocks_additional_files ... ok
test mount::tests::has_file_and_finalize_success ... ok
test mount::tests::path_policy_rejects_invalid_paths ... ok
test mount::tests::caps_enforced_for_file_size_and_path_len ... ok
test mount::tests::validate_main_tex_checks_nul_and_non_whitespace_bytes ... ok
test compile::tests::compile_result_builder_keeps_artifact_bytes_exact ... ok

test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_core

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests src/lib.rs (target/debug/deps/carreltex_engine-8c7f485924bd301b)

running 6 tests
test tests::compile_request_rejects_log_cap_above_limit ... ok
test tests::compile_requires_valid_mount ... ok
test tests::compile_request_rejects_invalid_entrypoint ... ok
test tests::compile_request_rejects_zero_epoch_or_log_cap ... ok
test tests::compile_request_log_is_truncated_by_max_log_bytes ... ok
test tests::compile_request_returns_not_implemented_when_valid ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_engine

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Compiling carreltex-core v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-core)
   Compiling carreltex-engine v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-engine)
   Compiling carreltex-wasm-smoke v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-wasm-smoke)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.43s
PASS: JS loaded WASM and exercised ABI (alloc/validate/mount/compile/report)
PASS: ledger status validation passed (6 rows)
PASS: carreltex v0 proof bundle
```
