### PR TITLE
Typeset minimal: quote environment with preview indent

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -14,6 +14,7 @@ const ITEM_CONTROL_V0: &[u8] = b"item";
 const DOCUMENT_ENV_V0: &[u8] = b"document";
 const ITEMIZE_ENV_V0: &[u8] = b"itemize";
 const ENUMERATE_ENV_V0: &[u8] = b"enumerate";
+const QUOTE_ENV_V0: &[u8] = b"quote";
 const ITALIC_START_MARKER_V0: u8 = b'[';
 const ITALIC_END_MARKER_V0: u8 = b']';
 const BOLD_START_MARKER_V0: u8 = b'{';
@@ -689,6 +690,71 @@ fn consume_list_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u
     }
 }
 
+fn prefix_quote_lines_v0(content: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(content.len().saturating_add(8));
+    let mut at_line_start = true;
+    for &byte in content {
+        if matches!(byte, NEWLINE_MARKER_V0 | PAGE_BREAK_MARKER_V0) {
+            out.push(byte);
+            at_line_start = true;
+            continue;
+        }
+        if at_line_start {
+            out.extend_from_slice(b"> ");
+            at_line_start = false;
+        }
+        out.push(byte);
+    }
+    out
+}
+
+fn consume_quote_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+    let (env_name, mut cursor) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
+    if env_name.as_slice() != QUOTE_ENV_V0 {
+        return None;
+    }
+
+    push_paragraph_break(out);
+    let mut quoted = Vec::<u8>::new();
+    loop {
+        match tokens.get(cursor) {
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == END_CONTROL_V0 => {
+                let (end_env, next) = consume_env_name_command_v0(tokens, cursor, END_CONTROL_V0)?;
+                if end_env.as_slice() != QUOTE_ENV_V0 {
+                    return None;
+                }
+                trim_trailing_spaces(&mut quoted);
+                let prefixed = prefix_quote_lines_v0(&quoted);
+                out.extend_from_slice(&prefixed);
+                push_paragraph_break(out);
+                return Some(next);
+            }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == BEGIN_CONTROL_V0 => {
+                return None;
+            }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == CARRELPAR_MARKER_CONTROL_V0 => {
+                push_paragraph_break(&mut quoted);
+                cursor += 1;
+            }
+            Some(_) => {
+                cursor = consume_fragment_token_v0(tokens, cursor, &mut quoted, false, true)?;
+            }
+            None => return None,
+        }
+    }
+}
+
+fn consume_body_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+    let (env_name, _) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
+    if env_name.as_slice() == ITEMIZE_ENV_V0 || env_name.as_slice() == ENUMERATE_ENV_V0 {
+        return consume_list_environment_v0(tokens, index, out);
+    }
+    if env_name.as_slice() == QUOTE_ENV_V0 {
+        return consume_quote_environment_v0(tokens, index, out);
+    }
+    None
+}
+
 fn consume_meta_declaration_v0(
     tokens: &[TokenV0],
     index: usize,
@@ -788,7 +854,7 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
                 break;
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == BEGIN_CONTROL_V0 => {
-                index = consume_list_environment_v0(tokens, index, &mut body)?;
+                index = consume_body_environment_v0(tokens, index, &mut body)?;
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == CARRELPAR_MARKER_CONTROL_V0 => {
                 push_paragraph_break(&mut body);

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -130,6 +130,25 @@ fn typeset_minimal_rejects_nested_lists() {
 }
 
 #[test]
+fn typeset_minimal_quote_environment_prefixes_each_line() {
+    let main = b"\\documentclass{article}\n\\begin{document}\nBefore.\n\\begin{quote}\nQuoted one\\linebreak Quoted two\n\nNew paragraph\n\\end{quote}\nAfter.\n\\end{document}\n";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("Before.\n\n> Quoted one\n> Quoted two\n\n> New paragraph\n\nAfter."),
+        "body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_rejects_nested_quote_environment() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{quote}Outer\\begin{quote}Inner\\end{quote}\\end{quote}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
 fn typeset_minimal_long_paragraph_wraps_to_multiple_lines() {
     let main = b"\\documentclass{article}\\begin{document}This is a long paragraph that should wrap deterministically to multiple physical lines in the minimal typeset pipeline when width-based layout is enabled and the content exceeds the configured line width for the page body area.\\end{document}";
     let result = compile_typeset(main);

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -164,28 +164,36 @@ fn centered_line_x_v0(line_width_pt: f32) -> f32 {
     centered.clamp(MARGIN_PT_V0, PAGE_WIDTH_PT_V0 - MARGIN_PT_V0)
 }
 
-fn detect_list_prefix_advance_pt_v0(line: &LinePlanV0) -> Option<f32> {
-    if line.glyphs.len() >= 2 && line.glyphs[0].byte == b'-' && line.glyphs[1].byte == b' ' {
-        let prefix_sp = line.glyphs[0]
+fn detect_list_prefix_advance_pt_v0(glyphs: &[GlyphPlanV0]) -> Option<f32> {
+    if glyphs.len() >= 2 && glyphs[0].byte == b'-' && glyphs[1].byte == b' ' {
+        let prefix_sp = glyphs[0]
             .advance_sp
-            .checked_add(line.glyphs[1].advance_sp)?;
+            .checked_add(glyphs[1].advance_sp)?;
         return Some((prefix_sp as f32) / 65_536.0);
     }
 
     let mut index = 0usize;
-    while index < line.glyphs.len() && line.glyphs[index].byte.is_ascii_digit() {
+    while index < glyphs.len() && glyphs[index].byte.is_ascii_digit() {
         index += 1;
     }
-    if index == 0 || index + 1 >= line.glyphs.len() {
+    if index == 0 || index + 1 >= glyphs.len() {
         return None;
     }
-    if line.glyphs[index].byte != b'.' || line.glyphs[index + 1].byte != b' ' {
+    if glyphs[index].byte != b'.' || glyphs[index + 1].byte != b' ' {
         return None;
     }
     let mut prefix_sp = 0i32;
-    for glyph in &line.glyphs[..=index + 1] {
+    for glyph in &glyphs[..=index + 1] {
         prefix_sp = prefix_sp.checked_add(glyph.advance_sp)?;
     }
+    Some((prefix_sp as f32) / 65_536.0)
+}
+
+fn detect_quote_prefix_advance_pt_v0(glyphs: &[GlyphPlanV0]) -> Option<f32> {
+    if glyphs.len() < 2 || glyphs[0].byte != b'>' || glyphs[1].byte != b' ' {
+        return None;
+    }
+    let prefix_sp = glyphs[0].advance_sp.checked_add(glyphs[1].advance_sp)?;
     Some((prefix_sp as f32) / 65_536.0)
 }
 
@@ -199,11 +207,23 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
     let mut previous_rendered_line_was_empty = false;
     let mut skip_indent_after_title_block = title_block_len > 0;
     let mut active_hang_indent_pt = 0.0f32;
+    let mut active_quote_indent_pt = 0.0f32;
     for (line_index, line) in lines.iter().enumerate() {
         if y < MARGIN_PT_V0 {
             break;
         }
-        let segments = parse_styled_segments_v0(&line.glyphs)?;
+        let quote_prefix_advance_pt = if line_index >= title_block_len {
+            detect_quote_prefix_advance_pt_v0(&line.glyphs)
+        } else {
+            None
+        };
+        let render_glyphs: &[GlyphPlanV0] = if quote_prefix_advance_pt.is_some() {
+            &line.glyphs[2..]
+        } else {
+            &line.glyphs
+        };
+
+        let segments = parse_styled_segments_v0(render_glyphs)?;
         let line_is_empty = segments.is_empty();
         let in_title_block = title_block_len > 0 && line_index < title_block_len;
         let font_size_pt = if in_title_block && line_index == 0 {
@@ -216,13 +236,20 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
             let list_prefix_advance_pt = if in_title_block {
                 None
             } else {
-                detect_list_prefix_advance_pt_v0(line)
+                detect_list_prefix_advance_pt_v0(render_glyphs)
             };
             let line_x = if in_title_block {
                 centered_line_x_v0(line_width_pt)
+            } else if let Some(prefix_advance_pt) = quote_prefix_advance_pt {
+                active_quote_indent_pt = (FONT_SIZE_PT_V0 * 2.0).max(prefix_advance_pt);
+                active_hang_indent_pt = 0.0;
+                MARGIN_PT_V0 + active_quote_indent_pt
             } else if let Some(prefix_advance_pt) = list_prefix_advance_pt {
                 active_hang_indent_pt = prefix_advance_pt;
+                active_quote_indent_pt = 0.0;
                 MARGIN_PT_V0
+            } else if active_quote_indent_pt > 0.0 {
+                MARGIN_PT_V0 + active_quote_indent_pt
             } else if active_hang_indent_pt > 0.0 {
                 MARGIN_PT_V0 + active_hang_indent_pt
             } else if previous_rendered_line_was_empty && !skip_indent_after_title_block {
@@ -254,6 +281,7 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
             }
         } else {
             active_hang_indent_pt = 0.0;
+            active_quote_indent_pt = 0.0;
         }
         previous_rendered_line_was_empty = line_is_empty;
         y -= LEADING_PT_V0;

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -248,6 +248,39 @@ fn pdf_renderer_applies_hanging_indent_for_list_continuation_v0() {
 }
 
 #[test]
+fn pdf_renderer_applies_quote_indent_and_hides_prefix_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"\n> quoted line\ncontinuation line")
+        .expect("writer should accept text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    assert!(
+        !pdf.windows(b"(> quoted line) Tj".len())
+            .any(|w| w == b"(> quoted line) Tj")
+    );
+    assert!(
+        pdf.windows(b"(quoted line) Tj".len())
+            .any(|w| w == b"(quoted line) Tj")
+    );
+
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    let mut xs = Vec::<f32>::new();
+    for line in pdf_text.lines() {
+        if !line.contains(" Tm ") {
+            continue;
+        }
+        let fields = line.split_whitespace().collect::<Vec<_>>();
+        if fields.len() < 7 || fields[6] != "Tm" {
+            continue;
+        }
+        if let Ok(x_pt) = fields[4].parse::<f32>() {
+            xs.push(x_pt);
+        }
+    }
+    assert!(xs.len() >= 2, "expected at least two rendered lines, got {xs:?}");
+    assert!(xs[0] > 72.0, "quote line should be indented: {xs:?}");
+    assert!((xs[0] - xs[1]).abs() <= 0.02, "quote continuation should keep indent: {xs:?}");
+}
+
+#[test]
 fn parse_roundtrips_writer_layout_for_wrap_and_paging() {
     let text = b"word word word word word word word word word word";
     let layout = plan_layout_v0(text, 65_536, 786_432, 10, 1).expect("layout plan");

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -31,4 +31,11 @@ first-line indentation, and width-sensitive wrapping are visible in the PDF prev
 \item Second numbered item.
 \end{enumerate}
 
+\subsection{Quote}
+\begin{quote}
+This quoted paragraph is intentionally long so width-based wrapping produces continuation lines in the preview while preserving a deterministic left indent for each logical quote line.
+
+This is a second quoted paragraph to confirm paragraph breaks are preserved inside the quote environment.
+\end{quote}
+
 \end{document}


### PR DESCRIPTION
## Summary
- Add `quote` environment support in typeset-minimal extraction with strict fail-closed behavior.
- Prefix quote logical lines as `> ` in extracted text, reject nested quote envs.
- Render quote lines in PDF preview with deterministic left indent and hidden `> ` prefix glyphs.
- Extend engine/xdv tests and demo fixture for quote behavior.

## Proof
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests PASS
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml PASS
- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 6 PASS
