### PR TITLE
Typeset minimal: add variable glyph metrics table

### DIFF
--- a/crates/carreltex-xdv/src/layout_v0.rs
+++ b/crates/carreltex-xdv/src/layout_v0.rs
@@ -27,21 +27,30 @@ fn is_supported_text_byte_v0(byte: u8) -> bool {
     (0x20..=0x7e).contains(&byte)
 }
 
+fn glyph_width_ratio_v0(byte: u8) -> (u32, u32) {
+    match byte {
+        b' ' => (1, 2),
+        b'.' | b',' | b';' | b':' | b'!' | b'?' | b'\'' | b'"' => (1, 2),
+        b'i' | b'l' | b'I' | b'|' => (1, 2),
+        b'm' | b'w' | b'M' | b'W' => (3, 2),
+        _ => (1, 1),
+    }
+}
+
 pub(crate) fn glyph_width_sp_v0(byte: u8, glyph_advance_sp: i32) -> Option<i32> {
     if glyph_advance_sp <= 0 {
         return None;
     }
-    let half_em = glyph_advance_sp.checked_add(1)?.checked_div(2)?;
-    let one_and_half_em = glyph_advance_sp.checked_add(half_em)?;
-    let width = match byte {
-        b' ' | b'.' | b'i' => half_em,
-        b'm' | b'W' => one_and_half_em,
-        _ => glyph_advance_sp,
-    };
+    let (num, den) = glyph_width_ratio_v0(byte);
+    let glyph_advance = i64::from(glyph_advance_sp);
+    let width = (glyph_advance
+        .checked_mul(i64::from(num))?
+        .checked_add(i64::from(den / 2))?)
+    .checked_div(i64::from(den))?;
     if !(1..=8_388_607).contains(&width) {
         return None;
     }
-    Some(width)
+    i32::try_from(width).ok()
 }
 
 pub fn recompute_line_width_sp_v0(line: &LinePlanV0) -> Option<u32> {

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -108,7 +108,7 @@ fn planner_wrap_and_paging_shape_is_deterministic() {
     assert_eq!(plan.pages[1].lines.len(), 1);
     assert_eq!(plan.pages[0].lines[0].width_sp, 4 * 65_536);
     assert_eq!(plan.pages[0].lines[1].width_sp, 4 * 65_536);
-    assert_eq!(plan.pages[1].lines[0].width_sp, 4 * 65_536);
+    assert!(plan.pages[1].lines[0].width_sp < 4 * 65_536);
 }
 
 #[test]
@@ -164,6 +164,22 @@ fn planner_width_wraps_long_line_at_spaces() {
             .map(|glyph| glyph.byte)
             .collect::<Vec<_>>(),
         b"cccc"
+    );
+}
+
+#[test]
+fn planner_width_uses_variable_space_width_v0() {
+    let plan =
+        plan_layout_width_v0(b"A A", 100, 786_432, 250, 200).expect("layout plan");
+    assert_eq!(plan.pages.len(), 1);
+    assert_eq!(plan.pages[0].lines.len(), 1);
+    assert_eq!(
+        plan.pages[0].lines[0]
+            .glyphs
+            .iter()
+            .map(|glyph| glyph.byte)
+            .collect::<Vec<_>>(),
+        b"A A"
     );
 }
 

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -13,12 +13,8 @@
 \begin{document}
 \maketitle
 
-Hello, world.
+Hello, world. This first paragraph includes \emph{emphasis} and \textbf{bold} in supported inline forms.
 
-This is a paragraph with \emph{emphasis} and \textbf{bold}.
-
-This second paragraph is separated by a blank line and should remain a distinct paragraph in the minimal typeset slice.
-
-\par This third paragraph is started with an explicit marker and should also remain distinct.
+This second paragraph is intentionally plain text and separated by a blank line so paragraph flow and first-line indentation are visible in the PDF preview.
 
 \end{document}


### PR DESCRIPTION
Summary
- add a small deterministic variable-width glyph metrics table in `carreltex-xdv`
- keep width-based wrapping deterministic while using per-byte widths (space/punctuation/narrow/wide letters)
- simplify the minimal typeset fixture to supported features (title/author/date, two paragraphs, bold/italic)

Proof
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml
- ./scripts/proof_wasm_typeset_minimal_v0.sh | tail -n 6
