### PR TITLE
Typeset minimal: width-based wrapping with sp metrics

### DIFF
--- a/crates/carreltex-engine/src/compile_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0.rs
@@ -252,7 +252,7 @@ use carreltex_core::{
     CompileStatus, Mount, DEFAULT_COMPILE_MAIN_MAX_LOG_BYTES_V0, MAX_LOG_BYTES_V0,
 };
 use carreltex_xdv::{
-    plan_layout_v0, validate_dvi_v2_text_page_matches_layout_v0,
+    plan_layout_v0, plan_layout_width_v0, validate_dvi_v2_text_page_matches_layout_v0,
     validate_dvi_v2_text_page_with_layout_v0, write_dvi_v2_text_page_from_layout_v0,
     DEFAULT_MAX_LINES_PER_PAGE_V0, DEFAULT_MAX_LINE_GLYPHS_V0,
 };
@@ -266,10 +266,13 @@ use stats_v0::build_tex_stats_from_tokens_v0;
 use trace_v0::build_not_implemented_log_v0;
 use typeset_minimal_v0::{
     extract_typeset_minimal_text_body_v0, normalize_typeset_minimal_tokens_v0,
-    preprocess_typeset_minimal_source_v0, TYPESET_MINIMAL_MAX_LINE_GLYPHS_V0,
+    preprocess_typeset_minimal_source_v0,
 };
 const MISSING_COMPONENTS_V0: &[&str] = &["tex-engine"];
 const EMPTY_TEX_STATS_JSON: &str = "";
+const TYPESET_MINIMAL_GLYPH_ADVANCE_SP_V0: i32 = 471_859;
+const TYPESET_MINIMAL_LINE_ADVANCE_SP_V0: i32 = 917_504;
+const TYPESET_MINIMAL_MAX_LINE_WIDTH_SP_V0: u32 = 30_670_848;
 fn invalid_result_v0(max_log_bytes: u32, reason: InvalidInputReasonV0) -> CompileResultV0 {
     build_compile_result_v0(
         CompileStatus::InvalidInput,
@@ -356,13 +359,13 @@ pub fn compile_main_typeset_minimal_v0(mount: &mut Mount) -> CompileResultV0 {
     let ok_text_bytes = extract_typeset_minimal_text_body_v0(&normalized_typeset_tokens);
     if let Some(ok_text_bytes) = ok_text_bytes {
         if ok_text_bytes.len() <= MAX_OK_TEXT_BYTES_V0 {
-            let glyph_advance_sp = OK_GLYPH_ADVANCE_SP_V0;
-            let line_advance_sp = OK_LINE_ADVANCE_SP_V0;
-            let layout_plan = match plan_layout_v0(
+            let glyph_advance_sp = TYPESET_MINIMAL_GLYPH_ADVANCE_SP_V0;
+            let line_advance_sp = TYPESET_MINIMAL_LINE_ADVANCE_SP_V0;
+            let layout_plan = match plan_layout_width_v0(
                 &ok_text_bytes,
                 glyph_advance_sp,
                 line_advance_sp,
-                TYPESET_MINIMAL_MAX_LINE_GLYPHS_V0,
+                TYPESET_MINIMAL_MAX_LINE_WIDTH_SP_V0,
                 DEFAULT_MAX_LINES_PER_PAGE_V0,
             ) {
                 Some(plan) => plan,

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -1,7 +1,5 @@
 use crate::tex::tokenize_v0::TokenV0;
 
-pub(crate) const TYPESET_MINIMAL_MAX_LINE_GLYPHS_V0: usize = 56;
-
 const NEWLINE_MARKER_V0: u8 = 0x0a;
 const CARRELPAR_MARKER_CONTROL_V0: &[u8] = b"carrelpar";
 const ITALIC_START_MARKER_V0: u8 = b'[';

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -5,6 +5,7 @@ use super::typeset_minimal_v0::{
 };
 use crate::tex::tokenize_v0::tokenize_v0;
 use carreltex_core::{CompileStatus, Mount};
+use carreltex_xdv::parse_dvi_v2_text_page_to_layout_v0;
 
 fn compile_typeset(main: &[u8]) -> carreltex_core::CompileResultV0 {
     let mut mount = Mount::default();
@@ -75,4 +76,17 @@ fn typeset_minimal_author_and_is_single_newline() {
     let text = String::from_utf8(body).expect("body should be valid utf8");
     assert!(!text.contains("Alice\n\nBob"), "body={text:?}");
     assert!(text.contains("Alice\nBob"), "body={text:?}");
+}
+
+#[test]
+fn typeset_minimal_long_paragraph_wraps_to_multiple_lines() {
+    let main = b"\\documentclass{article}\\begin{document}This is a long paragraph that should wrap deterministically to multiple physical lines in the minimal typeset pipeline when width-based layout is enabled and the content exceeds the configured line width for the page body area.\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::Ok);
+    let layout =
+        parse_dvi_v2_text_page_to_layout_v0(&result.main_xdv_bytes, 917_504).expect("layout parse");
+    assert!(
+        layout.pages.first().map(|page| page.lines.len()).unwrap_or(0) >= 2,
+        "expected wrapped output with multiple lines"
+    );
 }

--- a/crates/carreltex-xdv/src/layout_v0.rs
+++ b/crates/carreltex-xdv/src/layout_v0.rs
@@ -128,6 +128,65 @@ fn wrap_logical_line_v0(line: &[u8], max_line_glyphs: usize) -> Option<Vec<Vec<u
     Some(wrapped)
 }
 
+fn wrap_logical_line_by_width_v0(
+    line: &[u8],
+    glyph_advance_sp: i32,
+    max_line_width_sp: u32,
+) -> Option<Vec<Vec<u8>>> {
+    if max_line_width_sp == 0 {
+        return None;
+    }
+    if line.is_empty() {
+        return Some(vec![Vec::new()]);
+    }
+    let mut wrapped = Vec::<Vec<u8>>::new();
+    let mut start = 0usize;
+    while start < line.len() {
+        let mut cursor = start;
+        let mut width = 0u32;
+        let mut last_space = None::<usize>;
+        while cursor < line.len() {
+            let advance_sp = u32::try_from(glyph_width_sp_v0(line[cursor], glyph_advance_sp)?).ok()?;
+            if width.checked_add(advance_sp)? > max_line_width_sp {
+                break;
+            }
+            width = width.checked_add(advance_sp)?;
+            if line[cursor] == b' ' {
+                last_space = Some(cursor);
+            }
+            cursor += 1;
+        }
+
+        if cursor == line.len() {
+            wrapped.push(line[start..].to_vec());
+            break;
+        }
+
+        if cursor == start {
+            let hard_break = start.checked_add(1)?;
+            wrapped.push(line[start..hard_break].to_vec());
+            start = hard_break;
+            continue;
+        }
+
+        if let Some(space_index) = last_space {
+            if space_index > start {
+                wrapped.push(line[start..space_index].to_vec());
+            } else {
+                wrapped.push(Vec::new());
+            }
+            start = space_index + 1;
+            while start < line.len() && line[start] == b' ' {
+                start += 1;
+            }
+        } else {
+            wrapped.push(line[start..cursor].to_vec());
+            start = cursor;
+        }
+    }
+    Some(wrapped)
+}
+
 fn build_line_plan_v0(line: &[u8], glyph_advance_sp: i32) -> Option<LinePlanV0> {
     let mut glyphs = Vec::<GlyphPlanV0>::new();
     for byte in line {
@@ -167,6 +226,46 @@ pub fn plan_layout_v0(
         let mut physical_lines = Vec::<LinePlanV0>::new();
         for logical_line in logical_lines {
             let wrapped = wrap_logical_line_v0(logical_line, max_line_glyphs)?;
+            for wrapped_line in wrapped {
+                let line_plan = build_line_plan_v0(&wrapped_line, glyph_advance_sp)?;
+                physical_lines.push(line_plan);
+            }
+        }
+        for chunk in physical_lines.chunks(max_lines_per_page) {
+            pages.push(PagePlanV0 {
+                lines: chunk.to_vec(),
+            });
+        }
+    }
+    if pages.is_empty() {
+        return None;
+    }
+    Some(LayoutPlanV0 { pages })
+}
+
+pub fn plan_layout_width_v0(
+    text: &[u8],
+    glyph_advance_sp: i32,
+    line_advance_sp: i32,
+    max_line_width_sp: u32,
+    max_lines_per_page: usize,
+) -> Option<LayoutPlanV0> {
+    if glyph_advance_sp <= 0
+        || line_advance_sp <= 0
+        || max_line_width_sp == 0
+        || max_lines_per_page == 0
+    {
+        return None;
+    }
+
+    let forced_pages = split_pages_v0(text)?;
+    let mut pages = Vec::<PagePlanV0>::new();
+    for forced_page in forced_pages {
+        let logical_lines = split_lines_v0(forced_page);
+        let mut physical_lines = Vec::<LinePlanV0>::new();
+        for logical_line in logical_lines {
+            let wrapped =
+                wrap_logical_line_by_width_v0(logical_line, glyph_advance_sp, max_line_width_sp)?;
             for wrapped_line in wrapped {
                 let line_plan = build_line_plan_v0(&wrapped_line, glyph_advance_sp)?;
                 physical_lines.push(line_plan);

--- a/crates/carreltex-xdv/src/lib.rs
+++ b/crates/carreltex-xdv/src/lib.rs
@@ -22,7 +22,8 @@ pub const DEFAULT_MAX_LINES_PER_PAGE_V0: usize = 200;
 mod layout_v0;
 mod pdf_v0;
 pub use layout_v0::{
-    plan_layout_v0, recompute_line_width_sp_v0, GlyphPlanV0, LayoutPlanV0, LinePlanV0,
+    plan_layout_v0, plan_layout_width_v0, recompute_line_width_sp_v0, GlyphPlanV0, LayoutPlanV0,
+    LinePlanV0,
     PagePlanV0,
 };
 pub use pdf_v0::render_dvi_v2_text_page_to_pdf_v0;
@@ -244,6 +245,17 @@ fn emit_line_plan_v0(out: &mut Vec<u8>, line: &LinePlanV0) -> Option<u32> {
     Some(emitted_width)
 }
 
+fn emit_reset_back_v0(out: &mut Vec<u8>, mut reset_back: u32) -> Option<()> {
+    const MAX_RIGHT3_STEP_V0: u32 = 8_388_607;
+    while reset_back > 0 {
+        let step = reset_back.min(MAX_RIGHT3_STEP_V0);
+        out.push(DVI_RIGHT3);
+        push_i24_be(out, -i32::try_from(step).ok()?)?;
+        reset_back -= step;
+    }
+    Some(())
+}
+
 pub fn write_dvi_v2_text_page_from_layout_v0(
     layout: &LayoutPlanV0,
     line_advance_sp: i32,
@@ -286,9 +298,7 @@ pub fn write_dvi_v2_text_page_from_layout_v0(
         page_h = page_h.max(previous_line_h);
         for line in page.lines.iter().skip(1) {
             if previous_line_h > 0 {
-                out.push(DVI_RIGHT3);
-                let reset_back = -i32::try_from(previous_line_h).ok()?;
-                push_i24_be(&mut out, reset_back)?;
+                emit_reset_back_v0(&mut out, previous_line_h)?;
             }
             out.push(DVI_DOWN3);
             push_i24_be(&mut out, line_advance_sp)?;
@@ -560,10 +570,10 @@ fn parse_dvi_v2_text_page_internal_v0(
                     return None;
                 }
                 let back = u32::try_from(-amount).ok()?;
-                if back != page_h {
+                if back == 0 || back > page_h {
                     return None;
                 }
-                page_h = 0;
+                page_h -= back;
                 expect_down3_after_reset = true;
                 continue;
             }

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -1,7 +1,8 @@
 use super::{
     count_dvi_v2_text_movements_v0, count_dvi_v2_text_pages_v0,
     count_dvi_v2_text_pages_with_advance_v0, validate_dvi_v2_empty_page_v0,
-    parse_dvi_v2_text_page_to_layout_v0, plan_layout_v0, recompute_line_width_sp_v0,
+    parse_dvi_v2_text_page_to_layout_v0, plan_layout_v0, plan_layout_width_v0,
+    recompute_line_width_sp_v0,
     render_dvi_v2_text_page_to_pdf_v0,
     sum_dvi_v2_positive_right3_amounts_with_layout_v0, validate_dvi_v2_text_page_matches_layout_v0,
     validate_dvi_v2_text_page_v0, validate_dvi_v2_text_page_with_layout_v0,
@@ -132,6 +133,38 @@ fn planner_propagates_wi_dot_glyph_advances_and_line_width() {
     assert_eq!(line.glyphs[2].advance_sp, 32_768);
     assert_eq!(line.width_sp, 163_840);
     assert_eq!(recompute_line_width_sp_v0(line), Some(line.width_sp));
+}
+
+#[test]
+fn planner_width_wraps_long_line_at_spaces() {
+    let plan =
+        plan_layout_width_v0(b"aaaa bbbb cccc", 65_536, 786_432, 327_680, 200).expect("layout plan");
+    assert_eq!(plan.pages.len(), 1);
+    assert_eq!(plan.pages[0].lines.len(), 3);
+    assert_eq!(
+        plan.pages[0].lines[0]
+            .glyphs
+            .iter()
+            .map(|glyph| glyph.byte)
+            .collect::<Vec<_>>(),
+        b"aaaa"
+    );
+    assert_eq!(
+        plan.pages[0].lines[1]
+            .glyphs
+            .iter()
+            .map(|glyph| glyph.byte)
+            .collect::<Vec<_>>(),
+        b"bbbb"
+    );
+    assert_eq!(
+        plan.pages[0].lines[2]
+            .glyphs
+            .iter()
+            .map(|glyph| glyph.byte)
+            .collect::<Vec<_>>(),
+        b"cccc"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Summary
- add width-based layout planning (`plan_layout_width_v0`) for deterministic wrapping by sp width with space-preferred breaks
- switch `compile_main_typeset_minimal_v0` to typeset-specific sp metrics and width-based planning
- add focused coverage for width planner wrapping and multi-line XDV output from long paragraph text

Proof
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- ./scripts/proof_wasm_typeset_minimal_v0.sh | tail -n 6
