### PR TITLE
Leaf 289b: typeset minimal hard line breaks

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -2,6 +2,7 @@ use crate::tex::tokenize_v0::TokenV0;
 
 const NEWLINE_MARKER_V0: u8 = 0x0a;
 const CARRELPAR_MARKER_CONTROL_V0: &[u8] = b"carrelpar";
+const HARD_LINE_BREAK_CONTROL_V0: &[u8] = b"\\";
 const ITALIC_START_MARKER_V0: u8 = b'[';
 const ITALIC_END_MARKER_V0: u8 = b']';
 const BOLD_START_MARKER_V0: u8 = b'{';
@@ -307,6 +308,7 @@ fn consume_fragment_token_v0(
     index: usize,
     out: &mut Vec<u8>,
     allow_and: bool,
+    allow_hard_break: bool,
 ) -> Option<usize> {
     match tokens.get(index)? {
         TokenV0::Char(byte) if *byte == NEWLINE_MARKER_V0 => {
@@ -328,6 +330,13 @@ fn consume_fragment_token_v0(
             push_newline(out);
             Some(index + 1)
         }
+        TokenV0::ControlSeq(name)
+            if allow_hard_break
+                && (name.as_slice().is_empty() || name.as_slice() == HARD_LINE_BREAK_CONTROL_V0) =>
+        {
+            push_newline(out);
+            Some(index + 1)
+        }
         TokenV0::ControlSeq(name) if name.as_slice() == b"protect" || name.as_slice() == b"relax" => {
             Some(index + 1)
         }
@@ -339,7 +348,7 @@ fn consume_fragment_token_v0(
             };
             let (group_start, group_end, next) = consume_group_bounds(tokens, index + 1)?;
             out.push(style_markers.0);
-            consume_fragment_range_v0(tokens, group_start, group_end, out, allow_and)?;
+            consume_fragment_range_v0(tokens, group_start, group_end, out, allow_and, allow_hard_break)?;
             out.push(style_markers.1);
             Some(next)
         }
@@ -353,10 +362,11 @@ fn consume_fragment_range_v0(
     end: usize,
     out: &mut Vec<u8>,
     allow_and: bool,
+    allow_hard_break: bool,
 ) -> Option<()> {
     let mut cursor = start;
     while cursor < end {
-        let next = consume_fragment_token_v0(tokens, cursor, out, allow_and)?;
+        let next = consume_fragment_token_v0(tokens, cursor, out, allow_and, allow_hard_break)?;
         if next <= cursor || next > end {
             return None;
         }
@@ -383,7 +393,7 @@ fn consume_meta_declaration_v0(
     }
     let (group_start, group_end, next) = consume_group_bounds(tokens, cursor)?;
     let mut value = Vec::new();
-    consume_fragment_range_v0(tokens, group_start, group_end, &mut value, allow_and)?;
+    consume_fragment_range_v0(tokens, group_start, group_end, &mut value, allow_and, false)?;
     trim_trailing_spaces(&mut value);
     if value.is_empty() {
         return None;
@@ -468,7 +478,7 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
                 index += 1;
             }
             Some(_) => {
-                index = consume_fragment_token_v0(tokens, index, &mut body, false)?;
+                index = consume_fragment_token_v0(tokens, index, &mut body, false, true)?;
             }
             None => return None,
         }

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -22,15 +22,15 @@ fn extract_typeset_body(main: &[u8]) -> Vec<u8> {
     extract_typeset_minimal_text_body_v0(&normalized).expect("extract should succeed")
 }
 
-fn layout_first_line_bytes(main: &[u8]) -> Vec<u8> {
+fn layout_lines_bytes(main: &[u8]) -> Vec<Vec<u8>> {
     let result = compile_typeset(main);
     assert_eq!(result.status, CompileStatus::Ok);
     let layout =
         parse_dvi_v2_text_page_to_layout_v0(&result.main_xdv_bytes, 917_504).expect("layout parse");
-    layout.pages[0].lines[0]
-        .glyphs
+    layout.pages[0]
+        .lines
         .iter()
-        .map(|glyph| glyph.byte)
+        .map(|line| line.glyphs.iter().map(|glyph| glyph.byte).collect())
         .collect()
 }
 
@@ -106,6 +106,15 @@ fn typeset_minimal_long_paragraph_wraps_to_multiple_lines() {
 #[test]
 fn typeset_minimal_single_newline_collapses_to_space() {
     let main = b"\\documentclass{article}\\begin{document}Hello,\nworld.\\end{document}";
-    let first_line = layout_first_line_bytes(main);
-    assert_eq!(first_line, b"Hello, world.");
+    let lines = layout_lines_bytes(main);
+    assert_eq!(lines[0], b"Hello, world.");
+}
+
+#[test]
+fn typeset_minimal_double_backslash_emits_hard_newline() {
+    let main = b"\\documentclass{article}\\begin{document}Hello\\\\world.\\end{document}";
+    let lines = layout_lines_bytes(main);
+    assert!(lines.len() >= 2, "expected at least two lines, got {:?}", lines);
+    assert_eq!(lines[0], b"Hello");
+    assert_eq!(lines[1], b"world.");
 }

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -15,7 +15,7 @@
 
 Hello, world. This first paragraph includes \emph{emphasis} and \textbf{bold} in supported inline forms.
 
-This second paragraph is intentionally plain text and separated by a blank line so paragraph flow,
+This second paragraph is intentionally plain text and separated by a blank line so paragraph flow,\\
 first-line indentation, and width-sensitive wrapping are visible in the PDF preview with words like WWWW and iiiii.
 
 \end{document}


### PR DESCRIPTION
## Summary
- treat explicit \\ in typeset-minimal body as a hard newline
- keep single source newlines collapsed to spaces
- add focused test + demo fixture hard-break sample

## Proof
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- ./scripts/proof_wasm_typeset_minimal_v0.sh | tail -n 6