### PR TITLE
Leaf 255: OK preamble text decl bundle refactor

### DIFF
--- a/crates/carreltex-engine/src/compile_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0.rs
@@ -80,6 +80,8 @@ mod ok_v0_preamble_declare_text_accent_default_tests;
 #[cfg(test)]
 mod ok_v0_preamble_declare_text_symbol_default_tests;
 #[cfg(test)]
+mod ok_v0_preamble_text_decl_bundle_tests;
+#[cfg(test)]
 mod ok_v0_preamble_text_symbol_accent_decls_tests;
 #[cfg(test)]
 mod ok_v0_preamble_text_composite_command_tests;

--- a/crates/carreltex-engine/src/compile_v0/ok_v0_extract.rs
+++ b/crates/carreltex-engine/src/compile_v0/ok_v0_extract.rs
@@ -473,8 +473,6 @@ fn consume_text_command_default_preamble_command(
                 name.as_slice(),
                 b"ProvideTextCommandDefault"
                     | b"DeclareTextCommandDefault"
-                    | b"DeclareTextAccentDefault"
-                    | b"DeclareTextSymbolDefault"
             )
     ) {
         return None;
@@ -486,21 +484,30 @@ fn consume_text_command_default_preamble_command(
     Some(skip_spaces(tokens, cursor))
 }
 
-fn consume_text_symbol_accent_decl_preamble_command(tokens: &[TokenV0], index: usize) -> Option<usize> {
+fn consume_text_decl_bundle_preamble_command(tokens: &[TokenV0], index: usize) -> Option<usize> {
     let name = match tokens.get(index) {
         Some(TokenV0::ControlSeq(name)) => name.as_slice(),
         _ => return None,
     };
-    if !matches!(name, b"DeclareTextSymbol" | b"DeclareTextAccent") {
-        return None;
+    match name {
+        b"DeclareTextSymbol" | b"DeclareTextAccent" => {
+            let mut cursor = skip_spaces(tokens, index + 1);
+            cursor = consume_single_controlseq_group_v0(tokens, cursor)?;
+            cursor = skip_spaces(tokens, cursor);
+            cursor = consume_char_space_group_non_empty(tokens, cursor)?;
+            cursor = skip_spaces(tokens, cursor);
+            cursor = consume_char_space_group_non_empty(tokens, cursor)?;
+            Some(skip_spaces(tokens, cursor))
+        }
+        b"DeclareTextAccentDefault" | b"DeclareTextSymbolDefault" => {
+            let mut cursor = skip_spaces(tokens, index + 1);
+            cursor = consume_single_controlseq_group_v0(tokens, cursor)?;
+            cursor = skip_spaces(tokens, cursor);
+            cursor = consume_char_space_nested_group_non_empty_v0(tokens, cursor, tokens.len())?;
+            Some(skip_spaces(tokens, cursor))
+        }
+        _ => None,
     }
-    let mut cursor = skip_spaces(tokens, index + 1);
-    cursor = consume_single_controlseq_group_v0(tokens, cursor)?;
-    cursor = skip_spaces(tokens, cursor);
-    cursor = consume_char_space_group_non_empty(tokens, cursor)?;
-    cursor = skip_spaces(tokens, cursor);
-    cursor = consume_char_space_group_non_empty(tokens, cursor)?;
-    Some(skip_spaces(tokens, cursor))
 }
 
 fn consume_declare_text_composite_command_preamble_command(
@@ -686,17 +693,21 @@ pub(crate) fn extract_strict_ok_text_body_v0(tokens: &[TokenV0]) -> Option<Vec<u
                     name.as_slice(),
                     b"ProvideTextCommandDefault"
                         | b"DeclareTextCommandDefault"
-                        | b"DeclareTextAccentDefault"
-                        | b"DeclareTextSymbolDefault"
                 ) =>
             {
                 index = consume_text_command_default_preamble_command(tokens, index)?;
                 continue;
             }
             Some(TokenV0::ControlSeq(name))
-                if matches!(name.as_slice(), b"DeclareTextSymbol" | b"DeclareTextAccent") =>
+                if matches!(
+                    name.as_slice(),
+                    b"DeclareTextSymbol"
+                        | b"DeclareTextAccent"
+                        | b"DeclareTextAccentDefault"
+                        | b"DeclareTextSymbolDefault"
+                ) =>
             {
-                index = consume_text_symbol_accent_decl_preamble_command(tokens, index)?;
+                index = consume_text_decl_bundle_preamble_command(tokens, index)?;
                 continue;
             }
             Some(TokenV0::ControlSeq(name))

--- a/crates/carreltex-engine/src/compile_v0/ok_v0_preamble_text_decl_bundle_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/ok_v0_preamble_text_decl_bundle_tests.rs
@@ -1,0 +1,43 @@
+use super::compile_request_v0;
+use carreltex_core::{CompileRequestV0, CompileResultV0, CompileStatus, Mount};
+use carreltex_xdv::{sum_dvi_v2_positive_right3_amounts_with_layout_v0, validate_dvi_v2_text_page_v0};
+
+fn valid_request() -> CompileRequestV0 {
+    CompileRequestV0 {
+        entrypoint: "main.tex".to_owned(),
+        source_date_epoch: 1,
+        max_log_bytes: 4096,
+        ok_max_line_glyphs_v0: None,
+        ok_max_lines_per_page_v0: None,
+        ok_line_advance_sp_v0: None,
+        ok_glyph_advance_sp_v0: None,
+    }
+}
+
+fn compile_main(main: &[u8]) -> CompileResultV0 {
+    let mut mount = Mount::default();
+    assert!(mount.add_file(b"main.tex", main).is_ok());
+    compile_request_v0(&mut mount, &valid_request())
+}
+
+fn right3_positive_total(result: &CompileResultV0) -> u32 {
+    sum_dvi_v2_positive_right3_amounts_with_layout_v0(&result.main_xdv_bytes, 65_536, 786_432)
+        .expect("sum parser should parse")
+}
+
+#[test]
+fn text_decl_bundle_preamble_is_ok_and_output_matches_without_decls() {
+    let with_decls = compile_main(
+        b"\\documentclass{article}\\DeclareTextAccent{\\Foo}{T1}{32}\\DeclareTextSymbol{\\Bar}{T1}{33}\\DeclareTextAccentDefault{\\Baz}{ABC}\\DeclareTextSymbolDefault{\\Qux}{DEF}\\begin{document}HelloWorld\\end{document}",
+    );
+    let without_decls =
+        compile_main(b"\\documentclass{article}\\begin{document}HelloWorld\\end{document}");
+    assert_eq!(with_decls.status, CompileStatus::Ok);
+    assert_eq!(without_decls.status, CompileStatus::Ok);
+    assert!(with_decls.log_bytes.is_empty());
+    assert!(validate_dvi_v2_text_page_v0(&with_decls.main_xdv_bytes));
+    assert_eq!(
+        right3_positive_total(&with_decls),
+        right3_positive_total(&without_decls)
+    );
+}


### PR DESCRIPTION
Summary
- Refactor-only: factor text symbol/accent decl handlers into a helper and add a bundle regression test (no behavior change).

Proof
- `./scripts/proof_v0.sh` (see PR comment for frozen head + tail)
