### PR TITLE
Typeset minimal: normalize ellipsis

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -411,6 +411,27 @@ fn normalize_tex_dashes_v0(body: &[u8]) -> Vec<u8> {
     out
 }
 
+fn normalize_tex_ellipsis_v0(body: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(body.len());
+    let mut index = 0usize;
+
+    while index < body.len() {
+        if index + 2 < body.len()
+            && body[index] == b'.'
+            && body[index + 1] == b'.'
+            && body[index + 2] == b'.'
+        {
+            out.extend_from_slice("…".as_bytes());
+            index += 3;
+            continue;
+        }
+        out.push(body[index]);
+        index += 1;
+    }
+
+    out
+}
+
 fn consume_fragment_token_v0(
     tokens: &[TokenV0],
     index: usize,
@@ -616,6 +637,7 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
     body = normalize_punctuation_spacing_v0(&body);
     body = normalize_tex_double_quotes_v0(&body);
     body = normalize_tex_dashes_v0(&body);
+    body = normalize_tex_ellipsis_v0(&body);
     trim_trailing_spaces(&mut body);
     while matches!(body.last().copied(), Some(NEWLINE_MARKER_V0)) {
         body.pop();

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -150,6 +150,15 @@ fn typeset_minimal_tex_dashes_normalize_to_unicode_dashes() {
 }
 
 #[test]
+fn typeset_minimal_tex_ellipsis_normalizes_to_unicode_ellipsis() {
+    let main = b"\\documentclass{article}\\begin{document}Wait... done.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("Wait… done."), "body={text:?}");
+    assert!(!text.contains("..."), "body={text:?}");
+}
+
+#[test]
 fn typeset_minimal_double_backslash_emits_hard_newline() {
     let main = b"\\documentclass{article}\\begin{document}Hello\\\\world.\\end{document}";
     let lines = layout_lines_bytes(main);


### PR DESCRIPTION
Summary
- Normalize `...` to Unicode ellipsis `…` in typeset-minimal.

Proof
- `cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests` PASS
- `./scripts/proof_wasm_typeset_minimal_v0.sh | tail -n 6` PASS

Frozen head
- 89eee6acbe0e6532a112064365d36501b9abf777
