### PR TITLE
Leaf 292: typeset minimal linebreak and pagebreak

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -1,10 +1,13 @@
 use crate::tex::tokenize_v0::TokenV0;
 
 const NEWLINE_MARKER_V0: u8 = 0x0a;
+const PAGE_BREAK_MARKER_V0: u8 = 0x0c;
 const CARRELPAR_MARKER_CONTROL_V0: &[u8] = b"carrelpar";
 const CARRELNEWLINE_MARKER_CONTROL_V0: &[u8] = b"carrelnewline";
 const HARD_LINE_BREAK_CONTROL_V0: &[u8] = b"\\";
 const NEWLINE_ALIAS_CONTROL_V0: &[u8] = b"newline";
+const LINEBREAK_ALIAS_CONTROL_V0: &[u8] = b"linebreak";
+const PAGEBREAK_ALIAS_CONTROL_V0: &[u8] = b"pagebreak";
 const ITALIC_START_MARKER_V0: u8 = b'[';
 const ITALIC_END_MARKER_V0: u8 = b']';
 const BOLD_START_MARKER_V0: u8 = b'{';
@@ -56,6 +59,13 @@ fn push_paragraph_break(out: &mut Vec<u8>) {
         out.push(NEWLINE_MARKER_V0);
     }
     out.push(NEWLINE_MARKER_V0);
+}
+
+fn push_page_break(out: &mut Vec<u8>) {
+    trim_trailing_spaces(out);
+    if !matches!(out.last().copied(), Some(PAGE_BREAK_MARKER_V0)) {
+        out.push(PAGE_BREAK_MARKER_V0);
+    }
 }
 
 fn is_horizontal_space_v0(byte: u8) -> bool {
@@ -315,6 +325,10 @@ fn consume_fragment_token_v0(
     allow_hard_break: bool,
 ) -> Option<usize> {
     match tokens.get(index)? {
+        TokenV0::Char(byte) if allow_hard_break && *byte == PAGE_BREAK_MARKER_V0 => {
+            push_page_break(out);
+            Some(index + 1)
+        }
         TokenV0::Char(byte) if *byte == NEWLINE_MARKER_V0 => {
             push_space(out);
             Some(index + 1)
@@ -339,9 +353,16 @@ fn consume_fragment_token_v0(
                 && (name.as_slice().is_empty()
                     || name.as_slice() == HARD_LINE_BREAK_CONTROL_V0
                     || name.as_slice() == NEWLINE_ALIAS_CONTROL_V0
+                    || name.as_slice() == LINEBREAK_ALIAS_CONTROL_V0
                     || name.as_slice() == CARRELNEWLINE_MARKER_CONTROL_V0) =>
         {
             push_newline(out);
+            Some(index + 1)
+        }
+        TokenV0::ControlSeq(name)
+            if allow_hard_break && name.as_slice() == PAGEBREAK_ALIAS_CONTROL_V0 =>
+        {
+            push_page_break(out);
             Some(index + 1)
         }
         TokenV0::ControlSeq(name) if name.as_slice() == b"protect" || name.as_slice() == b"relax" => {

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -127,3 +127,34 @@ fn typeset_minimal_newline_alias_emits_hard_newline() {
     assert_eq!(lines[0], b"Hello");
     assert_eq!(lines[1], b"world.");
 }
+
+#[test]
+fn typeset_minimal_linebreak_alias_emits_hard_newline() {
+    let main = b"\\documentclass{article}\\begin{document}Hello\\linebreak world.\\end{document}";
+    let lines = layout_lines_bytes(main);
+    assert!(lines.len() >= 2, "expected at least two lines, got {:?}", lines);
+    assert_eq!(lines[0], b"Hello");
+    assert_eq!(lines[1], b"world.");
+}
+
+#[test]
+fn typeset_minimal_pagebreak_alias_emits_forced_page_split() {
+    let main = b"\\documentclass{article}\\begin{document}A\\pagebreak B\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::Ok);
+    let layout =
+        parse_dvi_v2_text_page_to_layout_v0(&result.main_xdv_bytes, 917_504).expect("layout parse");
+    assert_eq!(layout.pages.len(), 2);
+    let first_line: Vec<u8> = layout.pages[0].lines[0]
+        .glyphs
+        .iter()
+        .map(|glyph| glyph.byte)
+        .collect();
+    let second_line: Vec<u8> = layout.pages[1].lines[0]
+        .glyphs
+        .iter()
+        .map(|glyph| glyph.byte)
+        .collect();
+    assert_eq!(first_line, b"A");
+    assert_eq!(second_line, b"B");
+}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -15,7 +15,7 @@
 
 Hello, world. This first paragraph includes \emph{emphasis} and \textbf{bold} in supported inline forms.
 
-This second paragraph is intentionally plain text and separated by a blank line so paragraph flow,\newline
+This second paragraph is intentionally plain text and separated by a blank line so paragraph flow,\linebreak
 first-line indentation, and width-sensitive wrapping are visible in the PDF preview with words like WWWW and iiiii.
 
 \end{document}


### PR DESCRIPTION
## Summary
- add  hard line break support in typeset-minimal body
- add  forced page split support in typeset-minimal body
- add focused tests and fixture coverage

## Proof
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- ./scripts/proof_wasm_typeset_minimal_v0.sh | tail -n 6