### PR TITLE
XDV: style markers as zero-width glyphs

### DIFF
--- a/crates/carreltex-xdv/src/layout_v0.rs
+++ b/crates/carreltex-xdv/src/layout_v0.rs
@@ -1,5 +1,9 @@
 const PAGEBREAK_MARKER_V0: u8 = 0x0c;
 const NEWLINE_MARKER_V0: u8 = 0x0a;
+const ITALIC_START_MARKER_V0: u8 = b'[';
+const ITALIC_END_MARKER_V0: u8 = b']';
+const BOLD_START_MARKER_V0: u8 = b'{';
+const BOLD_END_MARKER_V0: u8 = b'}';
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LayoutPlanV0 {
@@ -27,6 +31,13 @@ fn is_supported_text_byte_v0(byte: u8) -> bool {
     (0x20..=0x7e).contains(&byte)
 }
 
+pub(crate) fn is_style_marker_byte_v0(byte: u8) -> bool {
+    matches!(
+        byte,
+        ITALIC_START_MARKER_V0 | ITALIC_END_MARKER_V0 | BOLD_START_MARKER_V0 | BOLD_END_MARKER_V0
+    )
+}
+
 fn glyph_width_ratio_v0(byte: u8) -> (u32, u32) {
     match byte {
         b' ' => (1, 2),
@@ -40,6 +51,9 @@ fn glyph_width_ratio_v0(byte: u8) -> (u32, u32) {
 pub(crate) fn glyph_width_sp_v0(byte: u8, glyph_advance_sp: i32) -> Option<i32> {
     if glyph_advance_sp <= 0 {
         return None;
+    }
+    if is_style_marker_byte_v0(byte) {
+        return Some(0);
     }
     let (num, den) = glyph_width_ratio_v0(byte);
     let glyph_advance = i64::from(glyph_advance_sp);
@@ -56,8 +70,14 @@ pub(crate) fn glyph_width_sp_v0(byte: u8, glyph_advance_sp: i32) -> Option<i32> 
 pub fn recompute_line_width_sp_v0(line: &LinePlanV0) -> Option<u32> {
     let mut total = 0u32;
     for glyph in &line.glyphs {
-        if glyph.advance_sp <= 0 || glyph.advance_sp > 8_388_607 {
+        if glyph.advance_sp < 0 || glyph.advance_sp > 8_388_607 {
             return None;
+        }
+        if glyph.advance_sp == 0 {
+            if !is_style_marker_byte_v0(glyph.byte) {
+                return None;
+            }
+            continue;
         }
         total = total.checked_add(u32::try_from(glyph.advance_sp).ok()?)?;
     }

--- a/crates/carreltex-xdv/src/lib.rs
+++ b/crates/carreltex-xdv/src/lib.rs
@@ -27,7 +27,7 @@ pub use layout_v0::{
     PagePlanV0,
 };
 pub use pdf_v0::render_dvi_v2_text_page_to_pdf_v0;
-use layout_v0::glyph_width_sp_v0;
+use layout_v0::{glyph_width_sp_v0, is_style_marker_byte_v0};
 
 fn push_u32_be(out: &mut Vec<u8>, value: u32) {
     out.extend_from_slice(&value.to_be_bytes());
@@ -231,13 +231,18 @@ fn emit_line_plan_v0(out: &mut Vec<u8>, line: &LinePlanV0) -> Option<u32> {
     }
     let mut emitted_width = 0u32;
     for glyph in &line.glyphs {
-        if !is_supported_text_byte_v0(glyph.byte) || glyph.advance_sp <= 0 {
+        if !is_supported_text_byte_v0(glyph.byte) || glyph.advance_sp < 0 {
+            return None;
+        }
+        if glyph.advance_sp == 0 && !is_style_marker_byte_v0(glyph.byte) {
             return None;
         }
         out.push(glyph.byte);
         out.push(DVI_RIGHT3);
         push_i24_be(out, glyph.advance_sp)?;
-        emitted_width = emitted_width.checked_add(u32::try_from(glyph.advance_sp).ok()?)?;
+        if glyph.advance_sp > 0 {
+            emitted_width = emitted_width.checked_add(u32::try_from(glyph.advance_sp).ok()?)?;
+        }
     }
     if emitted_width != line.width_sp {
         return None;
@@ -548,12 +553,20 @@ fn parse_dvi_v2_text_page_internal_v0(
                 right3_count = right3_count.checked_add(1)?;
                 index += 1;
                 let amount = read_i24_be(bytes, &mut index)?;
-                if amount <= 0 {
+                if amount < 0 {
                     return None;
                 }
-                let amount_u32 = u32::try_from(amount).ok()?;
-                current_line_width = current_line_width.checked_add(amount_u32)?;
-                page_h = page_h.checked_add(amount_u32)?;
+                if is_style_marker_byte_v0(pending_byte) {
+                    if amount != 0 {
+                        return None;
+                    }
+                } else if amount == 0 {
+                    return None;
+                } else {
+                    let amount_u32 = u32::try_from(amount).ok()?;
+                    current_line_width = current_line_width.checked_add(amount_u32)?;
+                    page_h = page_h.checked_add(amount_u32)?;
+                }
                 current_glyphs.push(GlyphPlanV0 {
                     byte: pending_byte,
                     advance_sp: amount,

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -185,6 +185,33 @@ fn planner_width_uses_variable_space_width_v0() {
 }
 
 #[test]
+fn style_markers_have_zero_advance_and_roundtrip_v0() {
+    let layout = plan_layout_width_v0(b"A [B] {C}", 65_536, 786_432, 10_000_000, 200)
+        .expect("layout plan");
+    assert_eq!(layout.pages.len(), 1);
+    assert_eq!(layout.pages[0].lines.len(), 1);
+    let line = &layout.pages[0].lines[0];
+
+    for glyph in &line.glyphs {
+        if matches!(glyph.byte, b'[' | b']' | b'{' | b'}') {
+            assert_eq!(glyph.advance_sp, 0);
+        } else {
+            assert!(glyph.advance_sp > 0);
+        }
+    }
+
+    let xdv = write_dvi_v2_text_page_from_layout_v0(&layout, 786_432).expect("xdv bytes");
+    let parsed = parse_dvi_v2_text_page_to_layout_v0(&xdv, 786_432).expect("parsed layout");
+    assert_eq!(parsed, layout);
+    assert!(validate_dvi_v2_text_page_matches_layout_v0(
+        &xdv, &layout, 786_432
+    ));
+    assert!(validate_dvi_v2_text_page_with_layout_v0(
+        &xdv, 65_536, 786_432
+    ));
+}
+
+#[test]
 fn pdf_renderer_keeps_multi_space_line_unwrapped_under_width_limit_v0() {
     let layout =
         plan_layout_width_v0(b"A     B", 65_536, 786_432, 300_000, 200).expect("layout plan");


### PR DESCRIPTION
## Summary
- Make style marker bytes (`[ ] { }`) zero-width in layout planning.
- Emit marker bytes in DVI with RIGHT3 amount 0.
- Validate RIGHT3 amount 0 only for style marker bytes in parser/validator.
- Add regression test for zero-width marker roundtrip.

## Proof
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml PASS
- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 6 PASS
