### PR TITLE
Leaf 257: OK preamble DeclareTextCompositeDefault encoding form

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/ok_v0_extract.rs
+++ b/crates/carreltex-engine/src/compile_v0/ok_v0_extract.rs
@@ -466,21 +466,29 @@ fn consume_text_command_default_preamble_command(
     tokens: &[TokenV0],
     index: usize,
 ) -> Option<usize> {
+    let name = match tokens.get(index) {
+        Some(TokenV0::ControlSeq(name)) => name.as_slice(),
+        _ => return None,
+    };
     if !matches!(
-        tokens.get(index),
-        Some(TokenV0::ControlSeq(name))
-            if matches!(
-                name.as_slice(),
-                b"ProvideTextCommandDefault"
-                    | b"DeclareTextCommandDefault"
-                    | b"DeclareTextCompositeDefault"
-            )
+        name,
+        b"ProvideTextCommandDefault" | b"DeclareTextCommandDefault" | b"DeclareTextCompositeDefault"
     ) {
         return None;
     }
     let mut cursor = skip_spaces(tokens, index + 1);
     cursor = consume_single_controlseq_group_v0(tokens, cursor)?;
     cursor = skip_spaces(tokens, cursor);
+    if name == b"DeclareTextCompositeDefault" {
+        if let Some(enc_end) = consume_char_space_group_non_empty(tokens, cursor) {
+            let after_enc = skip_spaces(tokens, enc_end);
+            if matches!(tokens.get(after_enc), Some(TokenV0::BeginGroup)) {
+                cursor =
+                    consume_char_space_nested_group_non_empty_v0(tokens, after_enc, tokens.len())?;
+                return Some(skip_spaces(tokens, cursor));
+            }
+        }
+    }
     cursor = consume_char_space_nested_group_non_empty_v0(tokens, cursor, tokens.len())?;
     Some(skip_spaces(tokens, cursor))
 }

--- a/crates/carreltex-engine/src/compile_v0/ok_v0_preamble_declare_text_composite_default_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/ok_v0_preamble_declare_text_composite_default_tests.rs
@@ -56,3 +56,17 @@ fn declare_text_composite_default_bad_first_arg_shape_is_not_implemented() {
     assert_eq!(result.status, CompileStatus::NotImplemented);
     assert!(result.main_xdv_bytes.is_empty());
 }
+
+#[test]
+fn declare_text_composite_default_with_encoding_preamble_is_ok_and_output_matches_without_it() {
+    let with_decl = compile_main(
+        b"\\documentclass{article}\\DeclareTextCompositeDefault{\\Foo}{T1}{ABC}\\begin{document}HelloWorld\\end{document}",
+    );
+    let without_decl =
+        compile_main(b"\\documentclass{article}\\begin{document}HelloWorld\\end{document}");
+    assert_eq!(with_decl.status, CompileStatus::Ok);
+    assert_eq!(without_decl.status, CompileStatus::Ok);
+    assert!(with_decl.log_bytes.is_empty());
+    assert!(validate_dvi_v2_text_page_v0(&with_decl.main_xdv_bytes));
+    assert_eq!(right3_positive_total(&with_decl), right3_positive_total(&without_decl));
+}


### PR DESCRIPTION
Summary
- Extend strict OK preamble parsing for \DeclareTextCompositeDefault to accept both existing 2-arg form and new 3-arg encoding form.
- Keep validation fail-closed: arg1 single-control-seq group, encoding group Char/Space-only when present, body bounded and rejects control sequences.
- Extend focused tests to cover the new 3-arg positive case.

Proof tail (./scripts/proof_v0.sh | tail -n 6)
- PASS: loc_guard
- PASS: core tests
- PASS: engine tests
- PASS: JS loaded WASM and exercised ABI (alloc/validate/mount/compile/report)
- PASS: ledger status validation passed (68 rows)
- PASS: carreltex v0 proof bundle