### PR TITLE
Leaf 295: typeset minimal punctuation spacing

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -332,26 +332,24 @@ fn normalize_punctuation_spacing_v0(body: &[u8]) -> Vec<u8> {
     while index < body.len() {
         let byte = body[index];
         out.push(byte);
+        index += 1;
         if !is_punctuation_spacing_target_v0(byte) {
-            index += 1;
             continue;
         }
 
-        let mut cursor = index + 1;
-        if cursor >= body.len() || !is_spacing_or_newline_v0(body[cursor]) {
-            index += 1;
+        if index >= body.len() || !is_spacing_or_newline_v0(body[index]) {
             continue;
         }
 
         let mut saw_space = false;
         let mut newline_count = 0usize;
-        while cursor < body.len() && is_spacing_or_newline_v0(body[cursor]) {
-            match body[cursor] {
+        while index < body.len() && is_spacing_or_newline_v0(body[index]) {
+            match body[index] {
                 b' ' => saw_space = true,
                 NEWLINE_MARKER_V0 => newline_count += 1,
                 _ => {}
             }
-            cursor += 1;
+            index += 1;
         }
 
         if newline_count >= 2 {
@@ -359,11 +357,9 @@ fn normalize_punctuation_spacing_v0(body: &[u8]) -> Vec<u8> {
             out.push(NEWLINE_MARKER_V0);
         } else if newline_count == 1 {
             out.push(NEWLINE_MARKER_V0);
-        } else if saw_space && cursor < body.len() && body[cursor] != PAGE_BREAK_MARKER_V0 {
+        } else if saw_space && index < body.len() && body[index] != PAGE_BREAK_MARKER_V0 {
             out.push(b' ');
         }
-
-        index = cursor;
     }
 
     out

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -121,6 +121,15 @@ fn typeset_minimal_punctuation_does_not_cross_paragraph_break() {
 }
 
 #[test]
+fn typeset_minimal_punctuation_collapses_following_spaces_to_one() {
+    let main = b"\\documentclass{article}\\begin{document}Hello,    world.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("Hello, world."), "body={text:?}");
+    assert!(!text.contains("Hello,  world."), "body={text:?}");
+}
+
+#[test]
 fn typeset_minimal_double_backslash_emits_hard_newline() {
     let main = b"\\documentclass{article}\\begin{document}Hello\\\\world.\\end{document}";
     let lines = layout_lines_bytes(main);


### PR DESCRIPTION
## Summary
- add punctuation-spacing normalization post-pass in typeset-minimal extraction
- keep paragraph/page/hard-break semantics fail-closed and deterministic
- add focused tests for punctuation spacing behavior around single and blank-line breaks

## Proof
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- ./scripts/proof_wasm_typeset_minimal_v0.sh | tail -n 6
