### PR TITLE
Leaf 297: normalize TeX dash sequences

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -385,6 +385,32 @@ fn normalize_tex_double_quotes_v0(body: &[u8]) -> Vec<u8> {
     out
 }
 
+fn normalize_tex_dashes_v0(body: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(body.len());
+    let mut index = 0usize;
+
+    while index < body.len() {
+        if index + 2 < body.len()
+            && body[index] == b'-'
+            && body[index + 1] == b'-'
+            && body[index + 2] == b'-'
+        {
+            out.extend_from_slice("—".as_bytes());
+            index += 3;
+            continue;
+        }
+        if index + 1 < body.len() && body[index] == b'-' && body[index + 1] == b'-' {
+            out.extend_from_slice("–".as_bytes());
+            index += 2;
+            continue;
+        }
+        out.push(body[index]);
+        index += 1;
+    }
+
+    out
+}
+
 fn consume_fragment_token_v0(
     tokens: &[TokenV0],
     index: usize,
@@ -589,6 +615,7 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
 
     body = normalize_punctuation_spacing_v0(&body);
     body = normalize_tex_double_quotes_v0(&body);
+    body = normalize_tex_dashes_v0(&body);
     trim_trailing_spaces(&mut body);
     while matches!(body.last().copied(), Some(NEWLINE_MARKER_V0)) {
         body.pop();

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -140,6 +140,16 @@ fn typeset_minimal_tex_double_quotes_normalize_to_ascii_quote() {
 }
 
 #[test]
+fn typeset_minimal_tex_dashes_normalize_to_unicode_dashes() {
+    let main = b"\\documentclass{article}\\begin{document}A---B--C\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("A—B–C"), "body={text:?}");
+    assert!(!text.contains("---"), "body={text:?}");
+    assert!(!text.contains("--"), "body={text:?}");
+}
+
+#[test]
 fn typeset_minimal_double_backslash_emits_hard_newline() {
     let main = b"\\documentclass{article}\\begin{document}Hello\\\\world.\\end{document}";
     let lines = layout_lines_bytes(main);


### PR DESCRIPTION
## Summary
- add typeset-minimal post-pass normalization for TeX dash sequences (`---` -> em dash, `--` -> en dash)
- keep normalization deterministic and scoped to typeset-minimal extraction output bytes
- add focused dash normalization test coverage

## Proof
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- ./scripts/proof_wasm_typeset_minimal_v0.sh | tail -n 6
