### PR TITLE
typeset-minimal: add flushright and rightline support

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -17,6 +17,8 @@ const ENUMERATE_ENV_V0: &[u8] = b"enumerate";
 const QUOTE_ENV_V0: &[u8] = b"quote";
 const CENTER_ENV_V0: &[u8] = b"center";
 const CENTERLINE_CONTROL_V0: &[u8] = b"centerline";
+const FLUSHRIGHT_ENV_V0: &[u8] = b"flushright";
+const RIGHTLINE_CONTROL_V0: &[u8] = b"rightline";
 const ITALIC_START_MARKER_V0: u8 = b'[';
 const ITALIC_END_MARKER_V0: u8 = b']';
 const BOLD_START_MARKER_V0: u8 = b'{';
@@ -728,6 +730,24 @@ fn prefix_center_lines_v0(content: &[u8]) -> Vec<u8> {
     out
 }
 
+fn prefix_right_lines_v0(content: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(content.len().saturating_add(8));
+    let mut at_line_start = true;
+    for &byte in content {
+        if matches!(byte, NEWLINE_MARKER_V0 | PAGE_BREAK_MARKER_V0) {
+            out.push(byte);
+            at_line_start = true;
+            continue;
+        }
+        if at_line_start {
+            out.extend_from_slice(b"| ");
+            at_line_start = false;
+        }
+        out.push(byte);
+    }
+    out
+}
+
 fn consume_quote_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
     let (env_name, mut cursor) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
     if env_name.as_slice() != QUOTE_ENV_V0 {
@@ -825,6 +845,71 @@ fn consume_centerline_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec
     Some(next)
 }
 
+fn consume_flushright_environment_v0(
+    tokens: &[TokenV0],
+    index: usize,
+    out: &mut Vec<u8>,
+) -> Option<usize> {
+    let (env_name, mut cursor) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
+    if env_name.as_slice() != FLUSHRIGHT_ENV_V0 {
+        return None;
+    }
+
+    push_paragraph_break(out);
+    let mut right_aligned = Vec::<u8>::new();
+    loop {
+        match tokens.get(cursor) {
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == END_CONTROL_V0 => {
+                let (end_env, next) = consume_env_name_command_v0(tokens, cursor, END_CONTROL_V0)?;
+                if end_env.as_slice() != FLUSHRIGHT_ENV_V0 {
+                    return None;
+                }
+                trim_trailing_spaces(&mut right_aligned);
+                let prefixed = prefix_right_lines_v0(&right_aligned);
+                out.extend_from_slice(&prefixed);
+                push_paragraph_break(out);
+                return Some(next);
+            }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == BEGIN_CONTROL_V0 => {
+                return None;
+            }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == CARRELPAR_MARKER_CONTROL_V0 => {
+                push_paragraph_break(&mut right_aligned);
+                cursor += 1;
+            }
+            Some(_) => {
+                cursor = consume_fragment_token_v0(tokens, cursor, &mut right_aligned, false, true)?;
+            }
+            None => return None,
+        }
+    }
+}
+
+fn consume_rightline_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+    if !matches!(
+        tokens.get(index),
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == RIGHTLINE_CONTROL_V0
+    ) {
+        return None;
+    }
+    let (group_start, group_end, next) = consume_group_bounds(tokens, index + 1)?;
+    let mut right_aligned = Vec::new();
+    consume_fragment_range_v0(tokens, group_start, group_end, &mut right_aligned, false, true)?;
+    trim_trailing_spaces(&mut right_aligned);
+    if right_aligned.is_empty() {
+        return None;
+    }
+    if right_aligned.contains(&NEWLINE_MARKER_V0) || right_aligned.contains(&PAGE_BREAK_MARKER_V0) {
+        return None;
+    }
+
+    push_paragraph_break(out);
+    out.extend_from_slice(b"| ");
+    out.extend_from_slice(&right_aligned);
+    push_paragraph_break(out);
+    Some(next)
+}
+
 fn consume_body_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
     let (env_name, _) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
     if env_name.as_slice() == ITEMIZE_ENV_V0 || env_name.as_slice() == ENUMERATE_ENV_V0 {
@@ -835,6 +920,9 @@ fn consume_body_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u
     }
     if env_name.as_slice() == CENTER_ENV_V0 {
         return consume_center_environment_v0(tokens, index, out);
+    }
+    if env_name.as_slice() == FLUSHRIGHT_ENV_V0 {
+        return consume_flushright_environment_v0(tokens, index, out);
     }
     None
 }
@@ -946,6 +1034,9 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == CENTERLINE_CONTROL_V0 => {
                 index = consume_centerline_command_v0(tokens, index, &mut body)?;
+            }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == RIGHTLINE_CONTROL_V0 => {
+                index = consume_rightline_command_v0(tokens, index, &mut body)?;
             }
             Some(TokenV0::ControlSeq(name)) if is_heading_control_v0(name.as_slice()) => {
                 index = consume_heading_command_v0(tokens, index, &mut body)?;

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -177,6 +177,33 @@ fn typeset_minimal_centerline_rejects_multiline_content() {
 }
 
 #[test]
+fn typeset_minimal_flushright_environment_prefixes_each_line() {
+    let main = b"\\documentclass{article}\n\\begin{document}\nBefore.\n\\begin{flushright}\nRight one\\linebreak Right two\n\nRight paragraph\n\\end{flushright}\nAfter.\n\\end{document}\n";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("Before.\n\n| Right one\n| Right two\n\n| Right paragraph\n\nAfter."),
+        "body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_rightline_emits_single_right_aligned_line() {
+    let main = b"\\documentclass{article}\\begin{document}Before.\\rightline{A \\textbf{B}}After.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("Before.\n\n| A {B}\n\nAfter."), "body={text:?}");
+}
+
+#[test]
+fn typeset_minimal_rightline_rejects_multiline_content() {
+    let main = b"\\documentclass{article}\\begin{document}\\rightline{A\\\\B}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
 fn typeset_minimal_long_paragraph_wraps_to_multiple_lines() {
     let main = b"\\documentclass{article}\\begin{document}This is a long paragraph that should wrap deterministically to multiple physical lines in the minimal typeset pipeline when width-based layout is enabled and the content exceeds the configured line width for the page body area.\\end{document}";
     let result = compile_typeset(main);

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -201,6 +201,10 @@ fn has_center_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
     glyphs.len() >= 2 && glyphs[0].byte == b'^' && glyphs[1].byte == b' '
 }
 
+fn has_right_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() >= 2 && glyphs[0].byte == b'|' && glyphs[1].byte == b' '
+}
+
 fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
     let mut out = Vec::new();
     out.extend_from_slice(b"BT\n");
@@ -224,9 +228,15 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
         let center_prefixed = line_index >= title_block_len
             && quote_prefix_advance_pt.is_none()
             && has_center_prefix_v0(&line.glyphs);
+        let right_prefixed = line_index >= title_block_len
+            && quote_prefix_advance_pt.is_none()
+            && !center_prefixed
+            && has_right_prefix_v0(&line.glyphs);
         let render_glyphs: &[GlyphPlanV0] = if quote_prefix_advance_pt.is_some() {
             &line.glyphs[2..]
         } else if center_prefixed {
+            &line.glyphs[2..]
+        } else if right_prefixed {
             &line.glyphs[2..]
         } else {
             &line.glyphs
@@ -253,6 +263,10 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
                 active_quote_indent_pt = 0.0;
                 active_hang_indent_pt = 0.0;
                 centered_line_x_v0(line_width_pt)
+            } else if right_prefixed {
+                active_quote_indent_pt = 0.0;
+                active_hang_indent_pt = 0.0;
+                (PAGE_WIDTH_PT_V0 - MARGIN_PT_V0 - line_width_pt).max(MARGIN_PT_V0)
             } else if let Some(prefix_advance_pt) = quote_prefix_advance_pt {
                 active_quote_indent_pt = (FONT_SIZE_PT_V0 * 2.0).max(prefix_advance_pt);
                 active_hang_indent_pt = 0.0;

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -316,6 +316,39 @@ fn pdf_renderer_hides_center_prefix_and_centers_line_v0() {
 }
 
 #[test]
+fn pdf_renderer_hides_right_prefix_and_right_aligns_line_v0() {
+    let xdv =
+        write_dvi_v2_text_page_v0(b"\n| right aligned line").expect("writer should accept right text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    assert!(
+        !pdf.windows(b"(| right aligned line) Tj".len())
+            .any(|w| w == b"(| right aligned line) Tj")
+    );
+    assert!(
+        pdf.windows(b"(right aligned line) Tj".len())
+            .any(|w| w == b"(right aligned line) Tj")
+    );
+
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    let mut xs = Vec::<f32>::new();
+    for line in pdf_text.lines() {
+        if !line.contains(" Tm ") {
+            continue;
+        }
+        let fields = line.split_whitespace().collect::<Vec<_>>();
+        if fields.len() < 7 || fields[6] != "Tm" {
+            continue;
+        }
+        if let Ok(x_pt) = fields[4].parse::<f32>() {
+            xs.push(x_pt);
+        }
+    }
+    assert!(!xs.is_empty(), "expected right-aligned Tm position");
+    assert!((xs[0] - 72.0).abs() > 0.02, "line should not be at margin: {xs:?}");
+    assert!(xs[0] > 306.0, "right-aligned line should be on right half: {xs:?}");
+}
+
+#[test]
 fn parse_roundtrips_writer_layout_for_wrap_and_paging() {
     let text = b"word word word word word word word word word word";
     let layout = plan_layout_v0(text, 65_536, 786_432, 10, 1).expect("layout plan");

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -44,4 +44,10 @@ Centered environment line one.\linebreak Centered environment line two.
 \end{center}
 \centerline{Single centered command line.}
 
+\subsection{FlushRight}
+\begin{flushright}
+Flushright environment line one.\linebreak Flushright environment line two.
+\end{flushright}
+\rightline{Single right-aligned command line.}
+
 \end{document}


### PR DESCRIPTION
## Summary
- add flushright environment extraction with deterministic `| ` line prefix
- add rightline{...} extraction as single-line right-aligned command (multiline fails closed)
- hide `| ` prefix and render right-aligned lines in PDF preview
- extend focused engine/XDV tests and fixture coverage

## Proof
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml
- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 6
