### PR TITLE
Typeset minimal: preserve paragraph breaks in body

### DIFF
--- a/crates/carreltex-engine/src/compile_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0.rs
@@ -264,7 +264,10 @@ use ok_v0::{
 };
 use stats_v0::build_tex_stats_from_tokens_v0;
 use trace_v0::build_not_implemented_log_v0;
-use typeset_minimal_v0::{extract_typeset_minimal_text_body_v0, TYPESET_MINIMAL_MAX_LINE_GLYPHS_V0};
+use typeset_minimal_v0::{
+    extract_typeset_minimal_text_body_v0, normalize_typeset_minimal_tokens_v0,
+    preprocess_typeset_minimal_source_v0, TYPESET_MINIMAL_MAX_LINE_GLYPHS_V0,
+};
 const MISSING_COMPONENTS_V0: &[&str] = &["tex-engine"];
 const EMPTY_TEX_STATS_JSON: &str = "";
 fn invalid_result_v0(max_log_bytes: u32, reason: InvalidInputReasonV0) -> CompileResultV0 {
@@ -307,7 +310,8 @@ pub fn compile_main_typeset_minimal_v0(mount: &mut Mount) -> CompileResultV0 {
         Ok(Some(bytes)) => bytes.to_vec(),
         _ => return invalid_result_v0(request.max_log_bytes, InvalidInputReasonV0::EntrypointMissing),
     };
-    let tokens = match tokenize_v0(&entry_bytes) {
+    let preprocessed_entry_bytes = preprocess_typeset_minimal_source_v0(&entry_bytes);
+    let tokens = match tokenize_v0(&preprocessed_entry_bytes) {
         Ok(tokens) => tokens,
         Err(error) => {
             return invalid_result_v0(
@@ -348,7 +352,8 @@ pub fn compile_main_typeset_minimal_v0(mount: &mut Mount) -> CompileResultV0 {
     if tex_stats_json.is_empty() {
         return invalid_result_v0(request.max_log_bytes, InvalidInputReasonV0::StatsBuildFailed);
     }
-    let ok_text_bytes = extract_typeset_minimal_text_body_v0(&macro_expanded_tokens);
+    let normalized_typeset_tokens = normalize_typeset_minimal_tokens_v0(&macro_expanded_tokens);
+    let ok_text_bytes = extract_typeset_minimal_text_body_v0(&normalized_typeset_tokens);
     if let Some(ok_text_bytes) = ok_text_bytes {
         if ok_text_bytes.len() <= MAX_OK_TEXT_BYTES_V0 {
             let glyph_advance_sp = OK_GLYPH_ADVANCE_SP_V0;

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -3,6 +3,7 @@ use crate::tex::tokenize_v0::TokenV0;
 pub(crate) const TYPESET_MINIMAL_MAX_LINE_GLYPHS_V0: usize = 56;
 
 const NEWLINE_MARKER_V0: u8 = 0x0a;
+const CARRELPAR_MARKER_CONTROL_V0: &[u8] = b"carrelpar";
 const ITALIC_START_MARKER_V0: u8 = b'[';
 const ITALIC_END_MARKER_V0: u8 = b']';
 const BOLD_START_MARKER_V0: u8 = b'{';
@@ -40,6 +41,157 @@ fn push_newline(out: &mut Vec<u8>) {
     if !matches!(out.last().copied(), Some(NEWLINE_MARKER_V0)) {
         out.push(NEWLINE_MARKER_V0);
     }
+}
+
+fn push_paragraph_break(out: &mut Vec<u8>) {
+    trim_trailing_spaces(out);
+    if out.is_empty() {
+        return;
+    }
+    if out.ends_with(&[NEWLINE_MARKER_V0, NEWLINE_MARKER_V0]) {
+        return;
+    }
+    if !out.ends_with(&[NEWLINE_MARKER_V0]) {
+        out.push(NEWLINE_MARKER_V0);
+    }
+    out.push(NEWLINE_MARKER_V0);
+}
+
+fn is_horizontal_space_v0(byte: u8) -> bool {
+    matches!(byte, b' ' | b'\t')
+}
+
+fn trim_horizontal_space_bytes_v0(mut bytes: &[u8]) -> &[u8] {
+    while matches!(bytes.first(), Some(byte) if is_horizontal_space_v0(*byte)) {
+        bytes = &bytes[1..];
+    }
+    while matches!(bytes.last(), Some(byte) if is_horizontal_space_v0(*byte)) {
+        bytes = &bytes[..bytes.len() - 1];
+    }
+    bytes
+}
+
+fn strip_comment_unescaped_v0(line: &[u8]) -> &[u8] {
+    let mut index = 0usize;
+    while index < line.len() {
+        if line[index] == b'%' {
+            let mut backslashes = 0usize;
+            let mut cursor = index;
+            while cursor > 0 && line[cursor - 1] == b'\\' {
+                backslashes += 1;
+                cursor -= 1;
+            }
+            if backslashes % 2 == 0 {
+                return &line[..index];
+            }
+        }
+        index += 1;
+    }
+    line
+}
+
+fn is_ascii_letter_v0(byte: u8) -> bool {
+    byte.is_ascii_alphabetic()
+}
+
+fn rewrite_explicit_par_controls_v0(line: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(line.len());
+    let mut index = 0usize;
+    while index < line.len() {
+        if line[index] != b'\\' {
+            out.push(line[index]);
+            index += 1;
+            continue;
+        }
+        let control_start = index + 1;
+        if control_start >= line.len() || !is_ascii_letter_v0(line[control_start]) {
+            out.push(line[index]);
+            index += 1;
+            continue;
+        }
+        let mut control_end = control_start;
+        while control_end < line.len() && is_ascii_letter_v0(line[control_end]) {
+            control_end += 1;
+        }
+        let control_name = &line[control_start..control_end];
+        if control_name == b"par" {
+            out.extend_from_slice(b"\\carrelpar");
+        } else {
+            out.extend_from_slice(&line[index..control_end]);
+        }
+        index = control_end;
+    }
+    out
+}
+
+pub(crate) fn preprocess_typeset_minimal_source_v0(source: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(source.len() + 16);
+    let mut cursor = 0usize;
+    let mut in_body = false;
+    let mut pending_paragraph_break = false;
+
+    while cursor <= source.len() {
+        let line_start = cursor;
+        while cursor < source.len() && source[cursor] != b'\n' && source[cursor] != b'\r' {
+            cursor += 1;
+        }
+        let line = &source[line_start..cursor];
+        let had_newline = cursor < source.len();
+        if had_newline {
+            if source[cursor] == b'\r' && cursor + 1 < source.len() && source[cursor + 1] == b'\n' {
+                cursor += 2;
+            } else {
+                cursor += 1;
+            }
+        } else {
+            cursor += 1;
+        }
+
+        let line_no_comment = strip_comment_unescaped_v0(line);
+        let trimmed = trim_horizontal_space_bytes_v0(line_no_comment);
+
+        if !in_body {
+            out.extend_from_slice(line);
+            if had_newline {
+                out.push(b'\n');
+            }
+            if trimmed == b"\\begin{document}" {
+                in_body = true;
+            }
+            continue;
+        }
+
+        if trimmed == b"\\end{document}" {
+            pending_paragraph_break = false;
+            out.extend_from_slice(line);
+            if had_newline {
+                out.push(b'\n');
+            }
+            in_body = false;
+            continue;
+        }
+
+        if trimmed.is_empty() {
+            pending_paragraph_break = true;
+            continue;
+        }
+
+        if pending_paragraph_break {
+            out.extend_from_slice(b"\\carrelpar ");
+            pending_paragraph_break = false;
+        }
+        let rewritten = rewrite_explicit_par_controls_v0(line);
+        out.extend_from_slice(&rewritten);
+        if had_newline {
+            out.push(b'\n');
+        }
+    }
+
+    out
+}
+
+pub(crate) fn normalize_typeset_minimal_tokens_v0(tokens: &[TokenV0]) -> Vec<TokenV0> {
+    tokens.to_vec()
 }
 
 fn consume_group_bounds(tokens: &[TokenV0], index: usize) -> Option<(usize, usize, usize)> {
@@ -313,9 +465,8 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
                 index = consume_document_env_command_v0(tokens, index, b"end")?;
                 break;
             }
-            Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"par" => {
-                push_newline(&mut body);
-                push_newline(&mut body);
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == CARRELPAR_MARKER_CONTROL_V0 => {
+                push_paragraph_break(&mut body);
                 index += 1;
             }
             Some(_) => {

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -1,4 +1,9 @@
 use super::compile_main_typeset_minimal_v0;
+use super::typeset_minimal_v0::{
+    extract_typeset_minimal_text_body_v0, normalize_typeset_minimal_tokens_v0,
+    preprocess_typeset_minimal_source_v0,
+};
+use crate::tex::tokenize_v0::tokenize_v0;
 use carreltex_core::{CompileStatus, Mount};
 
 fn compile_typeset(main: &[u8]) -> carreltex_core::CompileResultV0 {
@@ -7,6 +12,13 @@ fn compile_typeset(main: &[u8]) -> carreltex_core::CompileResultV0 {
         .add_file(b"main.tex", main)
         .expect("main.tex should mount");
     compile_main_typeset_minimal_v0(&mut mount)
+}
+
+fn extract_typeset_body(main: &[u8]) -> Vec<u8> {
+    let preprocessed = preprocess_typeset_minimal_source_v0(main);
+    let tokens = tokenize_v0(&preprocessed).expect("tokenize should succeed");
+    let normalized = normalize_typeset_minimal_tokens_v0(&tokens);
+    extract_typeset_minimal_text_body_v0(&normalized).expect("extract should succeed")
 }
 
 #[test]
@@ -32,4 +44,35 @@ fn typeset_minimal_rejects_unsupported_wrapper_in_body() {
     let result = compile_typeset(main);
     assert_eq!(result.status, CompileStatus::NotImplemented);
     assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_blank_line_emits_paragraph_break() {
+    let main = b"\\documentclass{article}\n\\begin{document}\nFirst paragraph.\n\n% spacer comment\n   \nSecond paragraph.\n\\end{document}\n";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("First paragraph.\n\nSecond paragraph."),
+        "body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_explicit_par_emits_paragraph_break() {
+    let main = b"\\documentclass{article}\n\\begin{document}\nFirst paragraph.\\par Second paragraph.\n\\end{document}\n";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("First paragraph.\n\nSecond paragraph."),
+        "body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_author_and_is_single_newline() {
+    let main = b"\\documentclass{article}\\author{Alice\\and Bob}\\begin{document}\\maketitle\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(!text.contains("Alice\n\nBob"), "body={text:?}");
+    assert!(text.contains("Alice\nBob"), "body={text:?}");
 }

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -17,5 +17,8 @@ Hello, world.
 
 This is a paragraph with \emph{emphasis} and \textbf{bold}.
 
-\end{document}
+This second paragraph is separated by a blank line and should remain a distinct paragraph in the minimal typeset slice.
 
+\par This third paragraph is started with an explicit marker and should also remain distinct.
+
+\end{document}


### PR DESCRIPTION
Summary
- Preserve body paragraph breaks in minimal typeset via preprocessing marker (\carrelpar).
- Keep \and in author metadata as a single newline.
- Add regression coverage for blank-line and explicit \par paragraph breaks.

Proof
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- ./scripts/proof_wasm_typeset_minimal_v0.sh | tail -n 6
