### PR TITLE
Typeset minimal: collapse single newlines to spaces

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -310,7 +310,7 @@ fn consume_fragment_token_v0(
 ) -> Option<usize> {
     match tokens.get(index)? {
         TokenV0::Char(byte) if *byte == NEWLINE_MARKER_V0 => {
-            push_newline(out);
+            push_space(out);
             Some(index + 1)
         }
         TokenV0::Char(byte) => {

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -22,6 +22,18 @@ fn extract_typeset_body(main: &[u8]) -> Vec<u8> {
     extract_typeset_minimal_text_body_v0(&normalized).expect("extract should succeed")
 }
 
+fn layout_first_line_bytes(main: &[u8]) -> Vec<u8> {
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::Ok);
+    let layout =
+        parse_dvi_v2_text_page_to_layout_v0(&result.main_xdv_bytes, 917_504).expect("layout parse");
+    layout.pages[0].lines[0]
+        .glyphs
+        .iter()
+        .map(|glyph| glyph.byte)
+        .collect()
+}
+
 #[test]
 fn typeset_minimal_subset_compiles_ok() {
     let main = b"\\documentclass{article}\\title{CarrelTeX Minimal Typeset Demo}\\author{Alice \\and Bob}\\date{2026-03-04}\\begin{document}\\maketitle Hello, world. This is a paragraph with \\emph{emphasis} and \\textbf{bold}.\\end{document}";
@@ -89,4 +101,11 @@ fn typeset_minimal_long_paragraph_wraps_to_multiple_lines() {
         layout.pages.first().map(|page| page.lines.len()).unwrap_or(0) >= 2,
         "expected wrapped output with multiple lines"
     );
+}
+
+#[test]
+fn typeset_minimal_single_newline_collapses_to_space() {
+    let main = b"\\documentclass{article}\\begin{document}Hello,\nworld.\\end{document}";
+    let first_line = layout_first_line_bytes(main);
+    assert_eq!(first_line, b"Hello, world.");
 }

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -15,6 +15,7 @@
 
 Hello, world. This first paragraph includes \emph{emphasis} and \textbf{bold} in supported inline forms.
 
-This second paragraph is intentionally plain text and separated by a blank line so paragraph flow, first-line indentation, and width-sensitive wrapping are visible in the PDF preview with words like WWWW and iiiii.
+This second paragraph is intentionally plain text and separated by a blank line so paragraph flow,
+first-line indentation, and width-sensitive wrapping are visible in the PDF preview with words like WWWW and iiiii.
 
 \end{document}


### PR DESCRIPTION
Summary
- collapse single in-source newlines to spaces in typeset-minimal fragment extraction
- keep paragraph breaks only via blank-line/`\par` marker behavior and keep `\and` as author line separator
- add focused tests for newline-collapse behavior and keep fixture showing a mid-paragraph source newline

Proof
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- ./scripts/proof_wasm_typeset_minimal_v0.sh | tail -n 6
