### PR TITLE
Leaf 297: PDF preview layout + demo note

### DIFF
--- a/scripts/wasm_smoke_js/fixtures/ok_demo_capabilities_v0.tex
+++ b/scripts/wasm_smoke_js/fixtures/ok_demo_capabilities_v0.tex
@@ -1,13 +1,16 @@
 \documentclass{article}
 
 \begin{document}
+\section*{Note}
+Preview PDF: OK extracted text only (monospace). No real LaTeX typography yet.
+
 \title{CarrelTeX OK Demo}
 \author{Alice \and Bob}
 \date{2026-03-04}
 \maketitle
 
 \section*{Text}
-Plain text. \textbf{Bold}. \emph{Emph}.
+Plain text. Wrapper tokens are parsed, but style is not rendered in v1.
 
 \section[Short]{Markers}
 Cite: \cite{demo-key}. Citet: \citet{demo-key}.\\

--- a/scripts/wasm_smoke_js_emit_main_pdf_v0.mjs
+++ b/scripts/wasm_smoke_js_emit_main_pdf_v0.mjs
@@ -178,12 +178,14 @@ function parseDviV2TextPages(bytes) {
 }
 
 function buildPdfFromDviV2(parsed) {
-  const renderScale = 6;
-  const ptPerSp = (1 / 65536) * renderScale;
+  const renderScaleX = 6;
+  const renderScaleY = 1;
+  const ptPerSpX = (1 / 65536) * renderScaleX;
+  const ptPerSpY = (1 / 65536) * renderScaleY;
   const marginPt = 72;
   const fontSizePt = 10;
-  const pageWidthPt = Math.max(612, parsed.maxHSp * ptPerSp + marginPt * 2);
-  const pageHeightPt = Math.max(792, parsed.maxVSp * ptPerSp + marginPt * 2 + 2 * fontSizePt);
+  const pageWidthPt = Math.max(612, parsed.maxHSp * ptPerSpX + marginPt * 2);
+  const pageHeightPt = Math.max(792, parsed.maxVSp * ptPerSpY + marginPt * 2 + 2 * fontSizePt);
 
   const pageCount = parsed.pages.length;
   if (pageCount <= 0) {
@@ -215,8 +217,8 @@ function buildPdfFromDviV2(parsed) {
     let content = 'BT\n';
     content += `/F1 ${fontSizePt} Tf\n`;
     for (const glyph of page.glyphs) {
-      const x = marginPt + glyph.hSp * ptPerSp;
-      const y = pageHeightPt - marginPt - fontSizePt - glyph.vSp * ptPerSp;
+      const x = marginPt + glyph.hSp * ptPerSpX;
+      const y = pageHeightPt - marginPt - fontSizePt - glyph.vSp * ptPerSpY;
       const s = escapePdfStringByte(glyph.byte);
       if (s.length === 0) continue;
       content += `1 0 0 1 ${x.toFixed(3)} ${y.toFixed(3)} Tm (${s}) Tj\n`;


### PR DESCRIPTION
Tightens the preview PDF layout so the demo is easier to read, and adds an explicit in-document note clarifying this is OK-extracted text (not real LaTeX typography).

Proof:
- `PROOF_V0_WASM_PDF=1 ./scripts/proof_v0.sh | tail -n 6`
- `./scripts/demo_wasm_pdf.sh | tail -n 1`