### PR TITLE
Typeset minimal: heading controls bundle

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -12,6 +12,11 @@ const ITALIC_START_MARKER_V0: u8 = b'[';
 const ITALIC_END_MARKER_V0: u8 = b']';
 const BOLD_START_MARKER_V0: u8 = b'{';
 const BOLD_END_MARKER_V0: u8 = b'}';
+const SECTION_CONTROL_V0: &[u8] = b"section";
+const SUBSECTION_CONTROL_V0: &[u8] = b"subsection";
+const SUBSUBSECTION_CONTROL_V0: &[u8] = b"subsubsection";
+const PARAGRAPH_CONTROL_V0: &[u8] = b"paragraph";
+const SUBPARAGRAPH_CONTROL_V0: &[u8] = b"subparagraph";
 
 #[derive(Default)]
 struct TitleMetaV0 {
@@ -575,6 +580,33 @@ fn consume_fragment_range_v0(
     Some(())
 }
 
+fn is_heading_control_v0(name: &[u8]) -> bool {
+    name == SECTION_CONTROL_V0
+        || name == SUBSECTION_CONTROL_V0
+        || name == SUBSUBSECTION_CONTROL_V0
+        || name == PARAGRAPH_CONTROL_V0
+        || name == SUBPARAGRAPH_CONTROL_V0
+}
+
+fn consume_heading_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+    let TokenV0::ControlSeq(name) = tokens.get(index)? else {
+        return None;
+    };
+    if !is_heading_control_v0(name.as_slice()) {
+        return None;
+    }
+    let (group_start, group_end, next) = consume_group_bounds(tokens, index + 1)?;
+    let mut heading = Vec::new();
+    consume_fragment_range_v0(tokens, group_start, group_end, &mut heading, false, true)?;
+    trim_trailing_spaces(&mut heading);
+    push_paragraph_break(out);
+    out.push(BOLD_START_MARKER_V0);
+    out.extend_from_slice(&heading);
+    out.push(BOLD_END_MARKER_V0);
+    push_paragraph_break(out);
+    Some(next)
+}
+
 fn consume_meta_declaration_v0(
     tokens: &[TokenV0],
     index: usize,
@@ -676,6 +708,9 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == CARRELPAR_MARKER_CONTROL_V0 => {
                 push_paragraph_break(&mut body);
                 index += 1;
+            }
+            Some(TokenV0::ControlSeq(name)) if is_heading_control_v0(name.as_slice()) => {
+                index = consume_heading_command_v0(tokens, index, &mut body)?;
             }
             Some(_) => {
                 index = consume_fragment_token_v0(tokens, index, &mut body, false, true)?;

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -45,7 +45,7 @@ fn typeset_minimal_subset_compiles_ok() {
 
 #[test]
 fn typeset_minimal_rejects_unsupported_control_sequence() {
-    let main = b"\\documentclass{article}\\begin{document}\\section{X}\\end{document}";
+    let main = b"\\documentclass{article}\\begin{document}\\foo{X}\\end{document}";
     let result = compile_typeset(main);
     assert_eq!(result.status, CompileStatus::NotImplemented);
     assert!(result.main_xdv_bytes.is_empty());
@@ -88,6 +88,26 @@ fn typeset_minimal_author_and_is_single_newline() {
     let text = String::from_utf8(body).expect("body should be valid utf8");
     assert!(!text.contains("Alice\n\nBob"), "body={text:?}");
     assert!(text.contains("Alice\nBob"), "body={text:?}");
+}
+
+#[test]
+fn typeset_minimal_headings_emit_bold_with_paragraph_breaks() {
+    let main = b"\\documentclass{article}\\begin{document}Before.\\section{Intro}\\subsection{A \\emph{B}}After.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("Before.\n\n{Intro}\n\n{A [B]}\n\nAfter."),
+        "body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_heading_at_start_has_no_leading_blank_lines() {
+    let main =
+        b"\\documentclass{article}\\begin{document}\\paragraph{Lead in}Body text.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.starts_with("{Lead in}\n\nBody text."), "body={text:?}");
 }
 
 #[test]

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -13,8 +13,10 @@
 \begin{document}
 \maketitle
 
+\section{Overview}
 Hello, world. This first paragraph includes \emph{emphasis} and \textbf{bold} in supported inline forms.
 
+\subsection{Demonstration}
 This second paragraph is intentionally plain text and separated by a blank line so paragraph flow,\linebreak
 first-line indentation, and width-sensitive wrapping are visible in the PDF preview with words like WWWW and iiiii.
 


### PR DESCRIPTION
## Summary
- Add body heading support for \section, \subsection, \subsubsection, \paragraph, \subparagraph in typeset-minimal extraction.
- Emit headings as bold markers with paragraph break before/after.
- Extend focused tests and demo fixture for heading rendering.

## Proof
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests PASS
- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 6 PASS