### PR TITLE
Leaf 84: control-seq parser modularization (behavior-preserving)

### DIFF
--- a/crates/carreltex-engine/src/tex/tokenize_v0/control_seq.rs
+++ b/crates/carreltex-engine/src/tex/tokenize_v0/control_seq.rs
@@ -1,6 +1,11 @@
 use super::caret::decode_caret_hex_v0;
-use super::whitespace::{consume_whitespace_run_v0, is_whitespace_v0};
 use super::{TokenV0, TokenizeErrorV0};
+#[path = "control_seq_symbol.rs"]
+mod control_seq_symbol;
+#[path = "control_seq_word.rs"]
+mod control_seq_word;
+use control_seq_symbol::parse_control_symbol_v0;
+use control_seq_word::parse_control_word_v0;
 
 pub(super) struct ParsedControlSeqV0 {
     pub(super) token: TokenV0,
@@ -23,51 +28,6 @@ pub(super) fn parse_control_seq_v0(
     if next.is_ascii_alphabetic() {
         parse_control_word_v0(input, next, after_next_index)
     } else {
-        if !next.is_ascii() {
-            return Err(TokenizeErrorV0::ControlSeqNonAscii);
-        }
-        Ok(ParsedControlSeqV0 {
-            token: TokenV0::ControlSeq(vec![next]),
-            next_index: after_next_index,
-        })
+        parse_control_symbol_v0(next, after_next_index)
     }
-}
-
-fn parse_control_word_v0(
-    input: &[u8],
-    first_byte: u8,
-    mut index: usize,
-) -> Result<ParsedControlSeqV0, TokenizeErrorV0> {
-    let mut control_word = Vec::<u8>::new();
-    control_word.push(first_byte);
-    while index < input.len() {
-        let (word_byte, following_index) = decode_caret_hex_v0(input, index)?;
-        if word_byte == 0 {
-            return Err(TokenizeErrorV0::InvalidInput);
-        }
-        if !word_byte.is_ascii_alphabetic() {
-            break;
-        }
-        control_word.push(word_byte);
-        index = following_index;
-    }
-    if control_word.as_slice() == b"verb" {
-        return Err(TokenizeErrorV0::InvalidInput);
-    }
-    if !control_word.iter().all(|byte| byte.is_ascii()) {
-        return Err(TokenizeErrorV0::ControlSeqNonAscii);
-    }
-    if index < input.len() {
-        let (space_probe, _) = decode_caret_hex_v0(input, index)?;
-        if !is_whitespace_v0(space_probe) && !space_probe.is_ascii() {
-            return Err(TokenizeErrorV0::ControlSeqNonAscii);
-        }
-        if is_whitespace_v0(space_probe) {
-            index = consume_whitespace_run_v0(input, index)?;
-        }
-    }
-    Ok(ParsedControlSeqV0 {
-        token: TokenV0::ControlSeq(control_word),
-        next_index: index,
-    })
 }

--- a/crates/carreltex-engine/src/tex/tokenize_v0/control_seq_symbol.rs
+++ b/crates/carreltex-engine/src/tex/tokenize_v0/control_seq_symbol.rs
@@ -1,0 +1,14 @@
+use super::{ParsedControlSeqV0, TokenV0, TokenizeErrorV0};
+
+pub(super) fn parse_control_symbol_v0(
+    byte: u8,
+    next_index: usize,
+) -> Result<ParsedControlSeqV0, TokenizeErrorV0> {
+    if !byte.is_ascii() {
+        return Err(TokenizeErrorV0::ControlSeqNonAscii);
+    }
+    Ok(ParsedControlSeqV0 {
+        token: TokenV0::ControlSeq(vec![byte]),
+        next_index,
+    })
+}


### PR DESCRIPTION
## Summary
- Leaf 84 structure-only follow-up for control-seq parsing modularization.
- Split control-seq parsing internals into dedicated modules:
  - `control_seq_word.rs` (control-word scanning + `\\verb` block + whitespace swallow)
  - `control_seq_symbol.rs` (control-symbol path)
- Kept `control_seq.rs` as a thin dispatcher.
- No behavior changes; tokenizer semantics and API unchanged.

## Files
- `crates/carreltex-engine/src/tex/tokenize_v0/control_seq.rs`
- `crates/carreltex-engine/src/tex/tokenize_v0/control_seq_word.rs`
- `crates/carreltex-engine/src/tex/tokenize_v0/control_seq_symbol.rs`

## Proof
```text
PASS: loc_guard crates/carreltex-core/src/compile.rs lines=     710 limit=1000
PASS: loc_guard crates/carreltex-core/src/lib.rs lines=      16 limit=1000
PASS: loc_guard crates/carreltex-core/src/mount.rs lines=     307 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0.rs lines=     997 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/count_v0_tests.rs lines=      76 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/edef_v0_tests.rs lines=      68 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/ifnum_v0.rs lines=     113 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/ifnum_v0_tests.rs lines=     176 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/ifx_v0.rs lines=     105 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/ifx_v0_tests.rs lines=     127 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/input_expand_v0.rs lines=     161 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_expand_v0.rs lines=     285 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_v0/bindings.rs lines=     199 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_v0/count_the.rs lines=      65 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_v0/csname_expandafter.rs lines=      46 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_v0/def_xdef.rs lines=     157 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_v0/global_prefix.rs lines=      40 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_v0/let_futurelet.rs lines=      92 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_v0/noexpand.rs lines=      15 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_v0/string_meaning.rs lines=      61 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/macro_v0/utils.rs lines=     110 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/meaning_v0_tests.rs lines=     113 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/stats_v0.rs lines=      54 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/tokenize_reason_v0.rs lines=      10 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/trace_v0.rs lines=     104 limit=1000
PASS: loc_guard crates/carreltex-engine/src/compile_v0/xdef_noexpand_v0_tests.rs lines=      76 limit=1000
PASS: loc_guard crates/carreltex-engine/src/lib.rs lines=       6 limit=1000
PASS: loc_guard crates/carreltex-engine/src/reasons_v0.rs lines=     112 limit=1000
PASS: loc_guard crates/carreltex-engine/src/tex/mod.rs lines=       3 limit=1000
PASS: loc_guard crates/carreltex-engine/src/tex/tokenize_v0.rs lines=      51 limit=1000
PASS: loc_guard crates/carreltex-engine/src/tex/tokenize_v0/caret.rs lines=      26 limit=1000
PASS: loc_guard crates/carreltex-engine/src/tex/tokenize_v0/comment.rs lines=       7 limit=1000
PASS: loc_guard crates/carreltex-engine/src/tex/tokenize_v0/control_seq.rs lines=      33 limit=1000
PASS: loc_guard crates/carreltex-engine/src/tex/tokenize_v0/core.rs lines=      57 limit=1000
PASS: loc_guard crates/carreltex-engine/src/tex/tokenize_v0/tests.rs lines=     148 limit=1000
PASS: loc_guard crates/carreltex-engine/src/tex/tokenize_v0/whitespace.rs lines=      20 limit=1000
PASS: loc_guard crates/carreltex-wasm-smoke/src/lib.rs lines=     716 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/assert.mjs lines=     347 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/cases_v0.mjs lines=     420 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/cases_v0_count.mjs lines=      97 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/cases_v0_edef.mjs lines=      97 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/cases_v0_ifnum.mjs lines=      97 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/cases_v0_ifx.mjs lines=     143 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/cases_v0_macro.mjs lines=     611 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/cases_v0_meaning.mjs lines=      88 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/cases_v0_tokenizer.mjs lines=     160 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/cases_v0_xdef_noexpand.mjs lines=      97 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/ctx.mjs lines=      93 limit=1000
PASS: loc_guard scripts/wasm_smoke_js/mem.mjs lines=      24 limit=1000
PASS: loc_guard scripts/wasm_smoke_js_proof.mjs lines=      14 limit=1000
PASS: loc_guard

running 42 tests
test compile::tests::event_kind_tex_stats_json_constant_is_two ... ok
test compile::tests::default_compile_main_log_bytes_constant_is_1024 ... ok
test compile::tests::append_event_encodes_header_little_endian ... ok
test compile::tests::compile_result_builder_uses_canonical_key_order ... ok
test compile::tests::compile_request_struct_accepts_v0_fields ... ok
test compile::tests::build_tex_stats_json_builder_emits_exact_canonical_output ... ok
test compile::tests::append_event_rejects_when_exceeds_max_events_bytes ... ok
test compile::tests::compile_result_builder_keeps_artifact_bytes_exact ... ok
test compile::tests::compile_result_builder_escapes_json_string_content ... ok
test compile::tests::artifact_bytes_within_cap_honors_limit ... ok
test compile::tests::max_events_bytes_allows_log_and_stats_events ... ok
test compile::tests::max_log_bytes_constant_is_non_zero ... ok
test compile::tests::max_tex_stats_json_bytes_constant_is_4096 ... ok
test compile::tests::report_json_has_status_token_checks_exact_status ... ok
test compile::tests::report_json_missing_components_empty_detection ... ok
test compile::tests::report_json_stays_stable_with_different_log_bytes ... ok
test compile::tests::truncate_log_bytes_enforces_max ... ok
test compile::tests::validate_compile_report_json_accepts_single_known_status ... ok
test compile::tests::validate_compile_report_json_rejects_missing_keys_or_unknown_status ... ok
test compile::tests::validate_compile_report_json_rejects_multiple_status_tokens ... ok
test compile::tests::validate_input_trace_json_accepts_known_good_sample ... ok
test compile::tests::validate_input_trace_json_rejects_bad_escape ... ok
test compile::tests::validate_input_trace_json_rejects_missing_or_extra_key ... ok
test compile::tests::validate_input_trace_json_rejects_non_digit_number ... ok
test compile::tests::validate_input_trace_json_rejects_whitespace ... ok
test compile::tests::validate_input_trace_json_rejects_wrong_key_order ... ok
test compile::tests::validate_tex_stats_json_accepts_builder_output ... ok
test compile::tests::validate_tex_stats_json_rejects_extra_key ... ok
test compile::tests::validate_tex_stats_json_rejects_missing_key ... ok
test compile::tests::validate_tex_stats_json_rejects_negative_or_non_digit_or_empty ... ok
test compile::tests::validate_tex_stats_json_rejects_whitespace ... ok
test mount::tests::duplicate_path_rejected ... ok
test mount::tests::finalize_rejects_invalid_main_tex ... ok
test mount::tests::finalize_requires_main_tex ... ok
test mount::tests::caps_enforced_for_max_files ... ok
test mount::tests::finalize_sets_finalized_and_blocks_additional_files ... ok
test mount::tests::caps_enforced_for_file_size_and_path_len ... ok
test mount::tests::has_file_and_finalize_success ... ok
test mount::tests::normalize_path_v0_accepts_and_rejects_expected_inputs ... ok
test mount::tests::path_policy_rejects_invalid_paths ... ok
test mount::tests::read_file_by_bytes_v0_handles_existing_missing_and_invalid ... ok
test mount::tests::validate_main_tex_checks_nul_and_non_whitespace_bytes ... ok

test result: ok. 42 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 103 tests
test compile_v0::count_v0_tests::count_assignment_rejects_negative_values ... ok
test compile_v0::edef_v0_tests::edef_expands_body_once_at_definition_time ... ok
test compile_v0::count_v0_tests::count0_assignment_then_the_emits_decimal_chars ... ok
test compile_v0::count_v0_tests::the_rejects_unsupported_form ... ok
test compile_v0::count_v0_tests::the_count1_without_assignment_defaults_to_zero ... ok
test compile_v0::edef_v0_tests::edef_rejects_parameterized_definition ... ok
test compile_v0::ifnum_v0_tests::caret_hex_uppercase_decode_in_document_body_is_counted_in_stats ... ok
test compile_v0::edef_v0_tests::edef_is_snapshot_not_dynamic_after_redefinition ... ok
test compile_v0::ifnum_v0_tests::ifnum_else_is_invalid ... ok
test compile_v0::ifnum_v0_tests::ifnum_else_without_if_is_invalid ... ok
test compile_v0::ifnum_v0_tests::crlf_in_body_is_normalized_as_single_whitespace_run ... ok
test compile_v0::ifnum_v0_tests::ifnum_depth_cap_is_invalid ... ok
test compile_v0::ifnum_v0_tests::ifnum_missing_fi_is_invalid ... ok
test compile_v0::ifnum_v0_tests::ifnum_true_branch_keeps_tokens ... ok
test compile_v0::ifnum_v0_tests::lone_cr_in_body_is_normalized_as_single_whitespace_run ... ok
test compile_v0::ifnum_v0_tests::non_ascii_control_sequence_byte_maps_to_specific_reason_token ... ok
test compile_v0::ifnum_v0_tests::ifnum_false_branch_drops_tokens ... ok
test compile_v0::ifnum_v0_tests::unsupported_caret_form_maps_to_tokenizer_caret_reason ... ok
test compile_v0::ifnum_v0_tests::unsupported_caret_inside_comment_does_not_fail_and_body_counts_chars ... ok
test compile_v0::ifx_v0_tests::ifx_alias_equals_alias_keeps_then_branch ... ok
test compile_v0::ifx_v0_tests::ifx_duplicate_else_is_invalid ... ok
test compile_v0::ifx_v0_tests::ifx_else_without_if_is_invalid ... ok
test compile_v0::ifx_v0_tests::ifx_let_snapshot_not_equal_after_redefine_keeps_else_branch ... ok
test compile_v0::ifx_v0_tests::ifx_macro_equals_macro_keeps_then_branch ... ok
test compile_v0::ifx_v0_tests::ifx_undefined_equals_undefined_keeps_then_branch ... ok
test compile_v0::ifx_v0_tests::ifx_let_to_undefined_is_equal_to_undefined_control_sequence ... ok
test compile_v0::meaning_v0_tests::let_uses_snapshot_semantics_not_dynamic_alias ... ok
test compile_v0::ifx_v0_tests::ifx_macro_not_equal_macro_keeps_else_branch ... ok
test compile_v0::meaning_v0_tests::meaning_alias_binding_emits_alias_descriptor ... ok
test compile_v0::meaning_v0_tests::meaning_undefined_binding_emits_undefined_descriptor ... ok
test compile_v0::meaning_v0_tests::meaning_with_unsupported_tokens_is_invalid ... ok
test compile_v0::meaning_v0_tests::meaning_macro_binding_emits_macro_descriptor ... ok
test compile_v0::tests::compile_main_uses_default_log_cap_and_not_implemented ... ok
test compile_v0::tests::compile_request_log_is_truncated_by_max_log_bytes ... ok
test compile_v0::tests::compile_request_missing_main_tex_reports_entrypoint_missing_reason ... ok
test compile_v0::tests::compile_request_missing_entrypoint_reports_request_invalid_reason ... ok
test compile_v0::tests::compile_request_invalid_main_content_reports_mount_finalize_failed_reason ... ok
test compile_v0::tests::compile_request_precedence_request_invalid_over_mount_finalize_failed ... ok
test compile_v0::tests::compile_request_rejects_invalid_entrypoint ... ok
test compile_v0::tests::compile_request_rejects_log_cap_above_limit ... ok
test compile_v0::tests::compile_request_rejects_trailing_backslash_in_main_tex ... ok
test compile_v0::tests::compile_request_rejects_unbalanced_groups ... ok
test compile_v0::tests::compile_request_rejects_zero_epoch_or_log_cap ... ok
test compile_v0::tests::compile_request_returns_not_implemented_when_valid ... ok
test compile_v0::tests::compile_request_still_not_implemented_when_tokenization_succeeds ... ok
test compile_v0::tests::compile_request_stats_json_contains_expected_fields ... ok
test compile_v0::tests::compile_requires_valid_mount ... ok
test compile_v0::tests::compile_request_trace_is_emitted_when_log_budget_allows ... ok
test compile_v0::tests::csname_generates_control_sequence_for_macro_lookup ... ok
test compile_v0::tests::expandafter_with_unsupported_tokens_is_invalid ... ok
test compile_v0::tests::csname_with_invalid_inner_tokens_is_invalid ... ok
test compile_v0::tests::futurelet_alias_expands_control_sequence ... ok
test compile_v0::tests::expandafter_reorders_two_control_sequences ... ok
test compile_v0::tests::futurelet_with_non_control_sequence_is_invalid ... ok
test compile_v0::tests::global_futurelet_inside_group_leaks_globally ... ok
test compile_v0::tests::global_def_single_param_inside_group_leaks_globally ... ok
test compile_v0::tests::global_prefix_without_def_is_invalid ... ok
test compile_v0::tests::global_def_inside_group_leaks_globally ... ok
test compile_v0::tests::global_let_inside_group_leaks_globally ... ok
test compile_v0::tests::global_gdef_inside_group_leaks_globally ... ok
test compile_v0::tests::gdef_inside_group_leaks_globally ... ok
test compile_v0::tests::input_cycle_is_invalid ... ok
test compile_v0::tests::input_missing_file_is_invalid ... ok
test compile_v0::tests::input_expands_tokens_from_subfile ... ok
test compile_v0::tests::input_depth_cap_is_invalid ... ok
test compile_v0::tests::let_to_non_control_sequence_is_invalid ... ok
test compile_v0::tests::input_valid_when_file_exists ... ok
test compile_v0::tests::input_invalid_syntax_is_invalid ... ok
test compile_v0::tests::macro_cycle_is_invalid ... ok
test compile_v0::tests::let_alias_expands_control_sequence ... ok
test compile_v0::tests::macro_defs_can_override_inside_group_without_leaking ... ok
test compile_v0::tests::macro_defs_inside_group_do_not_leak_outside ... ok
test compile_v0::tests::macro_expansion_positive_increases_char_count ... ok
test compile_v0::tests::macro_single_param_missing_arg_is_invalid ... ok
test compile_v0::tests::macro_params_unsupported_is_invalid ... ok
test compile_v0::tests::macro_single_param_positive_increases_char_count ... ok
test compile_v0::tests::stacked_global_prefix_without_def_is_invalid ... ok
test compile_v0::tests::stacked_global_def_inside_group_leaks_globally ... ok
test compile_v0::tests::string_with_unsupported_tokens_is_invalid ... ok
test compile_v0::tests::string_control_sequence_produces_literal_chars ... ok
test compile_v0::xdef_noexpand_v0_tests::noexpand_makes_edef_dynamic ... ok
test compile_v0::xdef_noexpand_v0_tests::noexpand_without_next_token_invalid ... ok
test compile_v0::xdef_noexpand_v0_tests::xdef_params_unsupported ... ok
test compile_v0::xdef_noexpand_v0_tests::xdef_leaks_globally ... ok
test tex::tokenize_v0::tests::caret_hex_sequence_decodes_to_single_byte ... ok
test tex::tokenize_v0::tests::caret_hex_uppercase_is_allowed ... ok
test tex::tokenize_v0::tests::caret_hex_ff_is_allowed ... ok
test tex::tokenize_v0::tests::caret_hex_zero_decodes_to_nul_and_is_invalid ... ok
test tex::tokenize_v0::tests::caret_sequence_inside_comment_is_ignored_as_raw_text ... ok
test tex::tokenize_v0::tests::crlf_collapses_to_single_space_token ... ok
test tex::tokenize_v0::tests::control_sequence_bytes_must_be_ascii ... ok
test tex::tokenize_v0::tests::lone_cr_collapses_to_single_space_token ... ok
test tex::tokenize_v0::tests::percent_comment_is_skipped_until_newline ... ok
test tex::tokenize_v0::tests::nul_byte_is_invalid_input ... ok
test tex::tokenize_v0::tests::percent_comment_terminated_by_cr_does_not_emit_double_space ... ok
test tex::tokenize_v0::tests::tokenizes_minimal_document_and_contains_expected_control_words ... ok
test tex::tokenize_v0::tests::space_after_control_word_is_ignored ... ok
test compile_v0::tests::input_expansions_cap_is_invalid ... ok
test tex::tokenize_v0::tests::unsupported_caret_form_is_caret_not_supported ... ok
test tex::tokenize_v0::tests::verb_control_word_is_invalid_input ... ok
test tex::tokenize_v0::tests::whitespace_is_coalesced_to_single_space_token ... ok
test compile_v0::tests::macro_expansions_cap_is_invalid ... ok
test tex::tokenize_v0::tests::too_many_tokens_is_fail_closed ... ok

test result: ok. 103 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

PASS: JS loaded WASM and exercised ABI (alloc/validate/mount/compile/report)
PASS: ledger status validation passed (7 rows)
PASS: carreltex v0 proof bundle
```
