### PR TITLE
Leaf 293: use Helvetica in PDF preview

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -284,17 +284,17 @@ fn build_pdf_for_pages_v0(pages: &[Vec<Vec<u8>>]) -> Vec<u8> {
     offsets.push(write_pdf_obj(
         &mut out,
         font_regular_id,
-        b"<< /Type /Font /Subtype /Type1 /BaseFont /Courier >>",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
     ));
     offsets.push(write_pdf_obj(
         &mut out,
         font_italic_id,
-        b"<< /Type /Font /Subtype /Type1 /BaseFont /Courier-Oblique >>",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Oblique >>",
     ));
     offsets.push(write_pdf_obj(
         &mut out,
         font_bold_id,
-        b"<< /Type /Font /Subtype /Type1 /BaseFont /Courier-Bold >>",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>",
     ));
 
     let xref_offset = out.len() as u32;

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -294,6 +294,21 @@ fn pdf_renderer_emits_valid_header_and_contains_text() {
 }
 
 #[test]
+fn pdf_renderer_uses_helvetica_base_fonts_v0() {
+    let bytes = write_dvi_v2_text_page_v0(b"A [B] {C}").expect("writer should accept text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&bytes).expect("pdf render");
+    assert!(pdf.windows(b"/Helvetica".len()).any(|w| w == b"/Helvetica"));
+    assert!(
+        pdf.windows(b"/Helvetica-Oblique".len())
+            .any(|w| w == b"/Helvetica-Oblique")
+    );
+    assert!(
+        pdf.windows(b"/Helvetica-Bold".len())
+            .any(|w| w == b"/Helvetica-Bold")
+    );
+}
+
+#[test]
 fn pdf_renderer_applies_maketitle_typography_v0() {
     let demo_text =
         b"CarrelTeX Minimal Typeset Vertical Slice\nAlice\n2026-03-04\n\nBody paragraph line.";


### PR DESCRIPTION
## Summary
- switch PDF preview base fonts from Courier family to Helvetica family
- preserve existing Regular/Italic/Bold style mapping
- add deterministic test coverage for Helvetica font objects

## Proof
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml
- ./scripts/proof_wasm_typeset_minimal_v0.sh | tail -n 6
