### PR TITLE
Leaf 148: tokenizer text* greek placeholder batch

### DIFF
--- a/crates/carreltex-engine/src/compile_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0.rs
@@ -19,7 +19,7 @@ mod trace_v0;
 #[cfg(test)] mod tokenizer_textword_142_tests;
 #[cfg(test)] mod tokenizer_textword_143_tests;
 #[cfg(test)] mod tokenizer_textword_144_tests;
-#[cfg(test)] mod tokenizer_textword_145_tests; #[cfg(test)] mod tokenizer_textword_147_tests;
+#[cfg(test)] mod tokenizer_textword_145_tests; #[cfg(test)] mod tokenizer_textword_147_tests; #[cfg(test)] mod tokenizer_textword_148_tests;
 use crate::reasons_v0::{invalid_log_bytes_v0, InvalidInputReasonV0};
 use crate::tex::tokenize_v0::{tokenize_v0, TokenV0, MAX_TOKENS_V0};
 use carreltex_core::{

--- a/crates/carreltex-engine/src/compile_v0/tokenizer_textword_148_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/tokenizer_textword_148_tests.rs
@@ -1,0 +1,69 @@
+use super::compile_request_v0;
+use carreltex_core::{CompileRequestV0, CompileStatus, Mount};
+
+fn valid_request() -> CompileRequestV0 {
+    CompileRequestV0 {
+        entrypoint: "main.tex".to_owned(),
+        source_date_epoch: 1,
+        max_log_bytes: 4096,
+    }
+}
+
+fn stats_u64_field(stats_json: &str, field: &str) -> Option<u64> {
+    let marker = format!("\"{field}\":");
+    let start = stats_json.find(&marker)? + marker.len();
+    let rest = &stats_json[start..];
+    let digits_len = rest
+        .bytes()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    if digits_len == 0 {
+        return None;
+    }
+    rest[..digits_len].parse().ok()
+}
+
+fn hello_baseline_char_count() -> u64 {
+    let mut mount = Mount::default();
+    let main = b"\\documentclass{article}\n\\begin{document}\nHello.\n\\end{document}\n";
+    assert!(mount.add_file(b"main.tex", main).is_ok());
+    let result = compile_request_v0(&mut mount, &valid_request());
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    stats_u64_field(&result.tex_stats_json, "char_count").expect("char_count")
+}
+
+fn assert_control_word_delta(control_word: &str, expected_delta: u64) {
+    let baseline = hello_baseline_char_count();
+    let mut mount = Mount::default();
+    let main = format!(
+        "\\documentclass{{article}}\n\\begin{{document}}\nHello.\\{control_word} XYZ\n\\end{{document}}\n"
+    );
+    assert!(mount.add_file(b"main.tex", main.as_bytes()).is_ok());
+    let result = compile_request_v0(&mut mount, &valid_request());
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    let char_count = stats_u64_field(&result.tex_stats_json, "char_count").expect("char_count");
+    assert_eq!(char_count, baseline + expected_delta);
+}
+
+#[test]
+fn control_words_leaf_148_are_counted_with_expected_deltas() {
+    for control_word in [
+        "textalpha",
+        "textbeta",
+        "textgamma",
+        "textdelta",
+        "textepsilon",
+        "texttheta",
+        "textlambda",
+        "textpi",
+        "textrho",
+        "textsigma",
+        "texttau",
+        "textphi",
+        "textchi",
+        "textpsi",
+        "textomega",
+    ] {
+        assert_control_word_delta(control_word, 4);
+    }
+}

--- a/crates/carreltex-engine/src/tex/tokenize_v0.rs
+++ b/crates/carreltex-engine/src/tex/tokenize_v0.rs
@@ -32,6 +32,8 @@ mod tests_textword_144;
 mod tests_textword_145;
 #[cfg(test)]
 mod tests_textword_147;
+#[cfg(test)]
+mod tests_textword_148;
 
 /// Tokenize TeX input bytes with strict v0 assumptions.
 ///

--- a/crates/carreltex-engine/src/tex/tokenize_v0/control_seq_word.rs
+++ b/crates/carreltex-engine/src/tex/tokenize_v0/control_seq_word.rs
@@ -286,6 +286,36 @@ pub(super) fn parse_control_word_v0(
         vec![TokenV0::Char(b'c'), TokenV0::Char(b'c')]
     } else if control_word.as_slice() == b"textinterrobang" {
         vec![TokenV0::Char(b'!'), TokenV0::Char(b'?')]
+    } else if control_word.as_slice() == b"textalpha" {
+        vec![TokenV0::Char(b'a')]
+    } else if control_word.as_slice() == b"textbeta" {
+        vec![TokenV0::Char(b'b')]
+    } else if control_word.as_slice() == b"textgamma" {
+        vec![TokenV0::Char(b'g')]
+    } else if control_word.as_slice() == b"textdelta" {
+        vec![TokenV0::Char(b'd')]
+    } else if control_word.as_slice() == b"textepsilon" {
+        vec![TokenV0::Char(b'e')]
+    } else if control_word.as_slice() == b"texttheta" {
+        vec![TokenV0::Char(b't')]
+    } else if control_word.as_slice() == b"textlambda" {
+        vec![TokenV0::Char(b'l')]
+    } else if control_word.as_slice() == b"textpi" {
+        vec![TokenV0::Char(b'p')]
+    } else if control_word.as_slice() == b"textrho" {
+        vec![TokenV0::Char(b'r')]
+    } else if control_word.as_slice() == b"textsigma" {
+        vec![TokenV0::Char(b's')]
+    } else if control_word.as_slice() == b"texttau" {
+        vec![TokenV0::Char(b'u')]
+    } else if control_word.as_slice() == b"textphi" {
+        vec![TokenV0::Char(b'f')]
+    } else if control_word.as_slice() == b"textchi" {
+        vec![TokenV0::Char(b'c')]
+    } else if control_word.as_slice() == b"textpsi" {
+        vec![TokenV0::Char(b'y')]
+    } else if control_word.as_slice() == b"textomega" {
+        vec![TokenV0::Char(b'w')]
     } else if control_word.as_slice() == b"textoneeighth" {
         vec![TokenV0::Char(b'1'), TokenV0::Char(b'/'), TokenV0::Char(b'8')]
     } else if control_word.as_slice() == b"textthreeeighths" {

--- a/crates/carreltex-engine/src/tex/tokenize_v0/tests_textword_148.rs
+++ b/crates/carreltex-engine/src/tex/tokenize_v0/tests_textword_148.rs
@@ -1,0 +1,70 @@
+use super::{tokenize_v0, TokenV0};
+
+#[test]
+fn control_words_leaf_148_map_to_expected_tokens_and_swallow_space() {
+    for (input, expected) in [
+        (
+            b"\\textalpha X".as_slice(),
+            vec![TokenV0::Char(b'a'), TokenV0::Char(b'X')],
+        ),
+        (
+            b"\\textbeta X".as_slice(),
+            vec![TokenV0::Char(b'b'), TokenV0::Char(b'X')],
+        ),
+        (
+            b"\\textgamma X".as_slice(),
+            vec![TokenV0::Char(b'g'), TokenV0::Char(b'X')],
+        ),
+        (
+            b"\\textdelta X".as_slice(),
+            vec![TokenV0::Char(b'd'), TokenV0::Char(b'X')],
+        ),
+        (
+            b"\\textepsilon X".as_slice(),
+            vec![TokenV0::Char(b'e'), TokenV0::Char(b'X')],
+        ),
+        (
+            b"\\texttheta X".as_slice(),
+            vec![TokenV0::Char(b't'), TokenV0::Char(b'X')],
+        ),
+        (
+            b"\\textlambda X".as_slice(),
+            vec![TokenV0::Char(b'l'), TokenV0::Char(b'X')],
+        ),
+        (
+            b"\\textpi X".as_slice(),
+            vec![TokenV0::Char(b'p'), TokenV0::Char(b'X')],
+        ),
+        (
+            b"\\textrho X".as_slice(),
+            vec![TokenV0::Char(b'r'), TokenV0::Char(b'X')],
+        ),
+        (
+            b"\\textsigma X".as_slice(),
+            vec![TokenV0::Char(b's'), TokenV0::Char(b'X')],
+        ),
+        (
+            b"\\texttau X".as_slice(),
+            vec![TokenV0::Char(b'u'), TokenV0::Char(b'X')],
+        ),
+        (
+            b"\\textphi X".as_slice(),
+            vec![TokenV0::Char(b'f'), TokenV0::Char(b'X')],
+        ),
+        (
+            b"\\textchi X".as_slice(),
+            vec![TokenV0::Char(b'c'), TokenV0::Char(b'X')],
+        ),
+        (
+            b"\\textpsi X".as_slice(),
+            vec![TokenV0::Char(b'y'), TokenV0::Char(b'X')],
+        ),
+        (
+            b"\\textomega X".as_slice(),
+            vec![TokenV0::Char(b'w'), TokenV0::Char(b'X')],
+        ),
+    ] {
+        let tokens = tokenize_v0(input).expect("tokenize should succeed");
+        assert_eq!(tokens, expected);
+    }
+}

--- a/docs/LEDGER.md
+++ b/docs/LEDGER.md
@@ -16,6 +16,7 @@ Regression guards (proof scenarios):
 - `\input{sub.tex}\expandafter\bar\foo`
 - `\input{sub.tex}\ifnum\count0<\count1 XYZ\else AAA\fi`
 - `\input{sub.tex}\let\bar=\foo\ifx\bar\foo SAME\else DIFF\fi`
+- Leaf 148 tokenizer textword mappings: `\textalpha->a`, `\textbeta->b`, `\textgamma->g`, `\textdelta->d`, `\textepsilon->e`, `\texttheta->t`, `\textlambda->l`, `\textpi->p`, `\textrho->r`, `\textsigma->s`, `\texttau->u`, `\textphi->f`, `\textchi->c`, `\textpsi->y`, `\textomega->w`
 
 These lock engine order and `\edef`/`\xdef`/`\let` snapshot semantics, plus `\futurelet`/`\csname`/`\string`/`\expandafter` visibility and `\ifnum`/`\ifx` state behavior across input boundaries.
 

--- a/scripts/wasm_smoke_js/cases_v0.mjs
+++ b/scripts/wasm_smoke_js/cases_v0.mjs
@@ -19,6 +19,7 @@ import { runTokenizerTextwordLeaf143Cases } from './cases_v0_tokenizer_textword_
 import { runTokenizerTextwordLeaf144Cases } from './cases_v0_tokenizer_textword_144.mjs';
 import { runTokenizerTextwordLeaf145Cases } from './cases_v0_tokenizer_textword_145.mjs';
 import { runTokenizerTextwordLeaf147Cases } from './cases_v0_tokenizer_textword_147.mjs';
+import { runTokenizerTextwordLeaf148Cases } from './cases_v0_tokenizer_textword_148.mjs';
 import { runMacroCases } from './cases_v0_macro.mjs';
 
 export function runCasesV0(ctx, mem, helpers) {
@@ -428,6 +429,7 @@ export function runCasesV0(ctx, mem, helpers) {
   runTokenizerTextwordLeaf144Cases(ctx, { addMountedFile, expectNotImplemented, readCompileLogBytes, assertEventsMatchLogAndStats, assertMainXdvArtifactEmpty });
   runTokenizerTextwordLeaf145Cases(ctx, { addMountedFile, expectNotImplemented, readCompileLogBytes, assertEventsMatchLogAndStats, assertMainXdvArtifactEmpty });
   runTokenizerTextwordLeaf147Cases(ctx, { addMountedFile, expectNotImplemented, readCompileLogBytes, assertEventsMatchLogAndStats, assertMainXdvArtifactEmpty });
+  runTokenizerTextwordLeaf148Cases(ctx, { addMountedFile, expectNotImplemented, readCompileLogBytes, assertEventsMatchLogAndStats, assertMainXdvArtifactEmpty });
 
   if (ctx.mountReset() !== 0) {
     throw new Error('mount_reset before compile_request negative setter tests failed');

--- a/scripts/wasm_smoke_js/cases_v0_tokenizer_textword_148.mjs
+++ b/scripts/wasm_smoke_js/cases_v0_tokenizer_textword_148.mjs
@@ -1,0 +1,56 @@
+export function runTokenizerTextwordLeaf148Cases(ctx, helpers) {
+  const {
+    addMountedFile,
+    expectNotImplemented,
+    readCompileLogBytes,
+    assertEventsMatchLogAndStats,
+    assertMainXdvArtifactEmpty,
+  } = helpers;
+
+  const compileAndAssertDelta = (label, controlWord, expectedDelta) => {
+    if (ctx.mountReset() !== 0) {
+      throw new Error(`mount_reset before ${label} baseline case failed`);
+    }
+    const baselineMain = new TextEncoder().encode('\\documentclass{article}\n\\begin{document}\nHello.\n\\end{document}\n');
+    if (addMountedFile('main.tex', baselineMain, `${label}_baseline_main`) !== 0) {
+      throw new Error(`mount_add_file(${label} baseline main.tex) failed`);
+    }
+    if (ctx.mountFinalize() !== 0) {
+      throw new Error(`mount_finalize for ${label} baseline case failed`);
+    }
+    expectNotImplemented(ctx.compileMain(), `compile_main_v0(${label} baseline)`);
+    const baselineStats = assertEventsMatchLogAndStats(readCompileLogBytes(), {}, `compile_main(${label} baseline)`);
+    if (ctx.mountReset() !== 0) {
+      throw new Error(`mount_reset before ${label} case failed`);
+    }
+    const mainBytes = new TextEncoder().encode(`\\documentclass{article}\n\\begin{document}\nHello.\\${controlWord} XYZ\n\\end{document}\n`);
+    if (addMountedFile('main.tex', mainBytes, `${label}_main`) !== 0) {
+      throw new Error(`mount_add_file(${label} main.tex) failed`);
+    }
+    if (ctx.mountFinalize() !== 0) {
+      throw new Error(`mount_finalize for ${label} case failed`);
+    }
+    expectNotImplemented(ctx.compileMain(), `compile_main_v0(${label})`);
+    const stats = assertEventsMatchLogAndStats(readCompileLogBytes(), {}, `compile_main(${label})`);
+    if (stats.char_count !== baselineStats.char_count + expectedDelta) {
+      throw new Error(`compile_main(${label}) char_count delta expected +${expectedDelta}, got baseline=${baselineStats.char_count}, current=${stats.char_count}`);
+    }
+    assertMainXdvArtifactEmpty(`compile_main(${label})`);
+  };
+
+  compileAndAssertDelta('tokenizer control-word-textalpha', 'textalpha', 4);
+  compileAndAssertDelta('tokenizer control-word-textbeta', 'textbeta', 4);
+  compileAndAssertDelta('tokenizer control-word-textgamma', 'textgamma', 4);
+  compileAndAssertDelta('tokenizer control-word-textdelta', 'textdelta', 4);
+  compileAndAssertDelta('tokenizer control-word-textepsilon', 'textepsilon', 4);
+  compileAndAssertDelta('tokenizer control-word-texttheta', 'texttheta', 4);
+  compileAndAssertDelta('tokenizer control-word-textlambda', 'textlambda', 4);
+  compileAndAssertDelta('tokenizer control-word-textpi', 'textpi', 4);
+  compileAndAssertDelta('tokenizer control-word-textrho', 'textrho', 4);
+  compileAndAssertDelta('tokenizer control-word-textsigma', 'textsigma', 4);
+  compileAndAssertDelta('tokenizer control-word-texttau', 'texttau', 4);
+  compileAndAssertDelta('tokenizer control-word-textphi', 'textphi', 4);
+  compileAndAssertDelta('tokenizer control-word-textchi', 'textchi', 4);
+  compileAndAssertDelta('tokenizer control-word-textpsi', 'textpsi', 4);
+  compileAndAssertDelta('tokenizer control-word-textomega', 'textomega', 4);
+}


### PR DESCRIPTION
## Summary
- Add exact-control-word tokenizer mappings for Leaf 148 batch:
  - `\\textalpha->a`, `\\textbeta->b`, `\\textgamma->g`, `\\textdelta->d`, `\\textepsilon->e`
  - `\\texttheta->t`, `\\textlambda->l`, `\\textpi->p`, `\\textrho->r`, `\\textsigma->s`
  - `\\texttau->u`, `\\textphi->f`, `\\textchi->c`, `\\textpsi->y`, `\\textomega->w`
- Add tokenizer unit module `tests_textword_148.rs` and wire it in `tokenize_v0.rs`.
- Add focused engine guard module `tokenizer_textword_148_tests.rs` and wire it in `compile_v0.rs`.
- Add JS proof module `cases_v0_tokenizer_textword_148.mjs` and wire it in `cases_v0.mjs`.
- Update `docs/LEDGER.md` with Leaf 148 tokenizer mapping note.

## Proof Tail
```text
PASS: JS loaded WASM and exercised ABI (alloc/validate/mount/compile/report)
PASS: ledger status validation passed (7 rows)
PASS: carreltex v0 proof bundle
```
