### PR TITLE
wasm: add on-demand resolver harness v0

### DIFF
--- a/scripts/ondemand_resolver_v0_proof.mjs
+++ b/scripts/ondemand_resolver_v0_proof.mjs
@@ -1,0 +1,116 @@
+import { mkdir, rm, writeFile, readFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createOfflineOnDemandResolverV0 } from './wasm_smoke_js/ondemand_resolver_v0.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+
+function sha256HexV0(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function assertV0(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function run() {
+  const outDir = path.resolve(process.argv[2] ?? path.join(rootDir, 'target', 'ondemand_resolver_v0'));
+  const storeDir = path.join(outDir, 'store');
+  const blobsDir = path.join(storeDir, 'blobs');
+  await rm(outDir, { recursive: true, force: true });
+  await mkdir(blobsDir, { recursive: true });
+
+  const blobBytes = Buffer.from('resolver-v0-deterministic-bytes\n', 'utf8');
+  const blobSha = sha256HexV0(blobBytes);
+  await writeFile(path.join(blobsDir, blobSha), blobBytes);
+
+  const index = {
+    version: 1,
+    entries: [
+      {
+        kind: 'texmf',
+        format: 'sty',
+        name: 'demo_pkg',
+        variant: 'v0',
+        sha256: blobSha,
+        stable_id: 'texmf_sty_demo_pkg_v0',
+      },
+    ],
+  };
+  const indexPath = path.join(storeDir, 'index.json');
+  await writeFile(indexPath, `${JSON.stringify(index, null, 2)}\n`);
+
+  const resolver = await createOfflineOnDemandResolverV0({
+    rootDir,
+    storeDir,
+  });
+
+  const expectedIndexSha = sha256HexV0(await readFile(indexPath));
+  assertV0(
+    resolver.resolverId === `offline-store-v0:${expectedIndexSha}`,
+    'resolver_id must include index hash',
+  );
+
+  const request = {
+    kind: 'texmf',
+    format: 'sty',
+    name: 'demo_pkg',
+    variant: 'v0',
+    resolver_id: resolver.resolverId,
+  };
+  const first = await resolver.resolve(request);
+  assertV0(first.tag === 'Found', 'first resolve must be Found');
+  assertV0(first.cache_hit === false, 'first resolve must be cache miss');
+  assertV0(first.sha256 === blobSha, 'first resolve sha mismatch');
+  assertV0(Buffer.compare(Buffer.from(first.bytes), blobBytes) === 0, 'first resolve bytes mismatch');
+
+  const second = await resolver.resolve(request);
+  assertV0(second.tag === 'Found', 'second resolve must be Found');
+  assertV0(second.cache_hit === true, 'second resolve must be cache hit');
+  assertV0(second.sha256 === blobSha, 'second resolve sha mismatch');
+  assertV0(Buffer.compare(Buffer.from(second.bytes), blobBytes) === 0, 'second resolve bytes mismatch');
+
+  const unsafeSlash = await resolver.resolve({
+    ...request,
+    name: 'demo/pkg',
+  });
+  assertV0(unsafeSlash.tag === 'NotFound', 'slash path must be rejected');
+  const unsafeDotDot = await resolver.resolve({
+    ...request,
+    name: '../demo_pkg',
+  });
+  assertV0(unsafeDotDot.tag === 'NotFound', 'dotdot path must be rejected');
+
+  const report = {
+    resolver_id: resolver.resolverId,
+    index_sha256: expectedIndexSha,
+    request,
+    deterministic_sha256: blobSha,
+    cache_second_hit: second.cache_hit,
+    path_safety: {
+      slash: unsafeSlash.tag,
+      dotdot: unsafeDotDot.tag,
+    },
+  };
+  const reportPath = path.join(outDir, 'report.json');
+  await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+
+  console.log(`PASS: resolver_id ${resolver.resolverId}`);
+  console.log(`PASS: deterministic_sha256 ${blobSha}`);
+  console.log('PASS: cache hit on second resolve');
+  console.log('PASS: path safety rejects "/" and ".."');
+  console.log(`PASS: resolver proof report ${reportPath}`);
+  console.log('PASS: on-demand resolver v0 proof');
+}
+
+run().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`FAIL: on-demand resolver v0 proof: ${message}`);
+  process.exit(1);
+});

--- a/scripts/proof_ondemand_resolver_v0.sh
+++ b/scripts/proof_ondemand_resolver_v0.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/target/ondemand_resolver_v0}"
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-1700000000}"
+export SOURCE_DATE_EPOCH
+export TZ=UTC
+
+node "$ROOT_DIR/scripts/ondemand_resolver_v0_proof.mjs" "$OUT_DIR"
+
+if [[ ! -s "$OUT_DIR/report.json" ]]; then
+  echo "FAIL: expected non-empty $OUT_DIR/report.json" >&2
+  exit 1
+fi
+
+echo "PASS: on-demand resolver proof artifacts $OUT_DIR"
+echo "PASS: on-demand resolver proof"

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { createCtx } from './wasm_smoke_js/ctx.mjs';
 import { createMemHelpers } from './wasm_smoke_js/mem.mjs';
 import { createAssertHelpers } from './wasm_smoke_js/assert.mjs';
+import { createOfflineOnDemandResolverV0 } from './wasm_smoke_js/ondemand_resolver_v0.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -125,12 +126,13 @@ function entrypointSetOkV0(ctx, mem, entrypoint) {
   );
 }
 
-function buildConfigHashV0(cases, sourceDateEpoch) {
+function buildConfigHashV0(cases, sourceDateEpoch, resolverId) {
   const config = {
     runner: 'wasm_fixture_gallery_v0',
     source_date_epoch: sourceDateEpoch,
     tz: 'UTC',
     max_log_bytes: DEFAULT_MAX_LOG_BYTES_V0,
+    resolver_id: resolverId,
     cases: cases.map((item) => ({
       id: item.id,
       mode: item.mode,
@@ -140,7 +142,17 @@ function buildConfigHashV0(cases, sourceDateEpoch) {
   return sha256HexV0(Buffer.from(JSON.stringify(config)));
 }
 
-async function runCaseV0(ctx, mem, helpers, outDir, caseSpec, sourceDateEpoch, engineRev, configHash) {
+async function runCaseV0(
+  ctx,
+  mem,
+  helpers,
+  outDir,
+  caseSpec,
+  sourceDateEpoch,
+  engineRev,
+  configHash,
+  resolver,
+) {
   const caseOutDir = path.join(outDir, caseSpec.id);
   await mkdir(caseOutDir, { recursive: true });
 
@@ -240,6 +252,26 @@ async function runCaseV0(ctx, mem, helpers, outDir, caseSpec, sourceDateEpoch, e
     errorMessage = errorMessage || 'expected non-empty main.pdf for OK case';
   }
 
+  const resolvedResources = [];
+  const resolution = await resolver.resolve({
+    kind: 'texmf',
+    format: 'tex',
+    name: caseSpec.id,
+    variant: caseSpec.mode,
+    resolver_id: resolver.resolverId,
+  });
+  if (resolution.tag === 'Found') {
+    resolvedResources.push({
+      kind: 'texmf',
+      format: 'tex',
+      name: caseSpec.id,
+      variant: caseSpec.mode,
+      stable_id: resolution.stable_id,
+      sha256: resolution.sha256,
+      cache_hit: resolution.cache_hit,
+    });
+  }
+
   const summary = {
     case_id: caseSpec.id,
     mode: caseSpec.mode,
@@ -260,7 +292,8 @@ async function runCaseV0(ctx, mem, helpers, outDir, caseSpec, sourceDateEpoch, e
       main_xdv: sha256HexV0(xdvBytes),
       main_pdf: sha256HexV0(pdfBytes),
     },
-    resolved_resources: [],
+    resolver_id: resolver.resolverId,
+    resolved_resources: resolvedResources,
   };
   if (errorMessage) {
     summary.error = errorMessage;
@@ -291,7 +324,11 @@ async function run() {
     encoding: 'utf8',
   }).trim();
   const cases = await loadFixtureCasesV0();
-  const configHash = buildConfigHashV0(cases, sourceDateEpoch);
+  const resolver = await createOfflineOnDemandResolverV0({
+    rootDir,
+    storeDir: path.join(rootDir, 'target', 'texlive_store_v0'),
+  });
+  const configHash = buildConfigHashV0(cases, sourceDateEpoch, resolver.resolverId);
 
   await rm(outDir, { recursive: true, force: true });
   await mkdir(outDir, { recursive: true });
@@ -302,13 +339,24 @@ async function run() {
   const summaries = [];
   for (const caseSpec of cases) {
     summaries.push(
-      await runCaseV0(ctx, mem, helpers, outDir, caseSpec, sourceDateEpoch, engineRev, configHash),
+      await runCaseV0(
+        ctx,
+        mem,
+        helpers,
+        outDir,
+        caseSpec,
+        sourceDateEpoch,
+        engineRev,
+        configHash,
+        resolver,
+      ),
     );
   }
 
   const report = {
     engine_rev: engineRev,
     source_date_epoch: sourceDateEpoch,
+    resolver_id: resolver.resolverId,
     config_hash: configHash,
     case_count: summaries.length,
     statuses: summaries.map((summary) => ({

--- a/scripts/wasm_smoke_js/ondemand_resolver_v0.mjs
+++ b/scripts/wasm_smoke_js/ondemand_resolver_v0.mjs
@@ -1,0 +1,166 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+
+const DEFAULT_INDEX_V0 = {
+  version: 1,
+  entries: [],
+};
+
+function sha256HexV0(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function isSafeTokenV0(value) {
+  return typeof value === 'string'
+    && value.length > 0
+    && !value.includes('/')
+    && !value.includes('\\')
+    && !value.includes('..');
+}
+
+function normalizeVariantV0(variant) {
+  if (variant === undefined || variant === null || variant === '') {
+    return '';
+  }
+  if (!isSafeTokenV0(variant)) {
+    return null;
+  }
+  return variant;
+}
+
+function makeRequestKeyV0(kind, format, name, variant) {
+  return `${kind}\u001f${format}\u001f${name}\u001f${variant}`;
+}
+
+export async function createOfflineOnDemandResolverV0(options = {}) {
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const storeDir = path.resolve(options.storeDir ?? path.join(rootDir, 'target', 'texlive_store_v0'));
+  const indexPath = path.join(storeDir, 'index.json');
+  const blobsDir = path.join(storeDir, 'blobs');
+
+  await mkdir(blobsDir, { recursive: true });
+
+  let indexBytes;
+  try {
+    indexBytes = await readFile(indexPath);
+  } catch (error) {
+    if (error && error.code !== 'ENOENT') {
+      throw error;
+    }
+    indexBytes = Buffer.from(`${JSON.stringify(DEFAULT_INDEX_V0, null, 2)}\n`, 'utf8');
+    await writeFile(indexPath, indexBytes);
+  }
+
+  let parsedIndex;
+  try {
+    parsedIndex = JSON.parse(indexBytes.toString('utf8'));
+  } catch {
+    throw new Error(`invalid resolver index json: ${indexPath}`);
+  }
+
+  const entriesRaw = Array.isArray(parsedIndex.entries) ? parsedIndex.entries : [];
+  const entries = [];
+  for (const rawEntry of entriesRaw) {
+    const kind = rawEntry?.kind;
+    const format = rawEntry?.format;
+    const name = rawEntry?.name;
+    const variant = normalizeVariantV0(rawEntry?.variant);
+    const sha256 = rawEntry?.sha256;
+    const stableId = rawEntry?.stable_id;
+    if (
+      !isSafeTokenV0(kind)
+      || !isSafeTokenV0(format)
+      || !isSafeTokenV0(name)
+      || variant === null
+      || typeof sha256 !== 'string'
+      || !/^[0-9a-f]{64}$/.test(sha256)
+      || !isSafeTokenV0(stableId)
+    ) {
+      continue;
+    }
+    entries.push({
+      kind,
+      format,
+      name,
+      variant,
+      sha256,
+      stable_id: stableId,
+    });
+  }
+
+  const indexSha256 = sha256HexV0(indexBytes);
+  const resolverId = `offline-store-v0:${indexSha256}`;
+  const cache = new Map();
+
+  async function resolve(request) {
+    const kind = request?.kind;
+    const format = request?.format;
+    const name = request?.name;
+    const variant = normalizeVariantV0(request?.variant);
+    const requestResolverId = request?.resolver_id;
+
+    if (!isSafeTokenV0(kind) || !isSafeTokenV0(format) || !isSafeTokenV0(name) || variant === null) {
+      return { tag: 'NotFound' };
+    }
+    if (requestResolverId !== resolverId) {
+      return { tag: 'NotFound' };
+    }
+
+    const key = makeRequestKeyV0(kind, format, name, variant);
+    const cached = cache.get(key);
+    if (cached) {
+      return {
+        tag: 'Found',
+        bytes: cached.bytes,
+        sha256: cached.sha256,
+        stable_id: cached.stable_id,
+        cache_hit: true,
+      };
+    }
+
+    const found = entries.find(
+      (entry) =>
+        entry.kind === kind
+        && entry.format === format
+        && entry.name === name
+        && entry.variant === variant,
+    );
+    if (!found) {
+      return { tag: 'NotFound' };
+    }
+
+    const blobPath = path.join(blobsDir, found.sha256);
+    const bytes = await readFile(blobPath).catch(() => null);
+    if (!bytes) {
+      return { tag: 'NotFound' };
+    }
+    const actualSha = sha256HexV0(bytes);
+    if (actualSha !== found.sha256) {
+      return { tag: 'NotFound' };
+    }
+
+    const result = {
+      bytes: new Uint8Array(bytes),
+      sha256: actualSha,
+      stable_id: found.stable_id,
+    };
+    cache.set(key, result);
+
+    return {
+      tag: 'Found',
+      bytes: result.bytes,
+      sha256: result.sha256,
+      stable_id: result.stable_id,
+      cache_hit: false,
+    };
+  }
+
+  return {
+    resolverId,
+    indexSha256,
+    storeDir,
+    indexPath,
+    resolve,
+  };
+}


### PR DESCRIPTION
## Summary
- add offline-first on-demand resolver interface for JS runner path with pinned index hash resolver_id
- implement content-addressed offline store backend under target/texlive_store_v0 (index + blobs)
- wire fixture gallery to carry resolver_id/config hash and record resolved_resources (empty unless a request resolves)
- add deterministic resolver proof for cache-hit determinism and path safety rejection (`/`, `..`)

## Proof
- ./scripts/proof_wasm_fixture_gallery_v0.sh
- ./scripts/proof_ondemand_resolver_v0.sh
