### PR TITLE
Leaf 80: modularize macro_expand_v0 internals

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/macro_expand_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/macro_expand_v0.rs
@@ -3,32 +3,58 @@ use std::collections::BTreeMap;
 use super::ifnum_v0::parse_ifnum_v0;
 use super::ifx_v0::parse_ifx_v0;
 use crate::reasons_v0::InvalidInputReasonV0;
-use crate::tex::tokenize_v0::{TokenV0, MAX_TOKENS_V0};
+use crate::tex::tokenize_v0::{TokenV0, TokenizeErrorV0, MAX_TOKENS_V0};
+
+#[path = "macro_v0/bindings.rs"]
+mod bindings;
+#[path = "macro_v0/count_the.rs"]
+mod count_the;
+#[path = "macro_v0/csname_expandafter.rs"]
+mod csname_expandafter;
+#[path = "macro_v0/def_xdef.rs"]
+mod def_xdef;
+#[path = "macro_v0/global_prefix.rs"]
+mod global_prefix;
+#[path = "macro_v0/let_futurelet.rs"]
+mod let_futurelet;
+#[path = "macro_v0/noexpand.rs"]
+mod noexpand;
+#[path = "macro_v0/string_meaning.rs"]
+mod string_meaning;
+#[path = "macro_v0/utils.rs"]
+mod utils;
+
+use bindings::{
+    compare_ifx_control_sequences_v0, expand_binding_v0, lookup_macro_binding_v0, MacroBindingV0,
+};
+use count_the::{parse_count_assignment_v0, parse_the_v0};
+use csname_expandafter::{parse_csname_v0, parse_expandafter_v0};
+use def_xdef::{parse_def_v0, parse_xdef_v0};
+use global_prefix::parse_global_prefixed_macro_binding_v0;
+use let_futurelet::{parse_futurelet_v0, parse_let_v0};
+use noexpand::parse_noexpand_v0;
+use string_meaning::{parse_meaning_v0, parse_string_v0};
+use utils::{push_checked_v0, substitute_single_param_placeholders_v0};
 
 pub(crate) const MAX_MACROS_V0: usize = 4096;
 pub(crate) const MAX_MACRO_EXPANSIONS_V0: usize = 4096;
 pub(crate) const MAX_MACRO_DEPTH_V0: usize = 64;
-const MAX_COUNT_VALUE_V0: u32 = 1_000_000;
-
-#[derive(Clone)]
-struct MacroDefV0 {
-    param_count: u8,
-    body_tokens: Vec<TokenV0>,
-}
-
-#[derive(Clone)]
-enum MacroBindingV0 {
-    Macro(MacroDefV0),
-    ControlSeqLiteral(Vec<u8>),
-    LetAlias {
-        target_name: Vec<u8>,
-        resolved_binding: Box<MacroBindingV0>,
-    },
-}
 
 enum ConditionalKindV0 {
     Ifnum,
     Ifx,
+}
+
+pub(crate) fn map_tokenize_error_to_reason_v0(
+    error: TokenizeErrorV0,
+) -> InvalidInputReasonV0 {
+    match error {
+        TokenizeErrorV0::CaretNotSupported => InvalidInputReasonV0::TokenizerCaretNotSupported,
+        TokenizeErrorV0::ControlSeqNonAscii => {
+            InvalidInputReasonV0::TokenizerControlSeqNonAscii
+        }
+        _ => InvalidInputReasonV0::TokenizeFailed,
+    }
 }
 
 pub(crate) fn expand_macros_v0(tokens: &[TokenV0]) -> Result<Vec<TokenV0>, InvalidInputReasonV0> {
@@ -86,7 +112,8 @@ fn expand_stream_v0(
             {
                 let is_global = name.as_slice() == b"gdef";
                 let expand_body = name.as_slice() == b"edef";
-                index = parse_def_v0(tokens, index, macro_frames, counters, is_global, expand_body)?;
+                index =
+                    parse_def_v0(tokens, index, macro_frames, counters, is_global, expand_body)?;
             }
             TokenV0::ControlSeq(name) if name.as_slice() == b"xdef" => {
                 index = parse_xdef_v0(tokens, index, macro_frames, counters, true)?;
@@ -171,7 +198,8 @@ fn expand_stream_v0(
                 let mut compare = |left: &[u8], right: &[u8]| {
                     compare_ifx_control_sequences_v0(macro_frames, left, right)
                 };
-                let (selected_tokens, next_index) = parse_ifx_v0(tokens, index, counters, 0, &mut compare)?;
+                let (selected_tokens, next_index) =
+                    parse_ifx_v0(tokens, index, counters, 0, &mut compare)?;
                 expand_stream_v0(
                     &selected_tokens,
                     macro_frames,
@@ -186,809 +214,84 @@ fn expand_stream_v0(
             }
             TokenV0::ControlSeq(name) if name.as_slice() == b"else" => {
                 return Err(match last_conditional_kind {
-                    Some(ConditionalKindV0::Ifx) => InvalidInputReasonV0::MacroIfxElseWithoutIf,
+                    Some(ConditionalKindV0::Ifx) => {
+                        InvalidInputReasonV0::MacroIfxElseWithoutIf
+                    }
                     _ => InvalidInputReasonV0::MacroIfElseWithoutIf,
                 });
             }
-            TokenV0::ControlSeq(name) => {
-                match lookup_macro_binding_v0(macro_frames, name) {
-                    Some(MacroBindingV0::Macro(macro_def)) => {
-                        *expansion_count = expansion_count
-                            .checked_add(1)
-                            .ok_or(InvalidInputReasonV0::MacroExpansionsExceeded)?;
-                        if *expansion_count > MAX_MACRO_EXPANSIONS_V0 {
-                            return Err(InvalidInputReasonV0::MacroExpansionsExceeded);
-                        }
-                        if active_macros.iter().any(|active| active == name) {
-                            return Err(InvalidInputReasonV0::MacroCycleFailed);
-                        }
-                        let (expanded_body, next_index) = match macro_def.param_count {
-                            0 => (macro_def.body_tokens, index + 1),
-                            1 => {
-                                let (argument_tokens, argument_next_index) =
-                                    parse_balanced_group_payload_v0(tokens, index + 1)?;
-                                let substituted_body = substitute_single_param_placeholders_v0(
+            TokenV0::ControlSeq(name) => match lookup_macro_binding_v0(macro_frames, name) {
+                Some(MacroBindingV0::Macro(macro_def)) => {
+                    *expansion_count = expansion_count
+                        .checked_add(1)
+                        .ok_or(InvalidInputReasonV0::MacroExpansionsExceeded)?;
+                    if *expansion_count > MAX_MACRO_EXPANSIONS_V0 {
+                        return Err(InvalidInputReasonV0::MacroExpansionsExceeded);
+                    }
+                    if active_macros.iter().any(|active| active == name) {
+                        return Err(InvalidInputReasonV0::MacroCycleFailed);
+                    }
+                    let (expanded_body, next_index) = match macro_def.param_count {
+                        0 => (macro_def.body_tokens, index + 1),
+                        1 => {
+                            let (argument_tokens, argument_next_index) =
+                                utils::parse_balanced_group_payload_v0(tokens, index + 1)?;
+                            let substituted_body =
+                                substitute_single_param_placeholders_v0(
                                     &macro_def.body_tokens,
                                     &argument_tokens,
                                 )?;
-                                (substituted_body, argument_next_index)
-                            }
-                            _ => return Err(InvalidInputReasonV0::MacroValidationFailed),
-                        };
-                        active_macros.push(name.clone());
-                        let result = expand_stream_v0(
-                            &expanded_body,
-                            macro_frames,
-                            counters,
-                            out,
-                            active_macros,
-                            expansion_count,
-                            depth + 1,
-                        );
-                        active_macros.pop();
-                        result?;
-                        index = next_index;
-                    }
-                    Some(MacroBindingV0::ControlSeqLiteral(target_name)) => {
-                        push_checked_v0(out, TokenV0::ControlSeq(target_name))?;
-                        index += 1;
-                    }
-                    Some(MacroBindingV0::LetAlias {
-                        target_name: _,
-                        resolved_binding,
-                    }) => {
-                        expand_binding_v0(
-                            name,
-                            *resolved_binding,
-                            macro_frames,
-                            counters,
-                            out,
-                            active_macros,
-                            expansion_count,
-                            depth,
-                        )?;
-                        index += 1;
-                    }
-                    None => {
-                        push_checked_v0(out, tokens[index].clone())?;
-                        index += 1;
-                    }
+                            (substituted_body, argument_next_index)
+                        }
+                        _ => return Err(InvalidInputReasonV0::MacroValidationFailed),
+                    };
+                    active_macros.push(name.clone());
+                    let result = expand_stream_v0(
+                        &expanded_body,
+                        macro_frames,
+                        counters,
+                        out,
+                        active_macros,
+                        expansion_count,
+                        depth + 1,
+                    );
+                    active_macros.pop();
+                    result?;
+                    index = next_index;
                 }
-            }
+                Some(MacroBindingV0::ControlSeqLiteral(target_name)) => {
+                    push_checked_v0(out, TokenV0::ControlSeq(target_name))?;
+                    index += 1;
+                }
+                Some(MacroBindingV0::LetAlias {
+                    target_name: _,
+                    resolved_binding,
+                }) => {
+                    expand_binding_v0(
+                        name,
+                        *resolved_binding,
+                        macro_frames,
+                        counters,
+                        out,
+                        active_macros,
+                        expansion_count,
+                        depth,
+                    )?;
+                    index += 1;
+                }
+                None => {
+                    push_checked_v0(out, tokens[index].clone())?;
+                    index += 1;
+                }
+            },
             token => {
                 push_checked_v0(out, token.clone())?;
                 index += 1;
             }
         }
     }
-    Ok(())
-}
-
-fn parse_global_prefixed_macro_binding_v0(
-    tokens: &[TokenV0],
-    global_index: usize,
-    macro_frames: &mut Vec<BTreeMap<Vec<u8>, MacroBindingV0>>,
-    counters: &mut [u32; 2],
-) -> Result<usize, InvalidInputReasonV0> {
-    let mut index = global_index;
-    while matches!(
-        tokens.get(index),
-        Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"global"
-    ) {
-        index += 1;
-    }
-
-    match tokens.get(index) {
-        Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"def" => {
-            parse_def_v0(tokens, index, macro_frames, counters, true, false)
-        }
-        Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"gdef" => {
-            parse_def_v0(tokens, index, macro_frames, counters, true, false)
-        }
-        Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"edef" => {
-            parse_def_v0(tokens, index, macro_frames, counters, true, true)
-        }
-        Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"xdef" => {
-            parse_xdef_v0(tokens, index, macro_frames, counters, true)
-        }
-        Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"let" => {
-            parse_let_v0(tokens, index, macro_frames, true)
-        }
-        Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"futurelet" => {
-            parse_futurelet_v0(tokens, index, macro_frames, true)
-        }
-        _ => return Err(InvalidInputReasonV0::MacroGlobalPrefixUnsupported),
-    }
-}
-
-fn parse_def_v0(
-    tokens: &[TokenV0],
-    def_index: usize,
-    macro_frames: &mut Vec<BTreeMap<Vec<u8>, MacroBindingV0>>,
-    counters: &mut [u32; 2],
-    is_global: bool,
-    expand_body: bool,
-) -> Result<usize, InvalidInputReasonV0> {
-    let name_index = def_index + 1;
-    let macro_name = match tokens.get(name_index) {
-        Some(TokenV0::ControlSeq(name)) => name.clone(),
-        _ => return Err(InvalidInputReasonV0::MacroValidationFailed),
-    };
-
-    let mut param_count = 0u8;
-    let mut body_start_index = name_index + 1;
-    match tokens.get(body_start_index) {
-        Some(TokenV0::BeginGroup) => {}
-        Some(TokenV0::Char(b'#')) => {
-            if expand_body {
-                return Err(InvalidInputReasonV0::MacroParamsUnsupported);
-            }
-            let placeholder_digit = match tokens.get(body_start_index + 1) {
-                Some(TokenV0::Char(digit)) => *digit,
-                _ => return Err(InvalidInputReasonV0::MacroParamsUnsupported),
-            };
-            if placeholder_digit != b'1' {
-                return Err(InvalidInputReasonV0::MacroParamsUnsupported);
-            }
-            param_count = 1;
-            body_start_index += 2;
-            if matches!(tokens.get(body_start_index), Some(TokenV0::Char(b'#'))) {
-                return Err(InvalidInputReasonV0::MacroParamsUnsupported);
-            }
-            if !matches!(tokens.get(body_start_index), Some(TokenV0::BeginGroup)) {
-                return Err(InvalidInputReasonV0::MacroValidationFailed);
-            }
-        }
-        _ => return Err(InvalidInputReasonV0::MacroValidationFailed),
-    }
-
-    let (body_tokens, next_index) = parse_balanced_group_payload_v0(tokens, body_start_index)?;
-    validate_macro_body_tokens_v0(&body_tokens, param_count)?;
-    let final_body_tokens = if expand_body {
-        if param_count != 0 {
-            return Err(InvalidInputReasonV0::MacroParamsUnsupported);
-        }
-        let mut expanded = Vec::<TokenV0>::new();
-        let mut active_macros = Vec::<Vec<u8>>::new();
-        let mut expansion_count = 0usize;
-        expand_stream_v0(
-            &body_tokens,
-            macro_frames,
-            counters,
-            &mut expanded,
-            &mut active_macros,
-            &mut expansion_count,
-            0,
-        )?;
-        expanded
-    } else {
-        body_tokens
-    };
-    let target_frame_index = if is_global {
-        0usize
-    } else {
-        macro_frames
-            .len()
-            .checked_sub(1)
-            .ok_or(InvalidInputReasonV0::MacroValidationFailed)?
-    };
-    let total_macro_defs = total_macro_defs_v0(macro_frames);
-    let target_frame = macro_frames
-        .get_mut(target_frame_index)
-        .ok_or(InvalidInputReasonV0::MacroValidationFailed)?;
-    if !target_frame.contains_key(&macro_name) && total_macro_defs >= MAX_MACROS_V0 {
+    if out.len() > MAX_TOKENS_V0 {
         return Err(InvalidInputReasonV0::MacroValidationFailed);
-    }
-    if param_count > 1 {
-        return Err(InvalidInputReasonV0::MacroValidationFailed);
-    }
-    target_frame.insert(
-        macro_name,
-        MacroBindingV0::Macro(MacroDefV0 {
-            param_count: if expand_body { 0 } else { param_count },
-            body_tokens: final_body_tokens,
-        }),
-    );
-    Ok(next_index)
-}
-
-fn parse_xdef_v0(
-    tokens: &[TokenV0],
-    xdef_index: usize,
-    macro_frames: &mut Vec<BTreeMap<Vec<u8>, MacroBindingV0>>,
-    counters: &mut [u32; 2],
-    is_global: bool,
-) -> Result<usize, InvalidInputReasonV0> {
-    let name_index = xdef_index + 1;
-    let macro_name = match tokens.get(name_index) {
-        Some(TokenV0::ControlSeq(name)) => name.clone(),
-        _ => return Err(InvalidInputReasonV0::MacroXdefUnsupported),
-    };
-    let body_start_index = name_index + 1;
-    if !matches!(tokens.get(body_start_index), Some(TokenV0::BeginGroup)) {
-        return Err(InvalidInputReasonV0::MacroXdefUnsupported);
-    }
-    let (body_tokens, next_index) = parse_balanced_group_payload_v0(tokens, body_start_index)
-        .map_err(|_| InvalidInputReasonV0::MacroXdefUnsupported)?;
-    if body_tokens.iter().any(|token| matches!(token, TokenV0::Char(b'#'))) {
-        return Err(InvalidInputReasonV0::MacroXdefUnsupported);
-    }
-
-    let mut expanded = Vec::<TokenV0>::new();
-    let mut active_macros = Vec::<Vec<u8>>::new();
-    let mut expansion_count = 0usize;
-    expand_stream_v0(
-        &body_tokens,
-        macro_frames,
-        counters,
-        &mut expanded,
-        &mut active_macros,
-        &mut expansion_count,
-        0,
-    )?;
-
-    let target_frame_index = if is_global {
-        0usize
-    } else {
-        macro_frames
-            .len()
-            .checked_sub(1)
-            .ok_or(InvalidInputReasonV0::MacroValidationFailed)?
-    };
-    let total_macro_defs = total_macro_defs_v0(macro_frames);
-    let target_frame = macro_frames
-        .get_mut(target_frame_index)
-        .ok_or(InvalidInputReasonV0::MacroValidationFailed)?;
-    if !target_frame.contains_key(&macro_name) && total_macro_defs >= MAX_MACROS_V0 {
-        return Err(InvalidInputReasonV0::MacroValidationFailed);
-    }
-    target_frame.insert(
-        macro_name,
-        MacroBindingV0::Macro(MacroDefV0 {
-            param_count: 0,
-            body_tokens: expanded,
-        }),
-    );
-    Ok(next_index)
-}
-
-fn parse_noexpand_v0(
-    tokens: &[TokenV0],
-    noexpand_index: usize,
-    out: &mut Vec<TokenV0>,
-) -> Result<usize, InvalidInputReasonV0> {
-    let next = tokens
-        .get(noexpand_index + 1)
-        .ok_or(InvalidInputReasonV0::MacroNoexpandUnsupported)?
-        .clone();
-    push_checked_v0(out, next)?;
-    Ok(noexpand_index + 2)
-}
-
-fn parse_let_v0(
-    tokens: &[TokenV0],
-    let_index: usize,
-    macro_frames: &mut Vec<BTreeMap<Vec<u8>, MacroBindingV0>>,
-    is_global: bool,
-) -> Result<usize, InvalidInputReasonV0> {
-    let alias_name = match tokens.get(let_index + 1) {
-        Some(TokenV0::ControlSeq(name)) => name.clone(),
-        _ => return Err(InvalidInputReasonV0::MacroValidationFailed),
-    };
-
-    let mut index = skip_space_tokens_v0(tokens, let_index + 2);
-    if matches!(tokens.get(index), Some(TokenV0::Char(b'='))) {
-        index = skip_space_tokens_v0(tokens, index + 1);
-    }
-
-    let target_name = match tokens.get(index) {
-        Some(TokenV0::ControlSeq(name)) => name.clone(),
-        _ => return Err(InvalidInputReasonV0::MacroLetUnsupported),
-    };
-    let resolved_binding = snapshot_let_binding_v0(&target_name, macro_frames)?;
-    let target_frame_index = if is_global {
-        0usize
-    } else {
-        macro_frames
-            .len()
-            .checked_sub(1)
-            .ok_or(InvalidInputReasonV0::MacroValidationFailed)?
-    };
-    let total_macro_defs = total_macro_defs_v0(macro_frames);
-    let target_frame = macro_frames
-        .get_mut(target_frame_index)
-        .ok_or(InvalidInputReasonV0::MacroValidationFailed)?;
-    if !target_frame.contains_key(&alias_name) && total_macro_defs >= MAX_MACROS_V0 {
-        return Err(InvalidInputReasonV0::MacroValidationFailed);
-    }
-    target_frame.insert(
-        alias_name,
-        MacroBindingV0::LetAlias {
-            target_name,
-            resolved_binding: Box::new(resolved_binding),
-        },
-    );
-    Ok(index + 1)
-}
-
-fn parse_futurelet_v0(
-    tokens: &[TokenV0],
-    futurelet_index: usize,
-    macro_frames: &mut Vec<BTreeMap<Vec<u8>, MacroBindingV0>>,
-    is_global: bool,
-) -> Result<usize, InvalidInputReasonV0> {
-    let alias_name_index = skip_space_tokens_v0(tokens, futurelet_index + 1);
-    let alias_name = match tokens.get(alias_name_index) {
-        Some(TokenV0::ControlSeq(name)) => name.clone(),
-        _ => return Err(InvalidInputReasonV0::MacroFutureletUnsupported),
-    };
-
-    let probe_index = skip_space_tokens_v0(tokens, alias_name_index + 1);
-    let _probe_name = match tokens.get(probe_index) {
-        Some(TokenV0::ControlSeq(name)) => name.clone(),
-        _ => return Err(InvalidInputReasonV0::MacroFutureletUnsupported),
-    };
-
-    let target_index = skip_space_tokens_v0(tokens, probe_index + 1);
-    let target_name = match tokens.get(target_index) {
-        Some(TokenV0::ControlSeq(name)) => name.clone(),
-        _ => return Err(InvalidInputReasonV0::MacroFutureletUnsupported),
-    };
-
-    let target_frame_index = if is_global {
-        0usize
-    } else {
-        macro_frames
-            .len()
-            .checked_sub(1)
-            .ok_or(InvalidInputReasonV0::MacroValidationFailed)?
-    };
-    let total_macro_defs = total_macro_defs_v0(macro_frames);
-    let target_frame = macro_frames
-        .get_mut(target_frame_index)
-        .ok_or(InvalidInputReasonV0::MacroValidationFailed)?;
-    if !target_frame.contains_key(&alias_name) && total_macro_defs >= MAX_MACROS_V0 {
-        return Err(InvalidInputReasonV0::MacroValidationFailed);
-    }
-    target_frame.insert(alias_name, MacroBindingV0::ControlSeqLiteral(target_name));
-    Ok(probe_index)
-}
-
-fn parse_expandafter_v0(
-    tokens: &[TokenV0],
-    expandafter_index: usize,
-) -> Result<(Vec<TokenV0>, usize), InvalidInputReasonV0> {
-    let first_index = skip_space_tokens_v0(tokens, expandafter_index + 1);
-    let first_name = match tokens.get(first_index) {
-        Some(TokenV0::ControlSeq(name)) => name.clone(),
-        _ => return Err(InvalidInputReasonV0::MacroExpandafterUnsupported),
-    };
-
-    let second_index = skip_space_tokens_v0(tokens, first_index + 1);
-    let second_name = match tokens.get(second_index) {
-        Some(TokenV0::ControlSeq(name)) => name.clone(),
-        _ => return Err(InvalidInputReasonV0::MacroExpandafterUnsupported),
-    };
-
-    Ok((
-        vec![TokenV0::ControlSeq(second_name), TokenV0::ControlSeq(first_name)],
-        second_index + 1,
-    ))
-}
-
-fn parse_csname_v0(
-    tokens: &[TokenV0],
-    csname_index: usize,
-) -> Result<(TokenV0, usize), InvalidInputReasonV0> {
-    let mut name_bytes = Vec::<u8>::new();
-    let mut index = csname_index + 1;
-    while index < tokens.len() {
-        match tokens.get(index) {
-            Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"endcsname" => {
-                if name_bytes.is_empty() {
-                    return Err(InvalidInputReasonV0::MacroCsnameUnsupported);
-                }
-                return Ok((TokenV0::ControlSeq(name_bytes), index + 1));
-            }
-            Some(TokenV0::Char(byte)) => name_bytes.push(*byte),
-            _ => return Err(InvalidInputReasonV0::MacroCsnameUnsupported),
-        }
-        index += 1;
-    }
-    Err(InvalidInputReasonV0::MacroCsnameUnsupported)
-}
-
-fn parse_string_v0(
-    tokens: &[TokenV0],
-    string_index: usize,
-) -> Result<(Vec<TokenV0>, usize), InvalidInputReasonV0> {
-    let next_index = skip_space_tokens_v0(tokens, string_index + 1);
-    let control_name = match tokens.get(next_index) {
-        Some(TokenV0::ControlSeq(name)) => name.clone(),
-        _ => return Err(InvalidInputReasonV0::MacroStringUnsupported),
-    };
-
-    let mut out = Vec::<TokenV0>::new();
-    out.push(TokenV0::Char(b'\\'));
-    for byte in control_name {
-        out.push(TokenV0::Char(byte));
-    }
-    Ok((out, next_index + 1))
-}
-
-fn parse_meaning_v0(
-    tokens: &[TokenV0],
-    meaning_index: usize,
-    macro_frames: &[BTreeMap<Vec<u8>, MacroBindingV0>],
-) -> Result<(Vec<TokenV0>, usize), InvalidInputReasonV0> {
-    let next_index = skip_space_tokens_v0(tokens, meaning_index + 1);
-    let query_name = match tokens.get(next_index) {
-        Some(TokenV0::ControlSeq(name)) => name.clone(),
-        _ => return Err(InvalidInputReasonV0::MacroMeaningUnsupported),
-    };
-
-    let mut out = Vec::<TokenV0>::new();
-    match lookup_macro_binding_v0(macro_frames, &query_name) {
-        Some(MacroBindingV0::Macro(_)) => {
-            push_ascii_bytes_v0(&mut out, b"macro:")?;
-            push_ascii_bytes_v0(&mut out, &query_name)?;
-        }
-        Some(MacroBindingV0::ControlSeqLiteral(target_name)) => {
-            push_ascii_bytes_v0(&mut out, b"alias:")?;
-            push_ascii_bytes_v0(&mut out, &query_name)?;
-            push_ascii_bytes_v0(&mut out, b"->")?;
-            push_ascii_bytes_v0(&mut out, &target_name)?;
-        }
-        Some(MacroBindingV0::LetAlias {
-            target_name,
-            resolved_binding: _,
-        }) => {
-            push_ascii_bytes_v0(&mut out, b"alias:")?;
-            push_ascii_bytes_v0(&mut out, &query_name)?;
-            push_ascii_bytes_v0(&mut out, b"->")?;
-            push_ascii_bytes_v0(&mut out, &target_name)?;
-        }
-        None => {
-            push_ascii_bytes_v0(&mut out, b"undefined:")?;
-            push_ascii_bytes_v0(&mut out, &query_name)?;
-        }
-    }
-    Ok((out, next_index + 1))
-}
-
-fn lookup_macro_binding_v0(
-    macro_frames: &[BTreeMap<Vec<u8>, MacroBindingV0>],
-    name: &[u8],
-) -> Option<MacroBindingV0> {
-    for frame in macro_frames.iter().rev() {
-        if let Some(binding) = frame.get(name) {
-            return Some(binding.clone());
-        }
-    }
-    None
-}
-
-enum IfxComparableBindingV0 {
-    Undefined,
-    AliasTarget(Vec<u8>),
-    Macro(MacroDefV0),
-}
-
-fn compare_ifx_control_sequences_v0(
-    macro_frames: &[BTreeMap<Vec<u8>, MacroBindingV0>],
-    left: &[u8],
-    right: &[u8],
-) -> bool {
-    match (
-        classify_ifx_binding_v0(macro_frames, left),
-        classify_ifx_binding_v0(macro_frames, right),
-    ) {
-        (IfxComparableBindingV0::Undefined, IfxComparableBindingV0::Undefined) => true,
-        (IfxComparableBindingV0::AliasTarget(left_target), IfxComparableBindingV0::AliasTarget(right_target)) => left_target == right_target,
-        (IfxComparableBindingV0::Macro(left_macro), IfxComparableBindingV0::Macro(right_macro)) => {
-            left_macro.param_count == right_macro.param_count
-                && left_macro.body_tokens == right_macro.body_tokens
-        }
-        _ => false,
-    }
-}
-
-fn classify_ifx_binding_v0(
-    macro_frames: &[BTreeMap<Vec<u8>, MacroBindingV0>],
-    name: &[u8],
-) -> IfxComparableBindingV0 {
-    match lookup_macro_binding_v0(macro_frames, name) {
-        None => IfxComparableBindingV0::Undefined,
-        Some(MacroBindingV0::Macro(definition)) => IfxComparableBindingV0::Macro(definition),
-        Some(MacroBindingV0::ControlSeqLiteral(target_name)) => IfxComparableBindingV0::AliasTarget(resolve_alias_target_name_v0(macro_frames, target_name)),
-        Some(MacroBindingV0::LetAlias { target_name: _, resolved_binding }) => classify_ifx_from_resolved_binding_v0(*resolved_binding),
-    }
-}
-
-fn classify_ifx_from_resolved_binding_v0(binding: MacroBindingV0) -> IfxComparableBindingV0 {
-    match binding {
-        MacroBindingV0::Macro(definition) => IfxComparableBindingV0::Macro(definition),
-        MacroBindingV0::ControlSeqLiteral(_name) => IfxComparableBindingV0::Undefined,
-        MacroBindingV0::LetAlias { target_name: _, resolved_binding } => classify_ifx_from_resolved_binding_v0(*resolved_binding),
-    }
-}
-
-fn resolve_alias_target_name_v0(
-    macro_frames: &[BTreeMap<Vec<u8>, MacroBindingV0>],
-    start: Vec<u8>,
-) -> Vec<u8> {
-    let mut current = start;
-    let mut seen = Vec::<Vec<u8>>::new();
-    loop {
-        if seen.iter().any(|entry| entry == &current) {
-            return current;
-        }
-        seen.push(current.clone());
-        match lookup_macro_binding_v0(macro_frames, &current) {
-            Some(MacroBindingV0::ControlSeqLiteral(next)) => current = next,
-            Some(MacroBindingV0::LetAlias {
-                target_name,
-                resolved_binding: _,
-            }) => current = target_name,
-            _ => return current,
-        }
-    }
-}
-
-fn snapshot_let_binding_v0(
-    target_name: &[u8],
-    macro_frames: &[BTreeMap<Vec<u8>, MacroBindingV0>],
-) -> Result<MacroBindingV0, InvalidInputReasonV0> {
-    let mut current = target_name.to_vec();
-    let mut seen = Vec::<Vec<u8>>::new();
-    loop {
-        if seen.iter().any(|entry| entry == &current) {
-            return Err(InvalidInputReasonV0::MacroCycleFailed);
-        }
-        let binding = lookup_macro_binding_v0(macro_frames, &current);
-        match binding {
-            Some(MacroBindingV0::Macro(definition)) => return Ok(MacroBindingV0::Macro(definition)),
-            Some(MacroBindingV0::ControlSeqLiteral(target)) => {
-                seen.push(current);
-                current = target;
-            }
-            Some(MacroBindingV0::LetAlias {
-                target_name: _,
-                resolved_binding,
-            }) => return Ok(*resolved_binding),
-            None => return Ok(MacroBindingV0::ControlSeqLiteral(current)),
-        }
-    }
-}
-
-fn expand_binding_v0(
-    name: &[u8],
-    binding: MacroBindingV0,
-    macro_frames: &mut Vec<BTreeMap<Vec<u8>, MacroBindingV0>>,
-    counters: &mut [u32; 2],
-    out: &mut Vec<TokenV0>,
-    active_macros: &mut Vec<Vec<u8>>,
-    expansion_count: &mut usize,
-    depth: usize,
-) -> Result<(), InvalidInputReasonV0> {
-    *expansion_count = expansion_count
-        .checked_add(1)
-        .ok_or(InvalidInputReasonV0::MacroExpansionsExceeded)?;
-    if *expansion_count > MAX_MACRO_EXPANSIONS_V0 {
-        return Err(InvalidInputReasonV0::MacroExpansionsExceeded);
-    }
-    if active_macros.iter().any(|active| active == name) {
-        return Err(InvalidInputReasonV0::MacroCycleFailed);
-    }
-    active_macros.push(name.to_vec());
-    let result = match binding {
-        MacroBindingV0::Macro(macro_def) => {
-            if macro_def.param_count != 0 {
-                return Err(InvalidInputReasonV0::MacroValidationFailed);
-            }
-            expand_stream_v0(
-                &macro_def.body_tokens,
-                macro_frames,
-                counters,
-                out,
-                active_macros,
-                expansion_count,
-                depth + 1,
-            )
-        }
-        MacroBindingV0::ControlSeqLiteral(target) => {
-            expand_stream_v0(
-                &[TokenV0::ControlSeq(target)],
-                macro_frames,
-                counters,
-                out,
-                active_macros,
-                expansion_count,
-                depth + 1,
-            )
-        }
-        MacroBindingV0::LetAlias {
-            target_name: _,
-            resolved_binding,
-        } => expand_binding_v0(
-            name,
-            *resolved_binding,
-            macro_frames,
-            counters,
-            out,
-            active_macros,
-            expansion_count,
-            depth + 1,
-        ),
-    };
-    active_macros.pop();
-    result
-}
-
-fn total_macro_defs_v0(macro_frames: &[BTreeMap<Vec<u8>, MacroBindingV0>]) -> usize {
-    macro_frames.iter().map(|frame| frame.len()).sum()
-}
-
-fn skip_space_tokens_v0(tokens: &[TokenV0], mut index: usize) -> usize {
-    while matches!(tokens.get(index), Some(TokenV0::Space)) {
-        index += 1;
-    }
-    index
-}
-
-fn validate_macro_body_tokens_v0(
-    body_tokens: &[TokenV0],
-    param_count: u8,
-) -> Result<(), InvalidInputReasonV0> {
-    let mut index = 0usize;
-    while index < body_tokens.len() {
-        match body_tokens.get(index) {
-            Some(TokenV0::Char(b'#')) => match param_count {
-                0 => return Err(InvalidInputReasonV0::MacroParamsUnsupported),
-                1 => match body_tokens.get(index + 1) {
-                    Some(TokenV0::Char(b'1')) => index += 2,
-                    _ => return Err(InvalidInputReasonV0::MacroParamsUnsupported),
-                },
-                _ => return Err(InvalidInputReasonV0::MacroParamsUnsupported),
-            },
-            Some(_) => index += 1,
-            None => break,
-        }
     }
     Ok(())
-}
-
-fn substitute_single_param_placeholders_v0(
-    body_tokens: &[TokenV0],
-    argument_tokens: &[TokenV0],
-) -> Result<Vec<TokenV0>, InvalidInputReasonV0> {
-    let mut out = Vec::<TokenV0>::new();
-    let mut index = 0usize;
-    while index < body_tokens.len() {
-        match body_tokens.get(index) {
-            Some(TokenV0::Char(b'#')) => match body_tokens.get(index + 1) {
-                Some(TokenV0::Char(b'1')) => {
-                    for token in argument_tokens {
-                        push_checked_v0(&mut out, token.clone())?;
-                    }
-                    index += 2;
-                }
-                _ => return Err(InvalidInputReasonV0::MacroParamsUnsupported),
-            },
-            Some(token) => {
-                push_checked_v0(&mut out, token.clone())?;
-                index += 1;
-            }
-            None => break,
-        }
-    }
-    Ok(out)
-}
-
-fn parse_balanced_group_payload_v0(
-    tokens: &[TokenV0],
-    begin_group_index: usize,
-) -> Result<(Vec<TokenV0>, usize), InvalidInputReasonV0> {
-    if !matches!(tokens.get(begin_group_index), Some(TokenV0::BeginGroup)) {
-        return Err(InvalidInputReasonV0::MacroValidationFailed);
-    }
-
-    let mut depth = 1usize;
-    let mut payload = Vec::<TokenV0>::new();
-    let mut index = begin_group_index + 1;
-    while index < tokens.len() {
-        match tokens.get(index) {
-            Some(TokenV0::BeginGroup) => {
-                depth += 1;
-                payload.push(TokenV0::BeginGroup);
-            }
-            Some(TokenV0::EndGroup) => {
-                depth -= 1;
-                if depth == 0 {
-                    return Ok((payload, index + 1));
-                }
-                payload.push(TokenV0::EndGroup);
-            }
-            Some(token) => payload.push(token.clone()),
-            None => break,
-        }
-        index += 1;
-    }
-    Err(InvalidInputReasonV0::MacroValidationFailed)
-}
-
-fn push_checked_v0(out: &mut Vec<TokenV0>, token: TokenV0) -> Result<(), InvalidInputReasonV0> {
-    if out.len() >= MAX_TOKENS_V0 {
-        return Err(InvalidInputReasonV0::MacroValidationFailed);
-    }
-    out.push(token);
-    Ok(())
-}
-
-fn push_ascii_bytes_v0(out: &mut Vec<TokenV0>, bytes: &[u8]) -> Result<(), InvalidInputReasonV0> {
-    for byte in bytes {
-        push_checked_v0(out, TokenV0::Char(*byte))?;
-    }
-    Ok(())
-}
-
-fn parse_count_assignment_v0(
-    tokens: &[TokenV0],
-    count_index: usize,
-    counters: &mut [u32; 2],
-) -> Result<usize, InvalidInputReasonV0> {
-    let register_index = match tokens.get(count_index + 1) {
-        Some(TokenV0::Char(b'0')) => 0usize,
-        Some(TokenV0::Char(b'1')) => 1usize,
-        _ => return Err(InvalidInputReasonV0::MacroCountAssignmentUnsupported),
-    };
-    if !matches!(tokens.get(count_index + 2), Some(TokenV0::Char(b'='))) {
-        return Err(InvalidInputReasonV0::MacroCountAssignmentUnsupported);
-    }
-
-    let mut index = count_index + 3;
-    let mut value: u32 = 0;
-    let mut saw_digit = false;
-    while let Some(TokenV0::Char(byte)) = tokens.get(index) {
-        if !byte.is_ascii_digit() {
-            break;
-        }
-        saw_digit = true;
-        value = value
-            .checked_mul(10)
-            .and_then(|current| current.checked_add((byte - b'0') as u32))
-            .ok_or(InvalidInputReasonV0::MacroCountAssignmentUnsupported)?;
-        if value > MAX_COUNT_VALUE_V0 {
-            return Err(InvalidInputReasonV0::MacroCountAssignmentUnsupported);
-        }
-        index += 1;
-    }
-    if !saw_digit {
-        return Err(InvalidInputReasonV0::MacroCountAssignmentUnsupported);
-    }
-
-    counters[register_index] = value;
-    Ok(index)
-}
-
-fn parse_the_v0(
-    tokens: &[TokenV0],
-    the_index: usize,
-    counters: &[u32; 2],
-) -> Result<(Vec<TokenV0>, usize), InvalidInputReasonV0> {
-    if !matches!(tokens.get(the_index + 1), Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"count")
-    {
-        return Err(InvalidInputReasonV0::MacroTheUnsupported);
-    }
-
-    let register_index = match tokens.get(the_index + 2) {
-        Some(TokenV0::Char(b'0')) => 0usize,
-        Some(TokenV0::Char(b'1')) => 1usize,
-        _ => return Err(InvalidInputReasonV0::MacroTheUnsupported),
-    };
-
-    let mut out = Vec::<TokenV0>::new();
-    let digits = counters[register_index].to_string();
-    push_ascii_bytes_v0(&mut out, digits.as_bytes())?;
-    Ok((out, the_index + 3))
 }

--- a/crates/carreltex-engine/src/compile_v0/macro_v0/bindings.rs
+++ b/crates/carreltex-engine/src/compile_v0/macro_v0/bindings.rs
@@ -1,0 +1,199 @@
+use super::*;
+
+#[derive(Clone)]
+pub(super) struct MacroDefV0 {
+    pub(super) param_count: u8,
+    pub(super) body_tokens: Vec<TokenV0>,
+}
+
+#[derive(Clone)]
+pub(super) enum MacroBindingV0 {
+    Macro(MacroDefV0),
+    ControlSeqLiteral(Vec<u8>),
+    LetAlias {
+        target_name: Vec<u8>,
+        resolved_binding: Box<MacroBindingV0>,
+    },
+}
+
+pub(super) fn lookup_macro_binding_v0(
+    macro_frames: &[BTreeMap<Vec<u8>, MacroBindingV0>],
+    name: &[u8],
+) -> Option<MacroBindingV0> {
+    for frame in macro_frames.iter().rev() {
+        if let Some(binding) = frame.get(name) {
+            return Some(binding.clone());
+        }
+    }
+    None
+}
+
+enum IfxComparableBindingV0 {
+    Undefined,
+    AliasTarget(Vec<u8>),
+    Macro(MacroDefV0),
+}
+
+pub(super) fn compare_ifx_control_sequences_v0(
+    macro_frames: &[BTreeMap<Vec<u8>, MacroBindingV0>],
+    left: &[u8],
+    right: &[u8],
+) -> bool {
+    match (
+        classify_ifx_binding_v0(macro_frames, left),
+        classify_ifx_binding_v0(macro_frames, right),
+    ) {
+        (IfxComparableBindingV0::Undefined, IfxComparableBindingV0::Undefined) => true,
+        (
+            IfxComparableBindingV0::AliasTarget(left_target),
+            IfxComparableBindingV0::AliasTarget(right_target),
+        ) => left_target == right_target,
+        (IfxComparableBindingV0::Macro(left_macro), IfxComparableBindingV0::Macro(right_macro)) => {
+            left_macro.param_count == right_macro.param_count
+                && left_macro.body_tokens == right_macro.body_tokens
+        }
+        _ => false,
+    }
+}
+
+fn classify_ifx_binding_v0(
+    macro_frames: &[BTreeMap<Vec<u8>, MacroBindingV0>],
+    name: &[u8],
+) -> IfxComparableBindingV0 {
+    match lookup_macro_binding_v0(macro_frames, name) {
+        None => IfxComparableBindingV0::Undefined,
+        Some(MacroBindingV0::Macro(definition)) => IfxComparableBindingV0::Macro(definition),
+        Some(MacroBindingV0::ControlSeqLiteral(target_name)) => {
+            IfxComparableBindingV0::AliasTarget(resolve_alias_target_name_v0(macro_frames, target_name))
+        }
+        Some(MacroBindingV0::LetAlias {
+            target_name: _,
+            resolved_binding,
+        }) => classify_ifx_from_resolved_binding_v0(*resolved_binding),
+    }
+}
+
+fn classify_ifx_from_resolved_binding_v0(binding: MacroBindingV0) -> IfxComparableBindingV0 {
+    match binding {
+        MacroBindingV0::Macro(definition) => IfxComparableBindingV0::Macro(definition),
+        MacroBindingV0::ControlSeqLiteral(_name) => IfxComparableBindingV0::Undefined,
+        MacroBindingV0::LetAlias {
+            target_name: _,
+            resolved_binding,
+        } => classify_ifx_from_resolved_binding_v0(*resolved_binding),
+    }
+}
+
+fn resolve_alias_target_name_v0(
+    macro_frames: &[BTreeMap<Vec<u8>, MacroBindingV0>],
+    start: Vec<u8>,
+) -> Vec<u8> {
+    let mut current = start;
+    let mut seen = Vec::<Vec<u8>>::new();
+    loop {
+        if seen.iter().any(|entry| entry == &current) {
+            return current;
+        }
+        seen.push(current.clone());
+        match lookup_macro_binding_v0(macro_frames, &current) {
+            Some(MacroBindingV0::ControlSeqLiteral(next)) => current = next,
+            Some(MacroBindingV0::LetAlias {
+                target_name,
+                resolved_binding: _,
+            }) => current = target_name,
+            _ => return current,
+        }
+    }
+}
+
+pub(super) fn snapshot_let_binding_v0(
+    target_name: &[u8],
+    macro_frames: &[BTreeMap<Vec<u8>, MacroBindingV0>],
+) -> Result<MacroBindingV0, InvalidInputReasonV0> {
+    let mut current = target_name.to_vec();
+    let mut seen = Vec::<Vec<u8>>::new();
+    loop {
+        if seen.iter().any(|entry| entry == &current) {
+            return Err(InvalidInputReasonV0::MacroCycleFailed);
+        }
+        let binding = lookup_macro_binding_v0(macro_frames, &current);
+        match binding {
+            Some(MacroBindingV0::Macro(definition)) => return Ok(MacroBindingV0::Macro(definition)),
+            Some(MacroBindingV0::ControlSeqLiteral(target)) => {
+                seen.push(current);
+                current = target;
+            }
+            Some(MacroBindingV0::LetAlias {
+                target_name: _,
+                resolved_binding,
+            }) => return Ok(*resolved_binding),
+            None => return Ok(MacroBindingV0::ControlSeqLiteral(current)),
+        }
+    }
+}
+
+pub(super) fn expand_binding_v0(
+    name: &[u8],
+    binding: MacroBindingV0,
+    macro_frames: &mut Vec<BTreeMap<Vec<u8>, MacroBindingV0>>,
+    counters: &mut [u32; 2],
+    out: &mut Vec<TokenV0>,
+    active_macros: &mut Vec<Vec<u8>>,
+    expansion_count: &mut usize,
+    depth: usize,
+) -> Result<(), InvalidInputReasonV0> {
+    *expansion_count = expansion_count
+        .checked_add(1)
+        .ok_or(InvalidInputReasonV0::MacroExpansionsExceeded)?;
+    if *expansion_count > MAX_MACRO_EXPANSIONS_V0 {
+        return Err(InvalidInputReasonV0::MacroExpansionsExceeded);
+    }
+    if active_macros.iter().any(|active| active == name) {
+        return Err(InvalidInputReasonV0::MacroCycleFailed);
+    }
+    active_macros.push(name.to_vec());
+    let result = match binding {
+        MacroBindingV0::Macro(macro_def) => {
+            if macro_def.param_count != 0 {
+                return Err(InvalidInputReasonV0::MacroValidationFailed);
+            }
+            super::expand_stream_v0(
+                &macro_def.body_tokens,
+                macro_frames,
+                counters,
+                out,
+                active_macros,
+                expansion_count,
+                depth + 1,
+            )
+        }
+        MacroBindingV0::ControlSeqLiteral(target) => super::expand_stream_v0(
+            &[TokenV0::ControlSeq(target)],
+            macro_frames,
+            counters,
+            out,
+            active_macros,
+            expansion_count,
+            depth + 1,
+        ),
+        MacroBindingV0::LetAlias {
+            target_name: _,
+            resolved_binding,
+        } => expand_binding_v0(
+            name,
+            *resolved_binding,
+            macro_frames,
+            counters,
+            out,
+            active_macros,
+            expansion_count,
+            depth + 1,
+        ),
+    };
+    active_macros.pop();
+    result
+}
+
+pub(super) fn total_macro_defs_v0(macro_frames: &[BTreeMap<Vec<u8>, MacroBindingV0>]) -> usize {
+    macro_frames.iter().map(|frame| frame.len()).sum()
+}

--- a/crates/carreltex-engine/src/compile_v0/macro_v0/count_the.rs
+++ b/crates/carreltex-engine/src/compile_v0/macro_v0/count_the.rs
@@ -1,0 +1,65 @@
+use super::*;
+use super::utils::push_ascii_bytes_v0;
+
+const MAX_COUNT_VALUE_V0: u32 = 1_000_000;
+
+pub(super) fn parse_count_assignment_v0(
+    tokens: &[TokenV0],
+    count_index: usize,
+    counters: &mut [u32; 2],
+) -> Result<usize, InvalidInputReasonV0> {
+    let register_index = match tokens.get(count_index + 1) {
+        Some(TokenV0::Char(b'0')) => 0usize,
+        Some(TokenV0::Char(b'1')) => 1usize,
+        _ => return Err(InvalidInputReasonV0::MacroCountAssignmentUnsupported),
+    };
+    if !matches!(tokens.get(count_index + 2), Some(TokenV0::Char(b'='))) {
+        return Err(InvalidInputReasonV0::MacroCountAssignmentUnsupported);
+    }
+
+    let mut index = count_index + 3;
+    let mut value: u32 = 0;
+    let mut saw_digit = false;
+    while let Some(TokenV0::Char(byte)) = tokens.get(index) {
+        if !byte.is_ascii_digit() {
+            break;
+        }
+        saw_digit = true;
+        value = value
+            .checked_mul(10)
+            .and_then(|current| current.checked_add((byte - b'0') as u32))
+            .ok_or(InvalidInputReasonV0::MacroCountAssignmentUnsupported)?;
+        if value > MAX_COUNT_VALUE_V0 {
+            return Err(InvalidInputReasonV0::MacroCountAssignmentUnsupported);
+        }
+        index += 1;
+    }
+    if !saw_digit {
+        return Err(InvalidInputReasonV0::MacroCountAssignmentUnsupported);
+    }
+
+    counters[register_index] = value;
+    Ok(index)
+}
+
+pub(super) fn parse_the_v0(
+    tokens: &[TokenV0],
+    the_index: usize,
+    counters: &[u32; 2],
+) -> Result<(Vec<TokenV0>, usize), InvalidInputReasonV0> {
+    if !matches!(tokens.get(the_index + 1), Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"count")
+    {
+        return Err(InvalidInputReasonV0::MacroTheUnsupported);
+    }
+
+    let register_index = match tokens.get(the_index + 2) {
+        Some(TokenV0::Char(b'0')) => 0usize,
+        Some(TokenV0::Char(b'1')) => 1usize,
+        _ => return Err(InvalidInputReasonV0::MacroTheUnsupported),
+    };
+
+    let mut out = Vec::<TokenV0>::new();
+    let digits = counters[register_index].to_string();
+    push_ascii_bytes_v0(&mut out, digits.as_bytes())?;
+    Ok((out, the_index + 3))
+}

--- a/crates/carreltex-engine/src/compile_v0/macro_v0/csname_expandafter.rs
+++ b/crates/carreltex-engine/src/compile_v0/macro_v0/csname_expandafter.rs
@@ -1,0 +1,46 @@
+use super::*;
+use super::utils::skip_space_tokens_v0;
+
+pub(super) fn parse_expandafter_v0(
+    tokens: &[TokenV0],
+    expandafter_index: usize,
+) -> Result<(Vec<TokenV0>, usize), InvalidInputReasonV0> {
+    let first_index = skip_space_tokens_v0(tokens, expandafter_index + 1);
+    let first_name = match tokens.get(first_index) {
+        Some(TokenV0::ControlSeq(name)) => name.clone(),
+        _ => return Err(InvalidInputReasonV0::MacroExpandafterUnsupported),
+    };
+
+    let second_index = skip_space_tokens_v0(tokens, first_index + 1);
+    let second_name = match tokens.get(second_index) {
+        Some(TokenV0::ControlSeq(name)) => name.clone(),
+        _ => return Err(InvalidInputReasonV0::MacroExpandafterUnsupported),
+    };
+
+    Ok((
+        vec![TokenV0::ControlSeq(second_name), TokenV0::ControlSeq(first_name)],
+        second_index + 1,
+    ))
+}
+
+pub(super) fn parse_csname_v0(
+    tokens: &[TokenV0],
+    csname_index: usize,
+) -> Result<(TokenV0, usize), InvalidInputReasonV0> {
+    let mut name_bytes = Vec::<u8>::new();
+    let mut index = csname_index + 1;
+    while index < tokens.len() {
+        match tokens.get(index) {
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"endcsname" => {
+                if name_bytes.is_empty() {
+                    return Err(InvalidInputReasonV0::MacroCsnameUnsupported);
+                }
+                return Ok((TokenV0::ControlSeq(name_bytes), index + 1));
+            }
+            Some(TokenV0::Char(byte)) => name_bytes.push(*byte),
+            _ => return Err(InvalidInputReasonV0::MacroCsnameUnsupported),
+        }
+        index += 1;
+    }
+    Err(InvalidInputReasonV0::MacroCsnameUnsupported)
+}

--- a/crates/carreltex-engine/src/compile_v0/macro_v0/def_xdef.rs
+++ b/crates/carreltex-engine/src/compile_v0/macro_v0/def_xdef.rs
@@ -1,0 +1,157 @@
+use super::*;
+use super::bindings::{total_macro_defs_v0, MacroBindingV0, MacroDefV0};
+use super::utils::{parse_balanced_group_payload_v0, validate_macro_body_tokens_v0};
+
+pub(super) fn parse_def_v0(
+    tokens: &[TokenV0],
+    def_index: usize,
+    macro_frames: &mut Vec<BTreeMap<Vec<u8>, MacroBindingV0>>,
+    counters: &mut [u32; 2],
+    is_global: bool,
+    expand_body: bool,
+) -> Result<usize, InvalidInputReasonV0> {
+    let name_index = def_index + 1;
+    let macro_name = match tokens.get(name_index) {
+        Some(TokenV0::ControlSeq(name)) => name.clone(),
+        _ => return Err(InvalidInputReasonV0::MacroValidationFailed),
+    };
+
+    let mut param_count = 0u8;
+    let mut body_start_index = name_index + 1;
+    match tokens.get(body_start_index) {
+        Some(TokenV0::BeginGroup) => {}
+        Some(TokenV0::Char(b'#')) => {
+            if expand_body {
+                return Err(InvalidInputReasonV0::MacroParamsUnsupported);
+            }
+            let placeholder_digit = match tokens.get(body_start_index + 1) {
+                Some(TokenV0::Char(digit)) => *digit,
+                _ => return Err(InvalidInputReasonV0::MacroParamsUnsupported),
+            };
+            if placeholder_digit != b'1' {
+                return Err(InvalidInputReasonV0::MacroParamsUnsupported);
+            }
+            param_count = 1;
+            body_start_index += 2;
+            if matches!(tokens.get(body_start_index), Some(TokenV0::Char(b'#'))) {
+                return Err(InvalidInputReasonV0::MacroParamsUnsupported);
+            }
+            if !matches!(tokens.get(body_start_index), Some(TokenV0::BeginGroup)) {
+                return Err(InvalidInputReasonV0::MacroValidationFailed);
+            }
+        }
+        _ => return Err(InvalidInputReasonV0::MacroValidationFailed),
+    }
+
+    let (body_tokens, next_index) = parse_balanced_group_payload_v0(tokens, body_start_index)?;
+    validate_macro_body_tokens_v0(&body_tokens, param_count)?;
+    let final_body_tokens = if expand_body {
+        if param_count != 0 {
+            return Err(InvalidInputReasonV0::MacroParamsUnsupported);
+        }
+        let mut expanded = Vec::<TokenV0>::new();
+        let mut active_macros = Vec::<Vec<u8>>::new();
+        let mut expansion_count = 0usize;
+        super::expand_stream_v0(
+            &body_tokens,
+            macro_frames,
+            counters,
+            &mut expanded,
+            &mut active_macros,
+            &mut expansion_count,
+            0,
+        )?;
+        expanded
+    } else {
+        body_tokens
+    };
+    let target_frame_index = if is_global {
+        0usize
+    } else {
+        macro_frames
+            .len()
+            .checked_sub(1)
+            .ok_or(InvalidInputReasonV0::MacroValidationFailed)?
+    };
+    let total_macro_defs = total_macro_defs_v0(macro_frames);
+    let target_frame = macro_frames
+        .get_mut(target_frame_index)
+        .ok_or(InvalidInputReasonV0::MacroValidationFailed)?;
+    if !target_frame.contains_key(&macro_name) && total_macro_defs >= MAX_MACROS_V0 {
+        return Err(InvalidInputReasonV0::MacroValidationFailed);
+    }
+    if param_count > 1 {
+        return Err(InvalidInputReasonV0::MacroValidationFailed);
+    }
+    target_frame.insert(
+        macro_name,
+        MacroBindingV0::Macro(MacroDefV0 {
+            param_count: if expand_body { 0 } else { param_count },
+            body_tokens: final_body_tokens,
+        }),
+    );
+    Ok(next_index)
+}
+
+pub(super) fn parse_xdef_v0(
+    tokens: &[TokenV0],
+    xdef_index: usize,
+    macro_frames: &mut Vec<BTreeMap<Vec<u8>, MacroBindingV0>>,
+    counters: &mut [u32; 2],
+    is_global: bool,
+) -> Result<usize, InvalidInputReasonV0> {
+    let name_index = xdef_index + 1;
+    let macro_name = match tokens.get(name_index) {
+        Some(TokenV0::ControlSeq(name)) => name.clone(),
+        _ => return Err(InvalidInputReasonV0::MacroXdefUnsupported),
+    };
+    let body_start_index = name_index + 1;
+    if !matches!(tokens.get(body_start_index), Some(TokenV0::BeginGroup)) {
+        return Err(InvalidInputReasonV0::MacroXdefUnsupported);
+    }
+    let (body_tokens, next_index) = parse_balanced_group_payload_v0(tokens, body_start_index)
+        .map_err(|_| InvalidInputReasonV0::MacroXdefUnsupported)?;
+    if body_tokens
+        .iter()
+        .any(|token| matches!(token, TokenV0::Char(b'#')))
+    {
+        return Err(InvalidInputReasonV0::MacroXdefUnsupported);
+    }
+
+    let mut expanded = Vec::<TokenV0>::new();
+    let mut active_macros = Vec::<Vec<u8>>::new();
+    let mut expansion_count = 0usize;
+    super::expand_stream_v0(
+        &body_tokens,
+        macro_frames,
+        counters,
+        &mut expanded,
+        &mut active_macros,
+        &mut expansion_count,
+        0,
+    )?;
+
+    let target_frame_index = if is_global {
+        0usize
+    } else {
+        macro_frames
+            .len()
+            .checked_sub(1)
+            .ok_or(InvalidInputReasonV0::MacroValidationFailed)?
+    };
+    let total_macro_defs = total_macro_defs_v0(macro_frames);
+    let target_frame = macro_frames
+        .get_mut(target_frame_index)
+        .ok_or(InvalidInputReasonV0::MacroValidationFailed)?;
+    if !target_frame.contains_key(&macro_name) && total_macro_defs >= MAX_MACROS_V0 {
+        return Err(InvalidInputReasonV0::MacroValidationFailed);
+    }
+    target_frame.insert(
+        macro_name,
+        MacroBindingV0::Macro(MacroDefV0 {
+            param_count: 0,
+            body_tokens: expanded,
+        }),
+    );
+    Ok(next_index)
+}

--- a/crates/carreltex-engine/src/compile_v0/macro_v0/global_prefix.rs
+++ b/crates/carreltex-engine/src/compile_v0/macro_v0/global_prefix.rs
@@ -1,0 +1,40 @@
+use super::*;
+use super::def_xdef::{parse_def_v0, parse_xdef_v0};
+use super::let_futurelet::{parse_futurelet_v0, parse_let_v0};
+
+pub(super) fn parse_global_prefixed_macro_binding_v0(
+    tokens: &[TokenV0],
+    global_index: usize,
+    macro_frames: &mut Vec<BTreeMap<Vec<u8>, MacroBindingV0>>,
+    counters: &mut [u32; 2],
+) -> Result<usize, InvalidInputReasonV0> {
+    let mut index = global_index;
+    while matches!(
+        tokens.get(index),
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"global"
+    ) {
+        index += 1;
+    }
+
+    match tokens.get(index) {
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"def" => {
+            parse_def_v0(tokens, index, macro_frames, counters, true, false)
+        }
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"gdef" => {
+            parse_def_v0(tokens, index, macro_frames, counters, true, false)
+        }
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"edef" => {
+            parse_def_v0(tokens, index, macro_frames, counters, true, true)
+        }
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"xdef" => {
+            parse_xdef_v0(tokens, index, macro_frames, counters, true)
+        }
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"let" => {
+            parse_let_v0(tokens, index, macro_frames, true)
+        }
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"futurelet" => {
+            parse_futurelet_v0(tokens, index, macro_frames, true)
+        }
+        _ => Err(InvalidInputReasonV0::MacroGlobalPrefixUnsupported),
+    }
+}

--- a/crates/carreltex-engine/src/compile_v0/macro_v0/let_futurelet.rs
+++ b/crates/carreltex-engine/src/compile_v0/macro_v0/let_futurelet.rs
@@ -1,0 +1,92 @@
+use super::*;
+use super::bindings::{snapshot_let_binding_v0, total_macro_defs_v0, MacroBindingV0};
+use super::utils::skip_space_tokens_v0;
+
+pub(super) fn parse_let_v0(
+    tokens: &[TokenV0],
+    let_index: usize,
+    macro_frames: &mut Vec<BTreeMap<Vec<u8>, MacroBindingV0>>,
+    is_global: bool,
+) -> Result<usize, InvalidInputReasonV0> {
+    let alias_name = match tokens.get(let_index + 1) {
+        Some(TokenV0::ControlSeq(name)) => name.clone(),
+        _ => return Err(InvalidInputReasonV0::MacroValidationFailed),
+    };
+
+    let mut index = skip_space_tokens_v0(tokens, let_index + 2);
+    if matches!(tokens.get(index), Some(TokenV0::Char(b'='))) {
+        index = skip_space_tokens_v0(tokens, index + 1);
+    }
+
+    let target_name = match tokens.get(index) {
+        Some(TokenV0::ControlSeq(name)) => name.clone(),
+        _ => return Err(InvalidInputReasonV0::MacroLetUnsupported),
+    };
+    let resolved_binding = snapshot_let_binding_v0(&target_name, macro_frames)?;
+    let target_frame_index = if is_global {
+        0usize
+    } else {
+        macro_frames
+            .len()
+            .checked_sub(1)
+            .ok_or(InvalidInputReasonV0::MacroValidationFailed)?
+    };
+    let total_macro_defs = total_macro_defs_v0(macro_frames);
+    let target_frame = macro_frames
+        .get_mut(target_frame_index)
+        .ok_or(InvalidInputReasonV0::MacroValidationFailed)?;
+    if !target_frame.contains_key(&alias_name) && total_macro_defs >= MAX_MACROS_V0 {
+        return Err(InvalidInputReasonV0::MacroValidationFailed);
+    }
+    target_frame.insert(
+        alias_name,
+        MacroBindingV0::LetAlias {
+            target_name,
+            resolved_binding: Box::new(resolved_binding),
+        },
+    );
+    Ok(index + 1)
+}
+
+pub(super) fn parse_futurelet_v0(
+    tokens: &[TokenV0],
+    futurelet_index: usize,
+    macro_frames: &mut Vec<BTreeMap<Vec<u8>, MacroBindingV0>>,
+    is_global: bool,
+) -> Result<usize, InvalidInputReasonV0> {
+    let alias_name_index = skip_space_tokens_v0(tokens, futurelet_index + 1);
+    let alias_name = match tokens.get(alias_name_index) {
+        Some(TokenV0::ControlSeq(name)) => name.clone(),
+        _ => return Err(InvalidInputReasonV0::MacroFutureletUnsupported),
+    };
+
+    let probe_index = skip_space_tokens_v0(tokens, alias_name_index + 1);
+    let _probe_name = match tokens.get(probe_index) {
+        Some(TokenV0::ControlSeq(name)) => name.clone(),
+        _ => return Err(InvalidInputReasonV0::MacroFutureletUnsupported),
+    };
+
+    let target_index = skip_space_tokens_v0(tokens, probe_index + 1);
+    let target_name = match tokens.get(target_index) {
+        Some(TokenV0::ControlSeq(name)) => name.clone(),
+        _ => return Err(InvalidInputReasonV0::MacroFutureletUnsupported),
+    };
+
+    let target_frame_index = if is_global {
+        0usize
+    } else {
+        macro_frames
+            .len()
+            .checked_sub(1)
+            .ok_or(InvalidInputReasonV0::MacroValidationFailed)?
+    };
+    let total_macro_defs = total_macro_defs_v0(macro_frames);
+    let target_frame = macro_frames
+        .get_mut(target_frame_index)
+        .ok_or(InvalidInputReasonV0::MacroValidationFailed)?;
+    if !target_frame.contains_key(&alias_name) && total_macro_defs >= MAX_MACROS_V0 {
+        return Err(InvalidInputReasonV0::MacroValidationFailed);
+    }
+    target_frame.insert(alias_name, MacroBindingV0::ControlSeqLiteral(target_name));
+    Ok(probe_index)
+}

--- a/crates/carreltex-engine/src/compile_v0/macro_v0/noexpand.rs
+++ b/crates/carreltex-engine/src/compile_v0/macro_v0/noexpand.rs
@@ -1,0 +1,15 @@
+use super::*;
+use super::utils::push_checked_v0;
+
+pub(super) fn parse_noexpand_v0(
+    tokens: &[TokenV0],
+    noexpand_index: usize,
+    out: &mut Vec<TokenV0>,
+) -> Result<usize, InvalidInputReasonV0> {
+    let next = tokens
+        .get(noexpand_index + 1)
+        .ok_or(InvalidInputReasonV0::MacroNoexpandUnsupported)?
+        .clone();
+    push_checked_v0(out, next)?;
+    Ok(noexpand_index + 2)
+}

--- a/crates/carreltex-engine/src/compile_v0/macro_v0/string_meaning.rs
+++ b/crates/carreltex-engine/src/compile_v0/macro_v0/string_meaning.rs
@@ -1,0 +1,61 @@
+use super::*;
+use super::bindings::{lookup_macro_binding_v0, MacroBindingV0};
+use super::utils::{push_ascii_bytes_v0, skip_space_tokens_v0};
+
+pub(super) fn parse_string_v0(
+    tokens: &[TokenV0],
+    string_index: usize,
+) -> Result<(Vec<TokenV0>, usize), InvalidInputReasonV0> {
+    let next_index = skip_space_tokens_v0(tokens, string_index + 1);
+    let control_name = match tokens.get(next_index) {
+        Some(TokenV0::ControlSeq(name)) => name.clone(),
+        _ => return Err(InvalidInputReasonV0::MacroStringUnsupported),
+    };
+
+    let mut out = Vec::<TokenV0>::new();
+    out.push(TokenV0::Char(b'\\'));
+    for byte in control_name {
+        out.push(TokenV0::Char(byte));
+    }
+    Ok((out, next_index + 1))
+}
+
+pub(super) fn parse_meaning_v0(
+    tokens: &[TokenV0],
+    meaning_index: usize,
+    macro_frames: &[BTreeMap<Vec<u8>, MacroBindingV0>],
+) -> Result<(Vec<TokenV0>, usize), InvalidInputReasonV0> {
+    let next_index = skip_space_tokens_v0(tokens, meaning_index + 1);
+    let query_name = match tokens.get(next_index) {
+        Some(TokenV0::ControlSeq(name)) => name.clone(),
+        _ => return Err(InvalidInputReasonV0::MacroMeaningUnsupported),
+    };
+
+    let mut out = Vec::<TokenV0>::new();
+    match lookup_macro_binding_v0(macro_frames, &query_name) {
+        Some(MacroBindingV0::Macro(_)) => {
+            push_ascii_bytes_v0(&mut out, b"macro:")?;
+            push_ascii_bytes_v0(&mut out, &query_name)?;
+        }
+        Some(MacroBindingV0::ControlSeqLiteral(target_name)) => {
+            push_ascii_bytes_v0(&mut out, b"alias:")?;
+            push_ascii_bytes_v0(&mut out, &query_name)?;
+            push_ascii_bytes_v0(&mut out, b"->")?;
+            push_ascii_bytes_v0(&mut out, &target_name)?;
+        }
+        Some(MacroBindingV0::LetAlias {
+            target_name,
+            resolved_binding: _,
+        }) => {
+            push_ascii_bytes_v0(&mut out, b"alias:")?;
+            push_ascii_bytes_v0(&mut out, &query_name)?;
+            push_ascii_bytes_v0(&mut out, b"->")?;
+            push_ascii_bytes_v0(&mut out, &target_name)?;
+        }
+        None => {
+            push_ascii_bytes_v0(&mut out, b"undefined:")?;
+            push_ascii_bytes_v0(&mut out, &query_name)?;
+        }
+    }
+    Ok((out, next_index + 1))
+}

--- a/crates/carreltex-engine/src/compile_v0/macro_v0/utils.rs
+++ b/crates/carreltex-engine/src/compile_v0/macro_v0/utils.rs
@@ -1,0 +1,110 @@
+use super::*;
+
+pub(super) fn skip_space_tokens_v0(tokens: &[TokenV0], mut index: usize) -> usize {
+    while matches!(tokens.get(index), Some(TokenV0::Space)) {
+        index += 1;
+    }
+    index
+}
+
+pub(super) fn push_checked_v0(
+    out: &mut Vec<TokenV0>,
+    token: TokenV0,
+) -> Result<(), InvalidInputReasonV0> {
+    if out.len() >= MAX_TOKENS_V0 {
+        return Err(InvalidInputReasonV0::MacroValidationFailed);
+    }
+    out.push(token);
+    Ok(())
+}
+
+pub(super) fn push_ascii_bytes_v0(
+    out: &mut Vec<TokenV0>,
+    bytes: &[u8],
+) -> Result<(), InvalidInputReasonV0> {
+    for byte in bytes {
+        push_checked_v0(out, TokenV0::Char(*byte))?;
+    }
+    Ok(())
+}
+
+pub(super) fn parse_balanced_group_payload_v0(
+    tokens: &[TokenV0],
+    begin_group_index: usize,
+) -> Result<(Vec<TokenV0>, usize), InvalidInputReasonV0> {
+    if !matches!(tokens.get(begin_group_index), Some(TokenV0::BeginGroup)) {
+        return Err(InvalidInputReasonV0::MacroValidationFailed);
+    }
+
+    let mut depth = 1usize;
+    let mut payload = Vec::<TokenV0>::new();
+    let mut index = begin_group_index + 1;
+    while index < tokens.len() {
+        match tokens.get(index) {
+            Some(TokenV0::BeginGroup) => {
+                depth += 1;
+                payload.push(TokenV0::BeginGroup);
+            }
+            Some(TokenV0::EndGroup) => {
+                depth -= 1;
+                if depth == 0 {
+                    return Ok((payload, index + 1));
+                }
+                payload.push(TokenV0::EndGroup);
+            }
+            Some(token) => payload.push(token.clone()),
+            None => break,
+        }
+        index += 1;
+    }
+    Err(InvalidInputReasonV0::MacroValidationFailed)
+}
+
+pub(super) fn validate_macro_body_tokens_v0(
+    body_tokens: &[TokenV0],
+    param_count: u8,
+) -> Result<(), InvalidInputReasonV0> {
+    let mut index = 0usize;
+    while index < body_tokens.len() {
+        match body_tokens.get(index) {
+            Some(TokenV0::Char(b'#')) => match param_count {
+                0 => return Err(InvalidInputReasonV0::MacroParamsUnsupported),
+                1 => match body_tokens.get(index + 1) {
+                    Some(TokenV0::Char(b'1')) => index += 2,
+                    _ => return Err(InvalidInputReasonV0::MacroParamsUnsupported),
+                },
+                _ => return Err(InvalidInputReasonV0::MacroParamsUnsupported),
+            },
+            Some(_) => index += 1,
+            None => break,
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn substitute_single_param_placeholders_v0(
+    body_tokens: &[TokenV0],
+    argument_tokens: &[TokenV0],
+) -> Result<Vec<TokenV0>, InvalidInputReasonV0> {
+    let mut out = Vec::<TokenV0>::new();
+    let mut index = 0usize;
+    while index < body_tokens.len() {
+        match body_tokens.get(index) {
+            Some(TokenV0::Char(b'#')) => match body_tokens.get(index + 1) {
+                Some(TokenV0::Char(b'1')) => {
+                    for token in argument_tokens {
+                        push_checked_v0(&mut out, token.clone())?;
+                    }
+                    index += 2;
+                }
+                _ => return Err(InvalidInputReasonV0::MacroParamsUnsupported),
+            },
+            Some(token) => {
+                push_checked_v0(&mut out, token.clone())?;
+                index += 1;
+            }
+            None => break,
+        }
+    }
+    Ok(out)
+}


### PR DESCRIPTION
## Summary
- Structure-only modularization of `macro_expand_v0` into focused internal modules under `crates/carreltex-engine/src/compile_v0/macro_v0/`
- Kept public compile API and macro behavior unchanged; updated internal wiring only
- Added tokenizer error mapping helper usage from compile path without semantic change

## Proof (`./scripts/proof_v0.sh`)
```text
PASS: loc_guard crates/carreltex-core/src/compile.rs lines=     710 limit=1000
PASS: loc_guard crates/carreltex-core/src/lib.rs lines=      16 limit=1000
PASS: loc_guard crates/carreltex-core/src/mount.rs lines=     307 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0.rs lines=    1000 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/count_v0_tests.rs lines=      76 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/edef_v0_tests.rs lines=      68 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/ifnum_v0.rs lines=     113 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/ifnum_v0_tests.rs lines=     176 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/ifx_v0.rs lines=     105 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/ifx_v0_tests.rs lines=     127 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/input_expand_v0.rs lines=     161 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_expand_v0.rs lines=     297 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_v0/bindings.rs lines=     199 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_v0/count_the.rs lines=      65 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_v0/csname_expandafter.rs lines=      46 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_v0/def_xdef.rs lines=     157 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_v0/global_prefix.rs lines=      40 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_v0/let_futurelet.rs lines=      92 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_v0/noexpand.rs lines=      15 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_v0/string_meaning.rs lines=      61 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_v0/utils.rs lines=     110 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/meaning_v0_tests.rs lines=     113 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/stats_v0.rs lines=      54 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/trace_v0.rs lines=     104 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/xdef_noexpand_v0_tests.rs lines=      76 limit=1000
PASS: loc_guard crates/carreltex-engine/src/lib.rs lines=       6 limit=1000
PASS: loc_guard crates/carreltex-engine/src/reasons_v0.rs lines=     112 limit=1000
PASS: loc_guard crates/carreltex-engine/src/tex/mod.rs lines=       3 limit=1000
PASS: loc_guard crates/carreltex-engine/src/tex/tokenize_v0.rs lines=     330 limit=1000
PASS: loc_guard crates/carreltex-wasm-smoke/src/lib.rs lines=     716 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/assert.mjs lines=     347 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/cases_v0.mjs lines=     994 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/cases_v0_count.mjs lines=      97 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/cases_v0_edef.mjs lines=      97 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/cases_v0_ifnum.mjs lines=      97 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/cases_v0_ifx.mjs lines=     143 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/cases_v0_meaning.mjs lines=      88 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/cases_v0_tokenizer.mjs lines=     160 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/cases_v0_xdef_noexpand.mjs lines=      97 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/ctx.mjs lines=      93 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/mem.mjs lines=      24 limit=1000
PASS: loc_guard scripts/wasm_smoke_js_proof.mjs lines=      14 limit=1000
PASS: loc_guard
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests src/lib.rs (target/debug/deps/carreltex_core-45034f808cfda7bc)

running 42 tests
test compile::tests::append_event_encodes_header_little_endian ... ok
test compile::tests::build_tex_stats_json_builder_emits_exact_canonical_output ... ok
test compile::tests::compile_result_builder_uses_canonical_key_order ... ok
test compile::tests::artifact_bytes_within_cap_honors_limit ... ok
test compile::tests::compile_request_struct_accepts_v0_fields ... ok
test compile::tests::compile_result_builder_keeps_artifact_bytes_exact ... ok
test compile::tests::default_compile_main_log_bytes_constant_is_1024 ... ok
test compile::tests::compile_result_builder_escapes_json_string_content ... ok
test compile::tests::event_kind_tex_stats_json_constant_is_two ... ok
test compile::tests::append_event_rejects_when_exceeds_max_events_bytes ... ok
test compile::tests::max_events_bytes_allows_log_and_stats_events ... ok
test compile::tests::max_log_bytes_constant_is_non_zero ... ok
test compile::tests::max_tex_stats_json_bytes_constant_is_4096 ... ok
test compile::tests::report_json_has_status_token_checks_exact_status ... ok
test compile::tests::report_json_missing_components_empty_detection ... ok
test compile::tests::report_json_stays_stable_with_different_log_bytes ... ok
test compile::tests::truncate_log_bytes_enforces_max ... ok
test compile::tests::validate_compile_report_json_accepts_single_known_status ... ok
test compile::tests::validate_compile_report_json_rejects_missing_keys_or_unknown_status ... ok
test compile::tests::validate_compile_report_json_rejects_multiple_status_tokens ... ok
test compile::tests::validate_input_trace_json_accepts_known_good_sample ... ok
test compile::tests::validate_input_trace_json_rejects_bad_escape ... ok
test compile::tests::validate_input_trace_json_rejects_missing_or_extra_key ... ok
test compile::tests::validate_input_trace_json_rejects_non_digit_number ... ok
test compile::tests::validate_input_trace_json_rejects_whitespace ... ok
test compile::tests::validate_input_trace_json_rejects_wrong_key_order ... ok
test compile::tests::validate_tex_stats_json_accepts_builder_output ... ok
test compile::tests::validate_tex_stats_json_rejects_extra_key ... ok
test compile::tests::validate_tex_stats_json_rejects_missing_key ... ok
test compile::tests::validate_tex_stats_json_rejects_negative_or_non_digit_or_empty ... ok
test compile::tests::validate_tex_stats_json_rejects_whitespace ... ok
test mount::tests::duplicate_path_rejected ... ok
test mount::tests::finalize_rejects_invalid_main_tex ... ok
test mount::tests::finalize_sets_finalized_and_blocks_additional_files ... ok
test mount::tests::finalize_requires_main_tex ... ok
test mount::tests::caps_enforced_for_max_files ... ok
test mount::tests::has_file_and_finalize_success ... ok
test mount::tests::normalize_path_v0_accepts_and_rejects_expected_inputs ... ok
test mount::tests::caps_enforced_for_file_size_and_path_len ... ok
test mount::tests::path_policy_rejects_invalid_paths ... ok
test mount::tests::read_file_by_bytes_v0_handles_existing_missing_and_invalid ... ok
test mount::tests::validate_main_tex_checks_nul_and_non_whitespace_bytes ... ok

test result: ok. 42 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests carreltex_core

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests src/lib.rs (target/debug/deps/carreltex_engine-8c7f485924bd301b)

running 103 tests
test compile_v0::count_v0_tests::the_rejects_unsupported_form ... ok
test compile_v0::edef_v0_tests::edef_rejects_parameterized_definition ... ok
test compile_v0::ifnum_v0_tests::crlf_in_body_is_normalized_as_single_whitespace_run ... ok
test compile_v0::count_v0_tests::count0_assignment_then_the_emits_decimal_chars ... ok
test compile_v0::count_v0_tests::count_assignment_rejects_negative_values ... ok
test compile_v0::count_v0_tests::the_count1_without_assignment_defaults_to_zero ... ok
test compile_v0::edef_v0_tests::edef_expands_body_once_at_definition_time ... ok
test compile_v0::ifnum_v0_tests::ifnum_else_is_invalid ... ok
test compile_v0::edef_v0_tests::edef_is_snapshot_not_dynamic_after_redefinition ... ok
test compile_v0::ifnum_v0_tests::caret_hex_uppercase_decode_in_document_body_is_counted_in_stats ... ok
test compile_v0::ifnum_v0_tests::ifnum_else_without_if_is_invalid ... ok
test compile_v0::ifnum_v0_tests::ifnum_false_branch_drops_tokens ... ok
test compile_v0::ifnum_v0_tests::ifnum_missing_fi_is_invalid ... ok
test compile_v0::ifnum_v0_tests::ifnum_depth_cap_is_invalid ... ok
test compile_v0::ifnum_v0_tests::ifnum_true_branch_keeps_tokens ... ok
test compile_v0::ifnum_v0_tests::lone_cr_in_body_is_normalized_as_single_whitespace_run ... ok
test compile_v0::ifnum_v0_tests::non_ascii_control_sequence_byte_maps_to_specific_reason_token ... ok
test compile_v0::ifnum_v0_tests::unsupported_caret_form_maps_to_tokenizer_caret_reason ... ok
test compile_v0::ifnum_v0_tests::unsupported_caret_inside_comment_does_not_fail_and_body_counts_chars ... ok
test compile_v0::ifx_v0_tests::ifx_duplicate_else_is_invalid ... ok
test compile_v0::ifx_v0_tests::ifx_alias_equals_alias_keeps_then_branch ... ok
test compile_v0::ifx_v0_tests::ifx_else_without_if_is_invalid ... ok
test compile_v0::ifx_v0_tests::ifx_let_snapshot_not_equal_after_redefine_keeps_else_branch ... ok
test compile_v0::ifx_v0_tests::ifx_let_to_undefined_is_equal_to_undefined_control_sequence ... ok
test compile_v0::ifx_v0_tests::ifx_macro_equals_macro_keeps_then_branch ... ok
test compile_v0::ifx_v0_tests::ifx_macro_not_equal_macro_keeps_else_branch ... ok
test compile_v0::ifx_v0_tests::ifx_undefined_equals_undefined_keeps_then_branch ... ok
test compile_v0::meaning_v0_tests::let_uses_snapshot_semantics_not_dynamic_alias ... ok
test compile_v0::meaning_v0_tests::meaning_alias_binding_emits_alias_descriptor ... ok
test compile_v0::meaning_v0_tests::meaning_macro_binding_emits_macro_descriptor ... ok
test compile_v0::meaning_v0_tests::meaning_undefined_binding_emits_undefined_descriptor ... ok
test compile_v0::meaning_v0_tests::meaning_with_unsupported_tokens_is_invalid ... ok
test compile_v0::tests::compile_main_uses_default_log_cap_and_not_implemented ... ok
test compile_v0::tests::compile_request_invalid_main_content_reports_mount_finalize_failed_reason ... ok
test compile_v0::tests::compile_request_log_is_truncated_by_max_log_bytes ... ok
test compile_v0::tests::compile_request_missing_entrypoint_reports_request_invalid_reason ... ok
test compile_v0::tests::compile_request_missing_main_tex_reports_entrypoint_missing_reason ... ok
test compile_v0::tests::compile_request_precedence_request_invalid_over_mount_finalize_failed ... ok
test compile_v0::tests::compile_request_rejects_invalid_entrypoint ... ok
test compile_v0::tests::compile_request_rejects_log_cap_above_limit ... ok
test compile_v0::tests::compile_request_rejects_trailing_backslash_in_main_tex ... ok
test compile_v0::tests::compile_request_rejects_unbalanced_groups ... ok
test compile_v0::tests::compile_request_rejects_zero_epoch_or_log_cap ... ok
test compile_v0::tests::compile_request_returns_not_implemented_when_valid ... ok
test compile_v0::tests::compile_request_stats_json_contains_expected_fields ... ok
test compile_v0::tests::compile_request_still_not_implemented_when_tokenization_succeeds ... ok
test compile_v0::tests::compile_request_trace_is_emitted_when_log_budget_allows ... ok
test compile_v0::tests::compile_requires_valid_mount ... ok
test compile_v0::tests::csname_generates_control_sequence_for_macro_lookup ... ok
test compile_v0::tests::csname_with_invalid_inner_tokens_is_invalid ... ok
test compile_v0::tests::expandafter_with_unsupported_tokens_is_invalid ... ok
test compile_v0::tests::expandafter_reorders_two_control_sequences ... ok
test compile_v0::tests::futurelet_with_non_control_sequence_is_invalid ... ok
test compile_v0::tests::futurelet_alias_expands_control_sequence ... ok
test compile_v0::tests::gdef_inside_group_leaks_globally ... ok
test compile_v0::tests::global_def_inside_group_leaks_globally ... ok
test compile_v0::tests::global_def_single_param_inside_group_leaks_globally ... ok
test compile_v0::tests::global_futurelet_inside_group_leaks_globally ... ok
test compile_v0::tests::global_gdef_inside_group_leaks_globally ... ok
test compile_v0::tests::global_prefix_without_def_is_invalid ... ok
test compile_v0::tests::global_let_inside_group_leaks_globally ... ok
test compile_v0::tests::input_cycle_is_invalid ... ok
test compile_v0::tests::input_expands_tokens_from_subfile ... ok
test compile_v0::tests::input_missing_file_is_invalid ... ok
test compile_v0::tests::input_invalid_syntax_is_invalid ... ok
test compile_v0::tests::input_valid_when_file_exists ... ok
test compile_v0::tests::input_depth_cap_is_invalid ... ok
test compile_v0::tests::let_to_non_control_sequence_is_invalid ... ok
test compile_v0::tests::macro_cycle_is_invalid ... ok
test compile_v0::tests::let_alias_expands_control_sequence ... ok
test compile_v0::tests::macro_defs_can_override_inside_group_without_leaking ... ok
test compile_v0::tests::macro_defs_inside_group_do_not_leak_outside ... ok
test compile_v0::tests::macro_expansion_positive_increases_char_count ... ok
test compile_v0::tests::macro_params_unsupported_is_invalid ... ok
test compile_v0::tests::macro_single_param_missing_arg_is_invalid ... ok
test compile_v0::tests::macro_single_param_positive_increases_char_count ... ok
test compile_v0::tests::stacked_global_prefix_without_def_is_invalid ... ok
test compile_v0::tests::stacked_global_def_inside_group_leaks_globally ... ok
test compile_v0::tests::string_with_unsupported_tokens_is_invalid ... ok
test compile_v0::tests::string_control_sequence_produces_literal_chars ... ok
test compile_v0::xdef_noexpand_v0_tests::noexpand_makes_edef_dynamic ... ok
test compile_v0::xdef_noexpand_v0_tests::noexpand_without_next_token_invalid ... ok
test compile_v0::xdef_noexpand_v0_tests::xdef_leaks_globally ... ok
test compile_v0::xdef_noexpand_v0_tests::xdef_params_unsupported ... ok
test tex::tokenize_v0::tests::caret_hex_ff_is_allowed ... ok
test tex::tokenize_v0::tests::caret_hex_sequence_decodes_to_single_byte ... ok
test tex::tokenize_v0::tests::caret_hex_uppercase_is_allowed ... ok
test tex::tokenize_v0::tests::caret_hex_zero_decodes_to_nul_and_is_invalid ... ok
test tex::tokenize_v0::tests::caret_sequence_inside_comment_is_ignored_as_raw_text ... ok
test tex::tokenize_v0::tests::control_sequence_bytes_must_be_ascii ... ok
test tex::tokenize_v0::tests::crlf_collapses_to_single_space_token ... ok
test tex::tokenize_v0::tests::lone_cr_collapses_to_single_space_token ... ok
test tex::tokenize_v0::tests::nul_byte_is_invalid_input ... ok
test tex::tokenize_v0::tests::percent_comment_is_skipped_until_newline ... ok
test tex::tokenize_v0::tests::percent_comment_terminated_by_cr_does_not_emit_double_space ... ok
test tex::tokenize_v0::tests::space_after_control_word_is_ignored ... ok
test tex::tokenize_v0::tests::tokenizes_minimal_document_and_contains_expected_control_words ... ok
test tex::tokenize_v0::tests::unsupported_caret_form_is_caret_not_supported ... ok
test tex::tokenize_v0::tests::verb_control_word_is_invalid_input ... ok
test tex::tokenize_v0::tests::whitespace_is_coalesced_to_single_space_token ... ok
test compile_v0::tests::input_expansions_cap_is_invalid ... ok
test compile_v0::tests::macro_expansions_cap_is_invalid ... ok
test tex::tokenize_v0::tests::too_many_tokens_is_fail_closed ... ok

test result: ok. 103 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

   Doc-tests carreltex_engine

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.00s
PASS: JS loaded WASM and exercised ABI (alloc/validate/mount/compile/report)
PASS: ledger status validation passed (7 rows)
PASS: carreltex v0 proof bundle
```
