### PR TITLE
Leaf 53: continue engine compile_v0 module split

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/input_expand_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/input_expand_v0.rs
@@ -1,0 +1,161 @@
+use crate::reasons_v0::InvalidInputReasonV0;
+use crate::tex::tokenize_v0::{tokenize_v0, TokenV0, MAX_TOKENS_V0};
+use carreltex_core::{normalize_path_v0, Mount};
+
+use super::trace_v0::InputTraceV0;
+
+pub(crate) const MAX_INPUT_DEPTH_V0: usize = 32;
+pub(crate) const MAX_INPUT_EXPANSIONS_V0: usize = 1024;
+
+pub(crate) fn expand_inputs_v0(
+    tokens: &[TokenV0],
+    mount: &Mount,
+) -> Result<(Vec<TokenV0>, InputTraceV0), InvalidInputReasonV0> {
+    let mut active_stack = vec!["main.tex".to_owned()];
+    let mut expansion_count = 0usize;
+    let mut trace = InputTraceV0::new();
+    let expanded = expand_inputs_inner_v0(
+        tokens,
+        mount,
+        0,
+        &mut active_stack,
+        &mut expansion_count,
+        &mut trace,
+    )?;
+    Ok((expanded, trace))
+}
+
+fn parse_input_path_group_v0(
+    tokens: &[TokenV0],
+    input_index: usize,
+) -> Result<(String, usize), InvalidInputReasonV0> {
+    if !matches!(
+        tokens.get(input_index),
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"input"
+    ) {
+        return Err(InvalidInputReasonV0::InputValidationFailed);
+    }
+
+    let mut index = input_index + 1;
+    if !matches!(tokens.get(index), Some(TokenV0::BeginGroup)) {
+        return Err(InvalidInputReasonV0::InputValidationFailed);
+    }
+    index += 1;
+
+    let mut path_bytes = Vec::new();
+    loop {
+        match tokens.get(index) {
+            Some(TokenV0::Char(byte)) => {
+                path_bytes.push(*byte);
+                index += 1;
+            }
+            Some(TokenV0::EndGroup) => {
+                index += 1;
+                break;
+            }
+            Some(TokenV0::Space)
+            | Some(TokenV0::ControlSeq(_))
+            | Some(TokenV0::BeginGroup)
+            | None => {
+                return Err(InvalidInputReasonV0::InputValidationFailed);
+            }
+        }
+    }
+
+    if path_bytes.is_empty() {
+        return Err(InvalidInputReasonV0::InputValidationFailed);
+    }
+
+    let normalized =
+        normalize_path_v0(&path_bytes).map_err(|_| InvalidInputReasonV0::InputValidationFailed)?;
+    if !normalized.ends_with(".tex") {
+        return Err(InvalidInputReasonV0::InputValidationFailed);
+    }
+    Ok((normalized, index))
+}
+
+fn push_token_checked(out: &mut Vec<TokenV0>, token: TokenV0) -> Result<(), InvalidInputReasonV0> {
+    if out.len() >= MAX_TOKENS_V0 {
+        return Err(InvalidInputReasonV0::InputValidationFailed);
+    }
+    out.push(token);
+    Ok(())
+}
+
+fn extend_tokens_checked(
+    out: &mut Vec<TokenV0>,
+    tokens: &[TokenV0],
+) -> Result<(), InvalidInputReasonV0> {
+    let total = out
+        .len()
+        .checked_add(tokens.len())
+        .ok_or(InvalidInputReasonV0::InputValidationFailed)?;
+    if total > MAX_TOKENS_V0 {
+        return Err(InvalidInputReasonV0::InputValidationFailed);
+    }
+    out.extend_from_slice(tokens);
+    Ok(())
+}
+
+fn expand_inputs_inner_v0(
+    tokens: &[TokenV0],
+    mount: &Mount,
+    depth: usize,
+    active_stack: &mut Vec<String>,
+    expansion_count: &mut usize,
+    trace: &mut InputTraceV0,
+) -> Result<Vec<TokenV0>, InvalidInputReasonV0> {
+    if depth > MAX_INPUT_DEPTH_V0 {
+        return Err(InvalidInputReasonV0::InputDepthExceeded);
+    }
+
+    let mut out = Vec::new();
+    let mut index = 0usize;
+    while index < tokens.len() {
+        match &tokens[index] {
+            TokenV0::ControlSeq(name) if name.as_slice() == b"input" => {
+                *expansion_count = expansion_count
+                    .checked_add(1)
+                    .ok_or(InvalidInputReasonV0::InputExpansionsExceeded)?;
+                if *expansion_count > MAX_INPUT_EXPANSIONS_V0 {
+                    return Err(InvalidInputReasonV0::InputExpansionsExceeded);
+                }
+                trace.expansions = *expansion_count as u64;
+
+                let (normalized_path, next_index) = parse_input_path_group_v0(tokens, index)?;
+                if active_stack.iter().any(|path| path == &normalized_path) {
+                    return Err(InvalidInputReasonV0::InputCycleFailed);
+                }
+                trace.record_file(&normalized_path);
+                trace.record_depth(depth + 1);
+
+                let included_bytes = match mount.read_file_by_bytes_v0(normalized_path.as_bytes()) {
+                    Ok(Some(bytes)) => bytes,
+                    _ => return Err(InvalidInputReasonV0::InputValidationFailed),
+                };
+                let included_tokens = tokenize_v0(included_bytes)
+                    .map_err(|_| InvalidInputReasonV0::InputValidationFailed)?;
+
+                active_stack.push(normalized_path);
+                let expanded = expand_inputs_inner_v0(
+                    &included_tokens,
+                    mount,
+                    depth + 1,
+                    active_stack,
+                    expansion_count,
+                    trace,
+                )?;
+                active_stack.pop();
+
+                extend_tokens_checked(&mut out, &expanded)?;
+                index = next_index;
+            }
+            token => {
+                push_token_checked(&mut out, token.clone())?;
+                index += 1;
+            }
+        }
+    }
+
+    Ok(out)
+}

--- a/crates/carreltex-engine/src/compile_v0/stats_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/stats_v0.rs
@@ -1,0 +1,54 @@
+use crate::tex::tokenize_v0::TokenV0;
+use carreltex_core::build_tex_stats_json_v0;
+
+pub(crate) fn build_tex_stats_from_tokens_v0(tokens: &[TokenV0]) -> Result<String, ()> {
+    let mut depth: u64 = 0;
+    let mut max_depth: u64 = 0;
+    let mut control_seq_count: u64 = 0;
+    let mut char_count: u64 = 0;
+    let mut space_count: u64 = 0;
+    let mut begin_group_count: u64 = 0;
+    let mut end_group_count: u64 = 0;
+
+    for token in tokens {
+        match token {
+            TokenV0::ControlSeq(_) => {
+                control_seq_count = control_seq_count.checked_add(1).ok_or(())?;
+            }
+            TokenV0::Char(_) => {
+                char_count = char_count.checked_add(1).ok_or(())?;
+            }
+            TokenV0::Space => {
+                space_count = space_count.checked_add(1).ok_or(())?;
+            }
+            TokenV0::BeginGroup => {
+                begin_group_count = begin_group_count.checked_add(1).ok_or(())?;
+                depth = depth.checked_add(1).ok_or(())?;
+                max_depth = max_depth.max(depth);
+            }
+            TokenV0::EndGroup => {
+                if depth == 0 {
+                    return Err(());
+                }
+                end_group_count = end_group_count.checked_add(1).ok_or(())?;
+                depth -= 1;
+            }
+        }
+    }
+
+    if depth != 0 {
+        return Err(());
+    }
+
+    let token_count: u64 = tokens.len().try_into().map_err(|_| ())?;
+    build_tex_stats_json_v0(
+        token_count,
+        control_seq_count,
+        char_count,
+        space_count,
+        begin_group_count,
+        end_group_count,
+        max_depth,
+    )
+    .map_err(|_| ())
+}

--- a/crates/carreltex-engine/src/compile_v0/trace_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/trace_v0.rs
@@ -1,0 +1,104 @@
+use carreltex_core::validate_input_trace_json_v0;
+
+pub(crate) const INPUT_TRACE_PREFIX_BYTES: &[u8] = b"\nINPUT_TRACE_V0:";
+const INPUT_TRACE_MAX_FILES_V0: usize = 32;
+
+#[derive(Default)]
+pub(crate) struct InputTraceV0 {
+    pub(crate) expansions: u64,
+    pub(crate) max_depth: u64,
+    pub(crate) unique_files: u64,
+    pub(crate) files: Vec<String>,
+}
+
+impl InputTraceV0 {
+    pub(crate) fn new() -> Self {
+        let mut trace = Self::default();
+        trace.record_file("main.tex");
+        trace
+    }
+
+    pub(crate) fn record_file(&mut self, path: &str) {
+        if self.files.iter().any(|existing| existing == path) {
+            return;
+        }
+        self.unique_files = self.unique_files.saturating_add(1);
+        if self.files.len() < INPUT_TRACE_MAX_FILES_V0 {
+            self.files.push(path.to_owned());
+        }
+    }
+
+    pub(crate) fn record_depth(&mut self, depth: usize) {
+        let depth_u64 = depth as u64;
+        if depth_u64 > self.max_depth {
+            self.max_depth = depth_u64;
+        }
+    }
+}
+
+pub(crate) fn build_input_trace_json_v0(trace: &InputTraceV0) -> String {
+    let mut out = String::new();
+    out.push_str("{\"expansions\":");
+    out.push_str(&trace.expansions.to_string());
+    out.push_str(",\"max_depth\":");
+    out.push_str(&trace.max_depth.to_string());
+    out.push_str(",\"unique_files\":");
+    out.push_str(&trace.unique_files.to_string());
+    out.push_str(",\"files\":[");
+    for (index, file) in trace.files.iter().enumerate() {
+        if index != 0 {
+            out.push(',');
+        }
+        out.push('"');
+        out.push_str(&escape_json_string_v0(file));
+        out.push('"');
+    }
+    out.push_str("]}");
+    out
+}
+
+pub(crate) fn build_not_implemented_log_v0(
+    max_log_bytes: usize,
+    trace: &InputTraceV0,
+) -> Option<Vec<u8>> {
+    let trace_json = build_input_trace_json_v0(trace);
+    if validate_input_trace_json_v0(&trace_json).is_err() {
+        return None;
+    }
+
+    let mut trace_line = Vec::new();
+    trace_line.extend_from_slice(INPUT_TRACE_PREFIX_BYTES);
+    trace_line.extend_from_slice(trace_json.as_bytes());
+
+    let mut not_implemented_log =
+        b"NOT_IMPLEMENTED: tex-engine compile pipeline is not wired yet".to_vec();
+    if not_implemented_log
+        .len()
+        .checked_add(trace_line.len())
+        .is_some_and(|total| total <= max_log_bytes)
+    {
+        not_implemented_log.extend_from_slice(&trace_line);
+    }
+    Some(not_implemented_log)
+}
+
+fn escape_json_string_v0(value: &str) -> String {
+    let mut escaped = String::new();
+    for ch in value.chars() {
+        match ch {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\u{08}' => escaped.push_str("\\b"),
+            '\u{0C}' => escaped.push_str("\\f"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            ch if ch.is_control() => {
+                let code = ch as u32;
+                escaped.push_str(&format!("\\u{code:04x}"));
+            }
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}


### PR DESCRIPTION
## Summary
- Continued engine module split to keep LOC safely under guard limits, behavior-preserving.
- Split `crates/carreltex-engine/src/compile_v0.rs` internals into focused submodules:
  - `crates/carreltex-engine/src/compile_v0/input_expand_v0.rs`
  - `crates/carreltex-engine/src/compile_v0/stats_v0.rs`
  - `crates/carreltex-engine/src/compile_v0/trace_v0.rs`
- Kept external/public engine API unchanged (`compile_main_v0`, `compile_request_v0` from crate root).
- No compile semantics changes; this is structure-only refactor.

## Proof
- `./scripts/proof_v0.sh`

Full output is posted in PR comment with frozen head.
