### PR TITLE
Leaf 31: add mount read-back ABI v0 seam

### DIFF
--- a/docs/LEDGER.md
+++ b/docs/LEDGER.md
@@ -7,6 +7,6 @@ Allowed status enum: `todo | stubbed | implemented | verified | skipped`.
 | `crates/carreltex-core/src/mount.rs` | core | mount-policy | verified | `cargo test --manifest-path crates/carreltex-core/Cargo.toml` | Path policy, resource caps, finalize rules, and byte-level (non-UTF8 allowed) main.tex validation |
 | `crates/carreltex-core/src/compile.rs` | core | compile-contract-types-v0 | verified | `cargo test --manifest-path crates/carreltex-core/Cargo.toml` | Compile status/request/result types + canonical report builder/validator |
 | `crates/carreltex-engine/src/lib.rs` | engine | compile-seam-v0 | verified | `cargo test --manifest-path crates/carreltex-engine/Cargo.toml` | Compile behavior seam; deterministic bounded compile logs + explicit `main.xdv` artifact seam (empty until engine wired) |
-| `crates/carreltex-wasm-smoke/src/lib.rs` | wasm-adapter | abi-v0 | verified | `./scripts/proof_v0.sh` | Thin ABI adapter over core+engine semantics, compile report/log and `main.xdv` artifact copy-out |
+| `crates/carreltex-wasm-smoke/src/lib.rs` | wasm-adapter | abi-v0 | verified | `./scripts/proof_v0.sh` | Thin ABI adapter over core+engine semantics, compile report/log + `main.xdv` artifact copy-out + mount read-back ABI |
 | `scripts/proof_v0.sh` | proof | v0-bundle | verified | `./scripts/proof_v0.sh` | Bundle gate: core tests + wasm smoke + ledger check |
 | `scripts/wasm_smoke_js_proof.mjs` | proof | wasm-js-smoke | verified | `./scripts/proof_wasm_smoke.sh` | JS ABI compatibility checks including compile-request path |


### PR DESCRIPTION
## Summary
- add mount read-back ABI for harness/debug seam (no compile semantics changes):
  - `carreltex_wasm_mount_read_file_len_v0(path_ptr, path_len)`
  - `carreltex_wasm_mount_read_file_copy_v0(path_ptr, path_len, out_ptr, out_len)`
- fail-closed behavior implemented:
  - invalid path / missing file => len=0, copy=0
  - null out_ptr / out_len=0 / out_len<file_len => copy=0
  - success => copy returns exact file_len and writes exact bytes
- no finalize requirement for read-back (reads from currently mounted files)
- JS proof expanded to assert:
  - roundtrip read-back for `main.tex` and `sub.tex`
  - non-UTF8 data roundtrip for `sub.bin` (`[0xff, 0x58]`)
  - missing path and invalid paths return len/copy=0
- ledger note updated for wasm adapter row to include mount read-back coverage

## Hard-rule alignment
- no fake artifacts or simplified compile behavior introduced
- deterministic, bounded, fail-closed ABI behavior

## Proof (full outputs)

1) `cargo test --manifest-path crates/carreltex-core/Cargo.toml`
```text
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on shared package cache
    Blocking waiting for file lock on build directory
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running unittests src/lib.rs (target/debug/deps/carreltex_core-45034f808cfda7bc)

running 17 tests
test compile::tests::compile_request_struct_accepts_v0_fields ... ok
test compile::tests::compile_result_builder_keeps_artifact_bytes_exact ... ok
test compile::tests::report_json_stays_stable_with_different_log_bytes ... ok
test compile::tests::max_log_bytes_constant_is_non_zero ... ok
test compile::tests::truncate_log_bytes_enforces_max ... ok
test compile::tests::compile_result_builder_escapes_json_string_content ... ok
test compile::tests::validate_compile_report_json_rejects_missing_keys ... ok
test compile::tests::compile_result_builder_uses_canonical_key_order ... ok
test mount::tests::caps_enforced_for_file_size_and_path_len ... ok
test mount::tests::caps_enforced_for_max_files ... ok
test mount::tests::duplicate_path_rejected ... ok
test mount::tests::finalize_rejects_invalid_main_tex ... ok
test mount::tests::finalize_requires_main_tex ... ok
test mount::tests::finalize_sets_finalized_and_blocks_additional_files ... ok
test mount::tests::has_file_and_finalize_success ... ok
test mount::tests::path_policy_rejects_invalid_paths ... ok
test mount::tests::validate_main_tex_checks_nul_and_non_whitespace_bytes ... ok

test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_core

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

2) `cargo test --manifest-path crates/carreltex-engine/Cargo.toml`
```text
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.02s
     Running unittests src/lib.rs (target/debug/deps/carreltex_engine-8c7f485924bd301b)

running 6 tests
test tests::compile_request_rejects_invalid_entrypoint ... ok
test tests::compile_request_log_is_truncated_by_max_log_bytes ... ok
test tests::compile_request_rejects_log_cap_above_limit ... ok
test tests::compile_request_rejects_zero_epoch_or_log_cap ... ok
test tests::compile_request_returns_not_implemented_when_valid ... ok
test tests::compile_requires_valid_mount ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_engine

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

3) `./scripts/proof_v0.sh`
```text
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests src/lib.rs (target/debug/deps/carreltex_core-45034f808cfda7bc)

running 17 tests
test compile::tests::compile_request_struct_accepts_v0_fields ... ok
test compile::tests::compile_result_builder_escapes_json_string_content ... ok
test compile::tests::compile_result_builder_uses_canonical_key_order ... ok
test compile::tests::truncate_log_bytes_enforces_max ... ok
test compile::tests::max_log_bytes_constant_is_non_zero ... ok
test compile::tests::compile_result_builder_keeps_artifact_bytes_exact ... ok
test compile::tests::validate_compile_report_json_rejects_missing_keys ... ok
test compile::tests::report_json_stays_stable_with_different_log_bytes ... ok
test mount::tests::duplicate_path_rejected ... ok
test mount::tests::finalize_requires_main_tex ... ok
test mount::tests::finalize_rejects_invalid_main_tex ... ok
test mount::tests::caps_enforced_for_max_files ... ok
test mount::tests::has_file_and_finalize_success ... ok
test mount::tests::finalize_sets_finalized_and_blocks_additional_files ... ok
test mount::tests::path_policy_rejects_invalid_paths ... ok
test mount::tests::validate_main_tex_checks_nul_and_non_whitespace_bytes ... ok
test mount::tests::caps_enforced_for_file_size_and_path_len ... ok

test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_core

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests src/lib.rs (target/debug/deps/carreltex_engine-8c7f485924bd301b)

running 6 tests
test tests::compile_request_log_is_truncated_by_max_log_bytes ... ok
test tests::compile_request_rejects_log_cap_above_limit ... ok
test tests::compile_request_rejects_invalid_entrypoint ... ok
test tests::compile_request_rejects_zero_epoch_or_log_cap ... ok
test tests::compile_request_returns_not_implemented_when_valid ... ok
test tests::compile_requires_valid_mount ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_engine

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Compiling carreltex-wasm-smoke v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-wasm-smoke)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.36s
PASS: JS loaded WASM and exercised ABI (alloc/validate/mount/compile/report)
PASS: ledger status validation passed (6 rows)
PASS: carreltex v0 proof bundle
```
