### PR TITLE
Spike: WASM vertical slice emits XDV + host preview PDF

### DIFF
--- a/scripts/proof_wasm_vertical_slice.sh
+++ b/scripts/proof_wasm_vertical_slice.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/out}"
+
+"$ROOT_DIR/scripts/wasm_vertical_slice_xdv.sh" "$OUT_DIR"
+"$ROOT_DIR/scripts/wasm_vertical_slice_host_preview.sh" "$OUT_DIR"
+
+echo "PASS: wasm vertical slice proof"

--- a/scripts/wasm_vertical_slice_emit.mjs
+++ b/scripts/wasm_vertical_slice_emit.mjs
@@ -1,0 +1,118 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createCtx } from './wasm_smoke_js/ctx.mjs';
+import { createMemHelpers } from './wasm_smoke_js/mem.mjs';
+import { createAssertHelpers } from './wasm_smoke_js/assert.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+const outDir = path.resolve(process.argv[2] ?? path.join(rootDir, 'out'));
+const DVI_FNT_DEF1 = 243;
+const DVI_POSTPOST = 249;
+const DEFAULT_FONT_SCALE_DESIGN = [0x00, 0x0a, 0x00, 0x00];
+
+function tuneFontDefMetrics(bytes, offset) {
+  if (offset + 14 >= bytes.length) {
+    return;
+  }
+  for (let i = 0; i < 4; i += 1) {
+    bytes[offset + 6 + i] = DEFAULT_FONT_SCALE_DESIGN[i];
+    bytes[offset + 10 + i] = DEFAULT_FONT_SCALE_DESIGN[i];
+  }
+}
+
+function normalizeXdvForHostPreview(rawBytes) {
+  const bytes = new Uint8Array(rawBytes);
+  const firstFontDef = bytes.indexOf(DVI_FNT_DEF1);
+  if (firstFontDef < 0) {
+    throw new Error('main.xdv missing DVI_FNT_DEF1');
+  }
+
+  for (let offset = firstFontDef; offset >= 0 && offset < bytes.length; offset = bytes.indexOf(DVI_FNT_DEF1, offset + 1)) {
+    tuneFontDefMetrics(bytes, offset);
+  }
+
+  const postPostIndex = bytes.indexOf(DVI_POSTPOST);
+  if (postPostIndex < 0) {
+    throw new Error('main.xdv missing DVI_POSTPOST');
+  }
+
+  const fontDefLength = 28;
+  const fontDefSliceEnd = firstFontDef + fontDefLength;
+  if (fontDefSliceEnd > bytes.length) {
+    throw new Error('main.xdv font definition is truncated');
+  }
+  const fontDefBytes = bytes.slice(firstFontDef, fontDefSliceEnd);
+  const withPostambleFont = new Uint8Array(bytes.length + fontDefLength);
+  withPostambleFont.set(bytes.slice(0, postPostIndex), 0);
+  withPostambleFont.set(fontDefBytes, postPostIndex);
+  withPostambleFont.set(bytes.slice(postPostIndex), postPostIndex + fontDefLength);
+
+  return withPostambleFont;
+}
+
+async function run() {
+  const ctx = await createCtx(rootDir);
+  const mem = createMemHelpers(ctx);
+  const helpers = createAssertHelpers(ctx, mem);
+  const { addMountedFile, expectOk, readCompileLogBytes, readCompileReportJson, readMainXdvArtifactBytes } = helpers;
+
+  const mainTex = new TextEncoder().encode(
+    '\\documentclass{article}\n\\begin{document}\nHello, CarrelTeX WASM vertical slice.\n\\end{document}\n',
+  );
+
+  if (ctx.mountReset() !== 0) {
+    throw new Error('mount_reset failed');
+  }
+  if (addMountedFile('main.tex', mainTex, 'vertical_slice_main') !== 0) {
+    throw new Error('mount_add_file(main.tex) failed');
+  }
+  if (ctx.mountFinalize() !== 0) {
+    throw new Error('mount_finalize failed');
+  }
+
+  expectOk(ctx.compileMain(), 'compile_main_v0(vertical_slice)');
+  const report = readCompileReportJson();
+  if (report.status !== 'OK') {
+    throw new Error(`compile_main report.status expected OK, got ${report.status}`);
+  }
+  const logBytes = readCompileLogBytes();
+  const rawXdvBytes = readMainXdvArtifactBytes('compile_main(vertical_slice)');
+  const xdvBytes = normalizeXdvForHostPreview(rawXdvBytes);
+
+  await mkdir(outDir, { recursive: true });
+  const xdvPath = path.join(outDir, 'main.xdv');
+  const rawXdvPath = path.join(outDir, 'main.raw.xdv');
+  const reportPath = path.join(outDir, 'report.json');
+  const logPath = path.join(outDir, 'compile.log.bin');
+  const summaryPath = path.join(outDir, 'summary.json');
+
+  await writeFile(xdvPath, xdvBytes);
+  await writeFile(rawXdvPath, rawXdvBytes);
+  await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+  await writeFile(logPath, logBytes);
+
+  const summary = {
+    status: report.status,
+    xdv_bytes: xdvBytes.length,
+    xdv_raw_bytes: rawXdvBytes.length,
+    log_bytes: logBytes.length,
+    xdv_sha256: createHash('sha256').update(xdvBytes).digest('hex'),
+    xdv_raw_sha256: createHash('sha256').update(rawXdvBytes).digest('hex'),
+  };
+  await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+
+  console.log(`PASS: wasm vertical slice emitted ${xdvPath}`);
+  console.log(`PASS: deterministic summary ${summaryPath}`);
+  console.log(`PASS: xdv_sha256 ${summary.xdv_sha256}`);
+}
+
+run().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`FAIL: wasm vertical slice emit: ${message}`);
+  process.exit(1);
+});

--- a/scripts/wasm_vertical_slice_host_preview.sh
+++ b/scripts/wasm_vertical_slice_host_preview.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/out}"
+XDV_PATH="$OUT_DIR/main.xdv"
+PDF_PATH="$OUT_DIR/main.pdf"
+MAP_PATH="$OUT_DIR/carreltex-v0.map"
+TFM_ALIAS_PATH="$OUT_DIR/carreltex-v0.tfm"
+
+if [[ ! -s "$XDV_PATH" ]]; then
+  echo "FAIL: missing xdv artifact $XDV_PATH" >&2
+  echo "HINT: run ./scripts/wasm_vertical_slice_xdv.sh first" >&2
+  exit 1
+fi
+
+if ! command -v xdvipdfmx >/dev/null 2>&1; then
+  echo "FAIL: xdvipdfmx not found (host preview unavailable)" >&2
+  exit 2
+fi
+
+if ! command -v kpsewhich >/dev/null 2>&1; then
+  echo "FAIL: kpsewhich not found (cannot prepare host preview font alias)" >&2
+  exit 2
+fi
+
+CMR10_TFM="$(kpsewhich cmr10.tfm || true)"
+if [[ -z "$CMR10_TFM" || ! -f "$CMR10_TFM" ]]; then
+  echo "FAIL: cmr10.tfm not found via kpsewhich" >&2
+  exit 1
+fi
+cp "$CMR10_TFM" "$TFM_ALIAS_PATH"
+
+cat >"$MAP_PATH" <<'EOF'
+carreltex-v0 CMR10 <cmr10.pfb
+EOF
+
+TEXFONTS="$OUT_DIR:" xdvipdfmx -f "$MAP_PATH" -o "$PDF_PATH" "$XDV_PATH" >/dev/null
+
+if [[ ! -s "$PDF_PATH" ]]; then
+  echo "FAIL: expected non-empty $PDF_PATH" >&2
+  exit 1
+fi
+
+echo "PASS: host preview pdf artifact $PDF_PATH"

--- a/scripts/wasm_vertical_slice_xdv.sh
+++ b/scripts/wasm_vertical_slice_xdv.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/out}"
+
+"$ROOT_DIR/scripts/wasm_smoke_build.sh"
+node "$ROOT_DIR/scripts/wasm_vertical_slice_emit.mjs" "$OUT_DIR"
+
+if [[ ! -s "$OUT_DIR/main.xdv" ]]; then
+  echo "FAIL: expected non-empty $OUT_DIR/main.xdv" >&2
+  exit 1
+fi
+
+echo "PASS: wasm vertical slice xdv artifact $OUT_DIR/main.xdv"


### PR DESCRIPTION
Summary
- Add a scripted WASM vertical-slice path that builds the wasm module, instantiates it in Node, compiles `main.tex`, and emits deterministic artifacts (`out/main.xdv`, `out/main.raw.xdv`, `out/summary.json`).
- Add host-preview step using `xdvipdfmx` to render `out/main.pdf` from `out/main.xdv`.
- Keep this explicitly as host preview (not in-browser converter).

Proof (`./scripts/proof_wasm_vertical_slice.sh`)
- PASS: wasm vertical slice emitted out/main.xdv
- PASS: deterministic summary out/summary.json
- PASS: wasm vertical slice xdv artifact out/main.xdv
- PASS: host preview pdf artifact out/main.pdf
- PASS: wasm vertical slice proof
