### PR TITLE
Typeset minimal: normalize spacing around brackets

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -432,13 +432,26 @@ fn normalize_tex_ellipsis_v0(body: &[u8]) -> Vec<u8> {
     out
 }
 
-fn normalize_parentheses_spacing_v0(body: &[u8]) -> Vec<u8> {
+fn opening_bracket_closer_v0(byte: u8) -> Option<u8> {
+    match byte {
+        b'(' => Some(b')'),
+        b'[' => Some(b']'),
+        b'{' => Some(b'}'),
+        _ => None,
+    }
+}
+
+fn is_closing_bracket_v0(byte: u8) -> bool {
+    matches!(byte, b')' | b']' | b'}')
+}
+
+fn normalize_bracket_spacing_v0(body: &[u8]) -> Vec<u8> {
     let mut out = Vec::with_capacity(body.len());
     let mut index = 0usize;
 
     while index < body.len() {
         let byte = body[index];
-        if byte == b'(' {
+        if opening_bracket_closer_v0(byte).is_some() {
             out.push(byte);
             index += 1;
 
@@ -462,7 +475,7 @@ fn normalize_parentheses_spacing_v0(body: &[u8]) -> Vec<u8> {
             while index < body.len() && body[index] == b' ' {
                 index += 1;
             }
-            if index < body.len() && body[index] == b')' {
+            if index < body.len() && is_closing_bracket_v0(body[index]) {
                 continue;
             }
             out.extend_from_slice(&body[spaces_start..index]);
@@ -682,7 +695,7 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
     body = normalize_tex_double_quotes_v0(&body);
     body = normalize_tex_dashes_v0(&body);
     body = normalize_tex_ellipsis_v0(&body);
-    body = normalize_parentheses_spacing_v0(&body);
+    body = normalize_bracket_spacing_v0(&body);
     trim_trailing_spaces(&mut body);
     while matches!(body.last().copied(), Some(NEWLINE_MARKER_V0)) {
         body.pop();

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -176,6 +176,25 @@ fn typeset_minimal_parentheses_do_not_strip_across_hard_newline() {
 }
 
 #[test]
+fn typeset_minimal_brackets_and_braces_remove_inner_spaces_same_line() {
+    let main = b"\\documentclass{article}\\begin{document}\\emph{ A } \\textbf{ B }\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("[A] {B}"), "body={text:?}");
+    assert!(!text.contains("[ A ]"), "body={text:?}");
+    assert!(!text.contains("{ B }"), "body={text:?}");
+}
+
+#[test]
+fn typeset_minimal_brackets_and_braces_do_not_strip_across_hard_newline() {
+    let main =
+        b"\\documentclass{article}\n\\begin{document}\n\\emph{\\textbf{ \\newline A }}\n\\end{document}\n";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("[{\nA}]"), "body={text:?}");
+}
+
+#[test]
 fn typeset_minimal_double_backslash_emits_hard_newline() {
     let main = b"\\documentclass{article}\\begin{document}Hello\\\\world.\\end{document}";
     let lines = layout_lines_bytes(main);


### PR DESCRIPTION
Summary\n- Normalize spacing around () [] and literal {} bytes in typeset-minimal body post-pass.\n- Keep newline/pagebreak boundaries intact.\n- Add focused tests for same-line normalization and hard-newline boundary behavior.\n\nProof\n- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests PASS\n- ./scripts/proof_wasm_typeset_minimal_v0.sh | tail -n 6 PASS