### PR TITLE
Leaf 241: DeclareMathOperator optional spacing before star

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/ok_v0_preamble_math_operator_decls_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/ok_v0_preamble_math_operator_decls_tests.rs
@@ -54,6 +54,20 @@ fn declare_math_operator_star_preamble_is_ok_and_output_matches_without_it() {
 }
 
 #[test]
+fn declare_math_operator_space_star_preamble_is_ok_and_output_matches_without_it() {
+    let with_decl = compile_main(
+        b"\\documentclass{article}\\DeclareMathOperator *{\\Foo}{Foo}\\begin{document}HelloWorld\\end{document}",
+    );
+    let without_decl =
+        compile_main(b"\\documentclass{article}\\begin{document}HelloWorld\\end{document}");
+    assert_eq!(with_decl.status, CompileStatus::Ok);
+    assert_eq!(without_decl.status, CompileStatus::Ok);
+    assert!(with_decl.log_bytes.is_empty());
+    assert!(validate_dvi_v2_text_page_v0(&with_decl.main_xdv_bytes));
+    assert_eq!(right3_positive_total(&with_decl), right3_positive_total(&without_decl));
+}
+
+#[test]
 fn declare_math_operator_bad_first_arg_shape_is_not_implemented() {
     let result = compile_main(
         b"\\documentclass{article}\\DeclareMathOperator{Foo}{Foo}\\begin{document}HelloWorld\\end{document}",


### PR DESCRIPTION
Summary
- Accept optional spaces between `\DeclareMathOperator` and `*` in strict OK preamble parsing.
- Add focused regression coverage for `\DeclareMathOperator *{\Foo}{Foo}`.
- No behavior changes outside this parsing tolerance.

Proof tail (`./scripts/proof_v0.sh | tail -n 6`)
- PASS: loc_guard
- PASS: core tests
- PASS: engine tests
- PASS: JS loaded WASM and exercised ABI (alloc/validate/mount/compile/report)
- PASS: ledger status validation passed (55 rows)
- PASS: carreltex v0 proof bundle