### PR TITLE
typeset-minimal: add centering support

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -15,6 +15,8 @@ const DOCUMENT_ENV_V0: &[u8] = b"document";
 const ITEMIZE_ENV_V0: &[u8] = b"itemize";
 const ENUMERATE_ENV_V0: &[u8] = b"enumerate";
 const QUOTE_ENV_V0: &[u8] = b"quote";
+const CENTER_ENV_V0: &[u8] = b"center";
+const CENTERLINE_CONTROL_V0: &[u8] = b"centerline";
 const ITALIC_START_MARKER_V0: u8 = b'[';
 const ITALIC_END_MARKER_V0: u8 = b']';
 const BOLD_START_MARKER_V0: u8 = b'{';
@@ -708,6 +710,24 @@ fn prefix_quote_lines_v0(content: &[u8]) -> Vec<u8> {
     out
 }
 
+fn prefix_center_lines_v0(content: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(content.len().saturating_add(8));
+    let mut at_line_start = true;
+    for &byte in content {
+        if matches!(byte, NEWLINE_MARKER_V0 | PAGE_BREAK_MARKER_V0) {
+            out.push(byte);
+            at_line_start = true;
+            continue;
+        }
+        if at_line_start {
+            out.extend_from_slice(b"^ ");
+            at_line_start = false;
+        }
+        out.push(byte);
+    }
+    out
+}
+
 fn consume_quote_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
     let (env_name, mut cursor) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
     if env_name.as_slice() != QUOTE_ENV_V0 {
@@ -744,6 +764,67 @@ fn consume_quote_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<
     }
 }
 
+fn consume_center_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+    let (env_name, mut cursor) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
+    if env_name.as_slice() != CENTER_ENV_V0 {
+        return None;
+    }
+
+    push_paragraph_break(out);
+    let mut centered = Vec::<u8>::new();
+    loop {
+        match tokens.get(cursor) {
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == END_CONTROL_V0 => {
+                let (end_env, next) = consume_env_name_command_v0(tokens, cursor, END_CONTROL_V0)?;
+                if end_env.as_slice() != CENTER_ENV_V0 {
+                    return None;
+                }
+                trim_trailing_spaces(&mut centered);
+                let prefixed = prefix_center_lines_v0(&centered);
+                out.extend_from_slice(&prefixed);
+                push_paragraph_break(out);
+                return Some(next);
+            }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == BEGIN_CONTROL_V0 => {
+                return None;
+            }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == CARRELPAR_MARKER_CONTROL_V0 => {
+                push_paragraph_break(&mut centered);
+                cursor += 1;
+            }
+            Some(_) => {
+                cursor = consume_fragment_token_v0(tokens, cursor, &mut centered, false, true)?;
+            }
+            None => return None,
+        }
+    }
+}
+
+fn consume_centerline_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+    if !matches!(
+        tokens.get(index),
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == CENTERLINE_CONTROL_V0
+    ) {
+        return None;
+    }
+    let (group_start, group_end, next) = consume_group_bounds(tokens, index + 1)?;
+    let mut centered = Vec::new();
+    consume_fragment_range_v0(tokens, group_start, group_end, &mut centered, false, true)?;
+    trim_trailing_spaces(&mut centered);
+    if centered.is_empty() {
+        return None;
+    }
+    if centered.contains(&NEWLINE_MARKER_V0) || centered.contains(&PAGE_BREAK_MARKER_V0) {
+        return None;
+    }
+
+    push_paragraph_break(out);
+    out.extend_from_slice(b"^ ");
+    out.extend_from_slice(&centered);
+    push_paragraph_break(out);
+    Some(next)
+}
+
 fn consume_body_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
     let (env_name, _) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
     if env_name.as_slice() == ITEMIZE_ENV_V0 || env_name.as_slice() == ENUMERATE_ENV_V0 {
@@ -751,6 +832,9 @@ fn consume_body_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u
     }
     if env_name.as_slice() == QUOTE_ENV_V0 {
         return consume_quote_environment_v0(tokens, index, out);
+    }
+    if env_name.as_slice() == CENTER_ENV_V0 {
+        return consume_center_environment_v0(tokens, index, out);
     }
     None
 }
@@ -859,6 +943,9 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == CARRELPAR_MARKER_CONTROL_V0 => {
                 push_paragraph_break(&mut body);
                 index += 1;
+            }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == CENTERLINE_CONTROL_V0 => {
+                index = consume_centerline_command_v0(tokens, index, &mut body)?;
             }
             Some(TokenV0::ControlSeq(name)) if is_heading_control_v0(name.as_slice()) => {
                 index = consume_heading_command_v0(tokens, index, &mut body)?;

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -149,6 +149,34 @@ fn typeset_minimal_rejects_nested_quote_environment() {
 }
 
 #[test]
+fn typeset_minimal_center_environment_prefixes_each_line() {
+    let main = b"\\documentclass{article}\n\\begin{document}\nBefore.\n\\begin{center}\nCentered one\\linebreak Centered two\n\nCentered paragraph\n\\end{center}\nAfter.\n\\end{document}\n";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("Before.\n\n^ Centered one\n^ Centered two\n\n^ Centered paragraph\n\nAfter."),
+        "body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_centerline_emits_single_centered_line() {
+    let main = b"\\documentclass{article}\\begin{document}Before.\\centerline{A \\emph{B}}After.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("Before.\n\n^ A [B]\n\nAfter."), "body={text:?}");
+}
+
+#[test]
+fn typeset_minimal_centerline_rejects_multiline_content() {
+    let main =
+        b"\\documentclass{article}\\begin{document}\\centerline{A\\\\B}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
 fn typeset_minimal_long_paragraph_wraps_to_multiple_lines() {
     let main = b"\\documentclass{article}\\begin{document}This is a long paragraph that should wrap deterministically to multiple physical lines in the minimal typeset pipeline when width-based layout is enabled and the content exceeds the configured line width for the page body area.\\end{document}";
     let result = compile_typeset(main);

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -197,6 +197,10 @@ fn detect_quote_prefix_advance_pt_v0(glyphs: &[GlyphPlanV0]) -> Option<f32> {
     Some((prefix_sp as f32) / 65_536.0)
 }
 
+fn has_center_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() >= 2 && glyphs[0].byte == b'^' && glyphs[1].byte == b' '
+}
+
 fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
     let mut out = Vec::new();
     out.extend_from_slice(b"BT\n");
@@ -217,7 +221,12 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
         } else {
             None
         };
+        let center_prefixed = line_index >= title_block_len
+            && quote_prefix_advance_pt.is_none()
+            && has_center_prefix_v0(&line.glyphs);
         let render_glyphs: &[GlyphPlanV0] = if quote_prefix_advance_pt.is_some() {
+            &line.glyphs[2..]
+        } else if center_prefixed {
             &line.glyphs[2..]
         } else {
             &line.glyphs
@@ -232,13 +241,17 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
             FONT_SIZE_PT_V0
         };
         if !line_is_empty {
-            let line_width_pt = (line.width_sp as f32) / 65_536.0;
+            let line_width_pt: f32 = segments.iter().map(|segment| segment.advance_pt).sum();
             let list_prefix_advance_pt = if in_title_block {
                 None
             } else {
                 detect_list_prefix_advance_pt_v0(render_glyphs)
             };
             let line_x = if in_title_block {
+                centered_line_x_v0(line_width_pt)
+            } else if center_prefixed {
+                active_quote_indent_pt = 0.0;
+                active_hang_indent_pt = 0.0;
                 centered_line_x_v0(line_width_pt)
             } else if let Some(prefix_advance_pt) = quote_prefix_advance_pt {
                 active_quote_indent_pt = (FONT_SIZE_PT_V0 * 2.0).max(prefix_advance_pt);

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -281,6 +281,41 @@ fn pdf_renderer_applies_quote_indent_and_hides_prefix_v0() {
 }
 
 #[test]
+fn pdf_renderer_hides_center_prefix_and_centers_line_v0() {
+    let xdv =
+        write_dvi_v2_text_page_v0(b"\n^ centered line").expect("writer should accept centered text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    assert!(
+        !pdf.windows(b"(^ centered line) Tj".len())
+            .any(|w| w == b"(^ centered line) Tj")
+    );
+    assert!(
+        pdf.windows(b"(centered line) Tj".len())
+            .any(|w| w == b"(centered line) Tj")
+    );
+
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    let mut xs = Vec::<f32>::new();
+    for line in pdf_text.lines() {
+        if !line.contains(" Tm ") {
+            continue;
+        }
+        let fields = line.split_whitespace().collect::<Vec<_>>();
+        if fields.len() < 7 || fields[6] != "Tm" {
+            continue;
+        }
+        if let Ok(x_pt) = fields[4].parse::<f32>() {
+            xs.push(x_pt);
+        }
+    }
+    assert!(!xs.is_empty(), "expected centered Tm position");
+    assert!(
+        (xs[0] - 72.0).abs() > 0.02,
+        "centered line should not be at margin: {xs:?}"
+    );
+}
+
+#[test]
 fn parse_roundtrips_writer_layout_for_wrap_and_paging() {
     let text = b"word word word word word word word word word word";
     let layout = plan_layout_v0(text, 65_536, 786_432, 10, 1).expect("layout plan");

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -38,4 +38,10 @@ This quoted paragraph is intentionally long so width-based wrapping produces con
 This is a second quoted paragraph to confirm paragraph breaks are preserved inside the quote environment.
 \end{quote}
 
+\subsection{Centering}
+\begin{center}
+Centered environment line one.\linebreak Centered environment line two.
+\end{center}
+\centerline{Single centered command line.}
+
 \end{document}


### PR DESCRIPTION
## Summary
- add  environment support in typeset-minimal extraction with deterministic  line marker encoding
- add  single-line command support and fail-closed multiline rejection
- render  prefixed lines as centered in PDF preview while hiding prefix bytes
- add focused engine/XDV tests and fixture updates for visible center output

## Proof
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml
- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 6