### PR TITLE
Leaf 36: centralize FS lookup policy in core

### DIFF
--- a/crates/carreltex-core/src/lib.rs
+++ b/crates/carreltex-core/src/lib.rs
@@ -9,6 +9,6 @@ pub use compile::{
     MAX_ARTIFACT_BYTES_V0, MAX_EVENTS_BYTES_V0, MAX_LOG_BYTES_V0,
 };
 pub use mount::{
-    validate_main_tex, Error, Mount, MAIN_TEX_MAX_BYTES, MAX_FILES, MAX_FILE_BYTES, MAX_PATH_LEN,
-    MAX_TOTAL_BYTES,
+    normalize_path_v0, validate_main_tex, Error, Mount, MAIN_TEX_MAX_BYTES, MAX_FILES,
+    MAX_FILE_BYTES, MAX_PATH_LEN, MAX_TOTAL_BYTES,
 };

--- a/docs/LEDGER.md
+++ b/docs/LEDGER.md
@@ -4,7 +4,7 @@ Allowed status enum: `todo | stubbed | implemented | verified | skipped`.
 
 | path | layer | component | status | proof | notes |
 | --- | --- | --- | --- | --- | --- |
-| `crates/carreltex-core/src/mount.rs` | core | mount-policy | verified | `cargo test --manifest-path crates/carreltex-core/Cargo.toml` | Path policy, resource caps, finalize rules, and byte-level (non-UTF8 allowed) main.tex validation |
+| `crates/carreltex-core/src/mount.rs` | core | mount-policy | verified | `cargo test --manifest-path crates/carreltex-core/Cargo.toml` | Path policy SSOT via `normalize_path_v0` + `read_file_by_bytes_v0`, resource caps, finalize rules, and byte-level (non-UTF8 allowed) main.tex validation |
 | `crates/carreltex-core/src/compile.rs` | core | compile-contract-types-v0 | verified | `cargo test --manifest-path crates/carreltex-core/Cargo.toml` | Compile status/request/result types + canonical report builder/validator + status-token/missing-components helper checks + bounded binary event encoding helpers/constants |
 | `crates/carreltex-engine/src/lib.rs` | engine | compile-seam-v0 | verified | `cargo test --manifest-path crates/carreltex-engine/Cargo.toml` | Compile behavior seam; deterministic bounded compile logs + explicit `main.xdv` artifact seam (empty until engine wired) |
 | `crates/carreltex-wasm-smoke/src/lib.rs` | wasm-adapter | abi-v0 | verified | `./scripts/proof_v0.sh` | Thin ABI adapter over core+engine semantics, strict report/status+missing_components cross-consistency, per-path log bounds, deterministic binary events seam for log streaming, generic artifact-by-name ABI + `main.xdv` copy-out cap enforcement, and mount read-back ABI |


### PR DESCRIPTION
## Summary
- promote path normalization to core SSOT helper `normalize_path_v0(path_bytes) -> Result<String, Error>`
- refactor core mount operations to use SSOT path helper:
  - `Mount::add_file`
  - `Mount::has_file`
- add new core read API for byte-path callers:
  - `Mount::read_file_by_bytes_v0(path_bytes) -> Result<Option<&[u8]>, Error>`
- refactor wasm adapter to remove duplicated path parsing logic:
  - deleted wasm-side `resolve_mounted_file(...)`
  - `carreltex_wasm_mount_read_file_len_v0/copy_v0` now lock mount and call `read_file_by_bytes_v0`
- add core tests for:
  - `normalize_path_v0` accepted/rejected path matrix
  - `read_file_by_bytes_v0` existing/missing/invalid behavior
- update ledger mount-policy row to explicitly mark `normalize_path_v0` + `read_file_by_bytes_v0` as path-policy SSOT

## Required proofs
### 1) `cargo test --manifest-path crates/carreltex-core/Cargo.toml`
```text
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on shared package cache
    Blocking waiting for file lock on build directory
   Compiling carreltex-core v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-core)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.97s
     Running unittests src/lib.rs (target/debug/deps/carreltex_core-45034f808cfda7bc)

running 27 tests
test compile::tests::append_event_encodes_header_little_endian ... ok
test compile::tests::append_event_rejects_when_exceeds_max_events_bytes ... ok
test compile::tests::artifact_bytes_within_cap_honors_limit ... ok
test compile::tests::compile_request_struct_accepts_v0_fields ... ok
test compile::tests::compile_result_builder_escapes_json_string_content ... ok
test compile::tests::compile_result_builder_uses_canonical_key_order ... ok
test compile::tests::compile_result_builder_keeps_artifact_bytes_exact ... ok
test compile::tests::default_compile_main_log_bytes_constant_is_1024 ... ok
test compile::tests::max_log_bytes_constant_is_non_zero ... ok
test compile::tests::report_json_has_status_token_checks_exact_status ... ok
test compile::tests::report_json_missing_components_empty_detection ... ok
test compile::tests::truncate_log_bytes_enforces_max ... ok
test compile::tests::report_json_stays_stable_with_different_log_bytes ... ok
test compile::tests::validate_compile_report_json_accepts_single_known_status ... ok
test compile::tests::validate_compile_report_json_rejects_missing_keys_or_unknown_status ... ok
test compile::tests::validate_compile_report_json_rejects_multiple_status_tokens ... ok
test mount::tests::duplicate_path_rejected ... ok
test mount::tests::finalize_rejects_invalid_main_tex ... ok
test mount::tests::finalize_requires_main_tex ... ok
test mount::tests::caps_enforced_for_max_files ... ok
test mount::tests::finalize_sets_finalized_and_blocks_additional_files ... ok
test mount::tests::caps_enforced_for_file_size_and_path_len ... ok
test mount::tests::has_file_and_finalize_success ... ok
test mount::tests::normalize_path_v0_accepts_and_rejects_expected_inputs ... ok
test mount::tests::path_policy_rejects_invalid_paths ... ok
test mount::tests::read_file_by_bytes_v0_handles_existing_missing_and_invalid ... ok
test mount::tests::validate_main_tex_checks_nul_and_non_whitespace_bytes ... ok

test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_core

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

### 2) `cargo test --manifest-path crates/carreltex-engine/Cargo.toml`
```text
    Blocking waiting for file lock on package cache
   Compiling carreltex-core v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-core)
   Compiling carreltex-engine v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-engine)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.74s
     Running unittests src/lib.rs (target/debug/deps/carreltex_engine-8c7f485924bd301b)

running 7 tests
test tests::compile_request_log_is_truncated_by_max_log_bytes ... ok
test tests::compile_request_rejects_invalid_entrypoint ... ok
test tests::compile_main_uses_default_log_cap_and_not_implemented ... ok
test tests::compile_request_rejects_zero_epoch_or_log_cap ... ok
test tests::compile_request_rejects_log_cap_above_limit ... ok
test tests::compile_request_returns_not_implemented_when_valid ... ok
test tests::compile_requires_valid_mount ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_engine

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

### 3) `./scripts/proof_v0.sh`
```text
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests src/lib.rs (target/debug/deps/carreltex_core-45034f808cfda7bc)

running 27 tests
test compile::tests::append_event_encodes_header_little_endian ... ok
test compile::tests::append_event_rejects_when_exceeds_max_events_bytes ... ok
test compile::tests::artifact_bytes_within_cap_honors_limit ... ok
test compile::tests::compile_request_struct_accepts_v0_fields ... ok
test compile::tests::compile_result_builder_uses_canonical_key_order ... ok
test compile::tests::compile_result_builder_keeps_artifact_bytes_exact ... ok
test compile::tests::default_compile_main_log_bytes_constant_is_1024 ... ok
test compile::tests::max_log_bytes_constant_is_non_zero ... ok
test compile::tests::compile_result_builder_escapes_json_string_content ... ok
test compile::tests::report_json_has_status_token_checks_exact_status ... ok
test compile::tests::report_json_missing_components_empty_detection ... ok
test compile::tests::report_json_stays_stable_with_different_log_bytes ... ok
test compile::tests::truncate_log_bytes_enforces_max ... ok
test compile::tests::validate_compile_report_json_accepts_single_known_status ... ok
test compile::tests::validate_compile_report_json_rejects_missing_keys_or_unknown_status ... ok
test compile::tests::validate_compile_report_json_rejects_multiple_status_tokens ... ok
test mount::tests::duplicate_path_rejected ... ok
test mount::tests::finalize_requires_main_tex ... ok
test mount::tests::finalize_rejects_invalid_main_tex ... ok
test mount::tests::caps_enforced_for_max_files ... ok
test mount::tests::finalize_sets_finalized_and_blocks_additional_files ... ok
test mount::tests::has_file_and_finalize_success ... ok
test mount::tests::normalize_path_v0_accepts_and_rejects_expected_inputs ... ok
test mount::tests::caps_enforced_for_file_size_and_path_len ... ok
test mount::tests::path_policy_rejects_invalid_paths ... ok
test mount::tests::read_file_by_bytes_v0_handles_existing_missing_and_invalid ... ok
test mount::tests::validate_main_tex_checks_nul_and_non_whitespace_bytes ... ok

test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_core

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests src/lib.rs (target/debug/deps/carreltex_engine-8c7f485924bd301b)

running 7 tests
test tests::compile_main_uses_default_log_cap_and_not_implemented ... ok
test tests::compile_request_returns_not_implemented_when_valid ... ok
test tests::compile_request_rejects_invalid_entrypoint ... ok
test tests::compile_request_log_is_truncated_by_max_log_bytes ... ok
test tests::compile_requires_valid_mount ... ok
test tests::compile_request_rejects_zero_epoch_or_log_cap ... ok
test tests::compile_request_rejects_log_cap_above_limit ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_engine

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Compiling carreltex-core v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-core)
   Compiling carreltex-engine v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-engine)
   Compiling carreltex-wasm-smoke v0.1.0 (/Users/boan/carrel/worktrees/carreltex/crates/carreltex-wasm-smoke)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.45s
PASS: JS loaded WASM and exercised ABI (alloc/validate/mount/compile/report)
PASS: ledger status validation passed (6 rows)
PASS: carreltex v0 proof bundle
```
