### PR TITLE
Leaf 34: add CI gate for proof_v0

### DIFF
--- a/.github/workflows/proof_v0.yml
+++ b/.github/workflows/proof_v0.yml
@@ -1,0 +1,34 @@
+name: proof-v0
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: proof-v0-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  proof-v0:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run v0 proof bundle
+        run: ./scripts/proof_v0.sh

--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ scripts/proof_wasm_smoke.sh
 ```bash
 scripts/proof_v0.sh
 ```
+
+CI runs the same `scripts/proof_v0.sh` gate on every PR and on pushes to `main`.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow `.github/workflows/proof_v0.yml`
- trigger on all `pull_request` events and pushes to `main`
- run deterministic CI gate with:
  - `actions/checkout@v4`
  - `actions/setup-node@v4` (`node-version: 20`)
  - `dtolnay/rust-toolchain@stable` with `wasm32-unknown-unknown`
  - `Swatinem/rust-cache@v2`
  - `./scripts/proof_v0.sh`
- configure concurrency guard:
  - `group: proof-v0-${{ github.ref }}`
  - `cancel-in-progress: true`
- add a short README proof note that CI runs the same `scripts/proof_v0.sh` gate on PR/main

## Required proof
### `./scripts/proof_v0.sh`
```text
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running unittests src/lib.rs (target/debug/deps/carreltex_core-45034f808cfda7bc)

running 23 tests
test compile::tests::default_compile_main_log_bytes_constant_is_1024 ... ok
test compile::tests::compile_result_builder_escapes_json_string_content ... ok
test compile::tests::compile_result_builder_uses_canonical_key_order ... ok
test compile::tests::report_json_has_status_token_checks_exact_status ... ok
test compile::tests::compile_result_builder_keeps_artifact_bytes_exact ... ok
test compile::tests::artifact_bytes_within_cap_honors_limit ... ok
test compile::tests::compile_request_struct_accepts_v0_fields ... ok
test compile::tests::max_log_bytes_constant_is_non_zero ... ok
test compile::tests::report_json_missing_components_empty_detection ... ok
test compile::tests::report_json_stays_stable_with_different_log_bytes ... ok
test compile::tests::truncate_log_bytes_enforces_max ... ok
test compile::tests::validate_compile_report_json_accepts_single_known_status ... ok
test compile::tests::validate_compile_report_json_rejects_missing_keys_or_unknown_status ... ok
test compile::tests::validate_compile_report_json_rejects_multiple_status_tokens ... ok
test mount::tests::duplicate_path_rejected ... ok
test mount::tests::finalize_rejects_invalid_main_tex ... ok
test mount::tests::finalize_requires_main_tex ... ok
test mount::tests::caps_enforced_for_max_files ... ok
test mount::tests::finalize_sets_finalized_and_blocks_additional_files ... ok
test mount::tests::has_file_and_finalize_success ... ok
test mount::tests::caps_enforced_for_file_size_and_path_len ... ok
test mount::tests::path_policy_rejects_invalid_paths ... ok
test mount::tests::validate_main_tex_checks_nul_and_non_whitespace_bytes ... ok

test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_core

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests src/lib.rs (target/debug/deps/carreltex_engine-8c7f485924bd301b)

running 7 tests
test tests::compile_request_log_is_truncated_by_max_log_bytes ... ok
test tests::compile_requires_valid_mount ... ok
test tests::compile_request_returns_not_implemented_when_valid ... ok
test tests::compile_main_uses_default_log_cap_and_not_implemented ... ok
test tests::compile_request_rejects_zero_epoch_or_log_cap ... ok
test tests::compile_request_rejects_log_cap_above_limit ... ok
test tests::compile_request_rejects_invalid_entrypoint ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_engine

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.00s
PASS: JS loaded WASM and exercised ABI (alloc/validate/mount/compile/report)
PASS: ledger status validation passed (6 rows)
PASS: carreltex v0 proof bundle
```
