### PR TITLE
PDF preview: hanging indent for list continuation lines

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -164,6 +164,31 @@ fn centered_line_x_v0(line_width_pt: f32) -> f32 {
     centered.clamp(MARGIN_PT_V0, PAGE_WIDTH_PT_V0 - MARGIN_PT_V0)
 }
 
+fn detect_list_prefix_advance_pt_v0(line: &LinePlanV0) -> Option<f32> {
+    if line.glyphs.len() >= 2 && line.glyphs[0].byte == b'-' && line.glyphs[1].byte == b' ' {
+        let prefix_sp = line.glyphs[0]
+            .advance_sp
+            .checked_add(line.glyphs[1].advance_sp)?;
+        return Some((prefix_sp as f32) / 65_536.0);
+    }
+
+    let mut index = 0usize;
+    while index < line.glyphs.len() && line.glyphs[index].byte.is_ascii_digit() {
+        index += 1;
+    }
+    if index == 0 || index + 1 >= line.glyphs.len() {
+        return None;
+    }
+    if line.glyphs[index].byte != b'.' || line.glyphs[index + 1].byte != b' ' {
+        return None;
+    }
+    let mut prefix_sp = 0i32;
+    for glyph in &line.glyphs[..=index + 1] {
+        prefix_sp = prefix_sp.checked_add(glyph.advance_sp)?;
+    }
+    Some((prefix_sp as f32) / 65_536.0)
+}
+
 fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
     let mut out = Vec::new();
     out.extend_from_slice(b"BT\n");
@@ -173,6 +198,7 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
     let mut y = PAGE_HEIGHT_PT_V0 - MARGIN_PT_V0 - TITLE_FONT_SIZE_PT_V0;
     let mut previous_rendered_line_was_empty = false;
     let mut skip_indent_after_title_block = title_block_len > 0;
+    let mut active_hang_indent_pt = 0.0f32;
     for (line_index, line) in lines.iter().enumerate() {
         if y < MARGIN_PT_V0 {
             break;
@@ -187,8 +213,18 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
         };
         if !line_is_empty {
             let line_width_pt = (line.width_sp as f32) / 65_536.0;
+            let list_prefix_advance_pt = if in_title_block {
+                None
+            } else {
+                detect_list_prefix_advance_pt_v0(line)
+            };
             let line_x = if in_title_block {
                 centered_line_x_v0(line_width_pt)
+            } else if let Some(prefix_advance_pt) = list_prefix_advance_pt {
+                active_hang_indent_pt = prefix_advance_pt;
+                MARGIN_PT_V0
+            } else if active_hang_indent_pt > 0.0 {
+                MARGIN_PT_V0 + active_hang_indent_pt
             } else if previous_rendered_line_was_empty && !skip_indent_after_title_block {
                 MARGIN_PT_V0 + INDENT_PT_V0
             } else {
@@ -216,6 +252,8 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
             if !in_title_block && skip_indent_after_title_block {
                 skip_indent_after_title_block = false;
             }
+        } else {
+            active_hang_indent_pt = 0.0;
         }
         previous_rendered_line_was_empty = line_is_empty;
         y -= LEADING_PT_V0;

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -224,6 +224,30 @@ fn pdf_renderer_keeps_multi_space_line_unwrapped_under_width_limit_v0() {
 }
 
 #[test]
+fn pdf_renderer_applies_hanging_indent_for_list_continuation_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"- item\ncontinuation").expect("writer should accept text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    let mut xs = Vec::<f32>::new();
+    for line in pdf_text.lines() {
+        if !line.contains(" Tm ") {
+            continue;
+        }
+        let fields = line.split_whitespace().collect::<Vec<_>>();
+        if fields.len() < 7 || fields[6] != "Tm" {
+            continue;
+        }
+        if let Ok(x_pt) = fields[4].parse::<f32>() {
+            xs.push(x_pt);
+        }
+    }
+    assert!(xs.len() >= 2, "expected at least two text lines, got {xs:?}");
+    assert!((xs[0] - 72.0).abs() <= 0.02, "first list line x={}", xs[0]);
+    assert!(xs[1] > xs[0], "continuation should hang-indent: {xs:?}");
+}
+
+#[test]
 fn parse_roundtrips_writer_layout_for_wrap_and_paging() {
     let text = b"word word word word word word word word word word";
     let layout = plan_layout_v0(text, 65_536, 786_432, 10, 1).expect("layout plan");


### PR DESCRIPTION
## Summary
- Add deterministic hanging-indent behavior for list lines in PDF preview renderer.
- Detect list prefixes (`- ` and `n. `) using glyph advances and carry indent to continuation lines.
- Reset hanging indent on blank lines while keeping title/paragraph behavior unchanged.
- Add focused renderer test asserting continuation line x-position is indented.

## Proof
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml PASS
- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 6 PASS
