### PR TITLE
Typeset minimal: normalize parentheses spacing

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -432,6 +432,50 @@ fn normalize_tex_ellipsis_v0(body: &[u8]) -> Vec<u8> {
     out
 }
 
+fn normalize_parentheses_spacing_v0(body: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(body.len());
+    let mut index = 0usize;
+
+    while index < body.len() {
+        let byte = body[index];
+        if byte == b'(' {
+            out.push(byte);
+            index += 1;
+
+            let spaces_start = index;
+            while index < body.len() && body[index] == b' ' {
+                index += 1;
+            }
+            if spaces_start < index {
+                if index >= body.len()
+                    || body[index] == NEWLINE_MARKER_V0
+                    || body[index] == PAGE_BREAK_MARKER_V0
+                {
+                    out.extend_from_slice(&body[spaces_start..index]);
+                }
+            }
+            continue;
+        }
+
+        if byte == b' ' {
+            let spaces_start = index;
+            while index < body.len() && body[index] == b' ' {
+                index += 1;
+            }
+            if index < body.len() && body[index] == b')' {
+                continue;
+            }
+            out.extend_from_slice(&body[spaces_start..index]);
+            continue;
+        }
+
+        out.push(byte);
+        index += 1;
+    }
+
+    out
+}
+
 fn consume_fragment_token_v0(
     tokens: &[TokenV0],
     index: usize,
@@ -638,6 +682,7 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
     body = normalize_tex_double_quotes_v0(&body);
     body = normalize_tex_dashes_v0(&body);
     body = normalize_tex_ellipsis_v0(&body);
+    body = normalize_parentheses_spacing_v0(&body);
     trim_trailing_spaces(&mut body);
     while matches!(body.last().copied(), Some(NEWLINE_MARKER_V0)) {
         body.pop();

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -159,6 +159,23 @@ fn typeset_minimal_tex_ellipsis_normalizes_to_unicode_ellipsis() {
 }
 
 #[test]
+fn typeset_minimal_parentheses_remove_inner_spaces_same_line() {
+    let main = b"\\documentclass{article}\\begin{document}( A )\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("(A)"), "body={text:?}");
+    assert!(!text.contains("( A )"), "body={text:?}");
+}
+
+#[test]
+fn typeset_minimal_parentheses_do_not_strip_across_hard_newline() {
+    let main = b"\\documentclass{article}\n\\begin{document}\n( \\newline A )\n\\end{document}\n";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("(\nA)"), "body={text:?}");
+}
+
+#[test]
 fn typeset_minimal_double_backslash_emits_hard_newline() {
     let main = b"\\documentclass{article}\\begin{document}Hello\\\\world.\\end{document}";
     let lines = layout_lines_bytes(main);


### PR DESCRIPTION
Summary
- Normalize spacing around parentheses in typeset-minimal: remove spaces after `(` and before `)` (without crossing newlines/page breaks).

Proof
- `cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests` PASS
- `./scripts/proof_wasm_typeset_minimal_v0.sh | tail -n 6` PASS

Frozen head
- 8797ad0ee8c0911e888c3adcbb8c258f9ee6341e
