### PR TITLE
Leaf 258: OK preamble textcmd bundle

### DIFF
--- a/crates/carreltex-engine/src/compile_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0.rs
@@ -84,6 +84,8 @@ mod ok_v0_preamble_declare_text_composite_default_tests;
 #[cfg(test)]
 mod ok_v0_preamble_text_decl_bundle_tests;
 #[cfg(test)]
+mod ok_v0_preamble_textcmd_bundle_tests;
+#[cfg(test)]
 mod ok_v0_preamble_text_symbol_accent_decls_tests;
 #[cfg(test)]
 mod ok_v0_preamble_text_composite_command_tests;

--- a/crates/carreltex-engine/src/compile_v0/ok_v0_preamble_textcmd_bundle_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/ok_v0_preamble_textcmd_bundle_tests.rs
@@ -1,0 +1,52 @@
+use super::compile_request_v0;
+use carreltex_core::{CompileRequestV0, CompileResultV0, CompileStatus, Mount};
+use carreltex_xdv::{sum_dvi_v2_positive_right3_amounts_with_layout_v0, validate_dvi_v2_text_page_v0};
+
+fn valid_request() -> CompileRequestV0 {
+    CompileRequestV0 {
+        entrypoint: "main.tex".to_owned(),
+        source_date_epoch: 1,
+        max_log_bytes: 4096,
+        ok_max_line_glyphs_v0: None,
+        ok_max_lines_per_page_v0: None,
+        ok_line_advance_sp_v0: None,
+        ok_glyph_advance_sp_v0: None,
+    }
+}
+
+fn compile_main(main: &[u8]) -> CompileResultV0 {
+    let mut mount = Mount::default();
+    assert!(mount.add_file(b"main.tex", main).is_ok());
+    compile_request_v0(&mut mount, &valid_request())
+}
+
+fn right3_positive_total(result: &CompileResultV0) -> u32 {
+    sum_dvi_v2_positive_right3_amounts_with_layout_v0(&result.main_xdv_bytes, 65_536, 786_432)
+        .expect("sum parser should parse")
+}
+
+#[test]
+fn textcmd_bundle_preamble_is_ok_and_output_matches_without_decls() {
+    let with_decls = compile_main(
+        b"\\documentclass{article}\\DeclareTextCommand{\\A}{T1}{X}\\ProvideTextCommand{\\B}{T1}{Y}\\ProvideTextCommandDefault{\\C}{Z}\\DeclareTextCommandDefault{\\D}{Q}\\DeclareTextAccentDefault{\\E}{R}\\DeclareTextSymbolDefault{\\F}{S}\\DeclareTextCompositeDefault{\\G}{T}\\DeclareTextCompositeDefault{\\H}{T1}{U}\\begin{document}HelloWorld\\end{document}",
+    );
+    let without_decls =
+        compile_main(b"\\documentclass{article}\\begin{document}HelloWorld\\end{document}");
+    assert_eq!(with_decls.status, CompileStatus::Ok);
+    assert_eq!(without_decls.status, CompileStatus::Ok);
+    assert!(with_decls.log_bytes.is_empty());
+    assert!(validate_dvi_v2_text_page_v0(&with_decls.main_xdv_bytes));
+    assert_eq!(
+        right3_positive_total(&with_decls),
+        right3_positive_total(&without_decls)
+    );
+}
+
+#[test]
+fn provide_text_command_body_with_controlseq_is_not_implemented() {
+    let result = compile_main(
+        b"\\documentclass{article}\\ProvideTextCommand{\\Foo}{T1}{\\cite{X}}\\begin{document}HelloWorld\\end{document}",
+    );
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}


### PR DESCRIPTION
Summary
- Add focused bundle regression coverage for high-frequency textcmd preamble declarations, including ProvideTextCommand.
- Keep strict/fail-closed behavior unchanged while validating representative supported forms in one module.
- Add negative coverage for ProvideTextCommand body containing a control sequence.

Proof tail (./scripts/proof_v0.sh | tail -n 6)
- PASS: loc_guard
- PASS: core tests
- PASS: engine tests
- PASS: JS loaded WASM and exercised ABI (alloc/validate/mount/compile/report)
- PASS: ledger status validation passed (68 rows)
- PASS: carreltex v0 proof bundle