### PR TITLE
Leaf 248: OK preamble DeclareTextCompositeCommand [1]

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/ok_v0_extract.rs
+++ b/crates/carreltex-engine/src/compile_v0/ok_v0_extract.rs
@@ -479,6 +479,8 @@ fn consume_declare_text_composite_command_preamble_command(
     cursor = skip_spaces(tokens, cursor);
     cursor = consume_char_space_group_non_empty(tokens, cursor)?;
     cursor = skip_spaces(tokens, cursor);
+    cursor = consume_optional_robust_command_one_arity_v0(tokens, cursor)?;
+    cursor = skip_spaces(tokens, cursor);
     cursor = consume_char_space_nested_group_non_empty_v0(tokens, cursor, tokens.len())?;
     Some(skip_spaces(tokens, cursor))
 }

--- a/crates/carreltex-engine/src/compile_v0/ok_v0_preamble_text_composite_command_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/ok_v0_preamble_text_composite_command_tests.rs
@@ -56,3 +56,26 @@ fn declare_text_composite_command_bad_first_arg_shape_is_not_implemented() {
     assert_eq!(result.status, CompileStatus::NotImplemented);
     assert!(result.main_xdv_bytes.is_empty());
 }
+
+#[test]
+fn declare_text_composite_command_optional_one_arity_is_ok_and_output_matches_without_it() {
+    let with_decl = compile_main(
+        b"\\documentclass{article}\\DeclareTextCompositeCommand{\\Foo}{T1}{32}[1]{ABC}\\begin{document}HelloWorld\\end{document}",
+    );
+    let without_decl =
+        compile_main(b"\\documentclass{article}\\begin{document}HelloWorld\\end{document}");
+    assert_eq!(with_decl.status, CompileStatus::Ok);
+    assert_eq!(without_decl.status, CompileStatus::Ok);
+    assert!(with_decl.log_bytes.is_empty());
+    assert!(validate_dvi_v2_text_page_v0(&with_decl.main_xdv_bytes));
+    assert_eq!(right3_positive_total(&with_decl), right3_positive_total(&without_decl));
+}
+
+#[test]
+fn declare_text_composite_command_optional_two_arity_is_not_implemented() {
+    let result = compile_main(
+        b"\\documentclass{article}\\DeclareTextCompositeCommand{\\Foo}{T1}{32}[2]{ABC}\\begin{document}HelloWorld\\end{document}",
+    );
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}


### PR DESCRIPTION
Summary
- Strict OK preamble scan: `\DeclareTextCompositeCommand` now accepts optional `[1]` arity marker (only `[1]`; other values remain NOT_IMPLEMENTED).

Proof
- `./scripts/proof_v0.sh` (see PR comment for frozen head + tail)
