### PR TITLE
wasm: add endpoint resolver adapter v0

### DIFF
--- a/scripts/ondemand_endpoint_v0_proof.mjs
+++ b/scripts/ondemand_endpoint_v0_proof.mjs
@@ -1,0 +1,178 @@
+import http from 'node:http';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createEndpointOnDemandResolverV0 } from './wasm_smoke_js/ondemand_resolver_v0.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+
+function sha256HexV0(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function assertV0(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function startStubServerV0() {
+  const hitCount = new Map();
+  const resources = new Map();
+
+  const texBytes = Buffer.from('endpoint-v0-tex-resource\n', 'utf8');
+  const texSha = sha256HexV0(texBytes);
+  resources.set('/xetex/tex/demo_pkg', {
+    status: 200,
+    body: texBytes,
+    headers: {
+      'content-type': 'application/octet-stream',
+      fileid: 'tex_demo_pkg_v0',
+    },
+    sha256: texSha,
+  });
+
+  const server = http.createServer((req, res) => {
+    const url = req.url ?? '';
+    hitCount.set(url, (hitCount.get(url) ?? 0) + 1);
+    const resource = resources.get(url);
+    if (!resource) {
+      res.statusCode = 404;
+      res.end('not found');
+      return;
+    }
+    res.statusCode = resource.status;
+    for (const [key, value] of Object.entries(resource.headers)) {
+      res.setHeader(key, value);
+    }
+    res.end(resource.body);
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address !== 'object') {
+    throw new Error('failed to resolve stub server address');
+  }
+  const endpoint = `http://127.0.0.1:${address.port}`;
+
+  return {
+    endpoint,
+    server,
+    hitCount,
+    texSha,
+    close: () =>
+      new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+async function run() {
+  const outDir = path.resolve(process.argv[2] ?? path.join(rootDir, 'target', 'ondemand_endpoint_v0'));
+  await rm(outDir, { recursive: true, force: true });
+  await mkdir(outDir, { recursive: true });
+
+  const stub = await startStubServerV0();
+  try {
+    const resolver = await createEndpointOnDemandResolverV0({
+      endpoint: stub.endpoint,
+      timeoutMs: 2000,
+    });
+
+    const request = {
+      kind: 'texmf',
+      format: 'tex',
+      name: 'demo_pkg',
+      variant: 'v0',
+      resolver_id: resolver.resolverId,
+    };
+
+    const firstFound = await resolver.resolve(request);
+    assertV0(firstFound.tag === 'Found', 'first fetch must be Found');
+    assertV0(firstFound.cache_hit === false, 'first fetch must be cache miss');
+    assertV0(firstFound.sha256 === stub.texSha, 'first fetch sha mismatch');
+    assertV0(firstFound.stable_id === 'tex_demo_pkg_v0', 'stable_id must come from fileid header');
+
+    const secondFound = await resolver.resolve(request);
+    assertV0(secondFound.tag === 'Found', 'second fetch must be Found');
+    assertV0(secondFound.cache_hit === true, 'second fetch must be cache hit');
+    assertV0(secondFound.sha256 === stub.texSha, 'second fetch sha mismatch');
+
+    const notFoundRequest = {
+      ...request,
+      name: 'missing_pkg',
+    };
+    const firstMiss = await resolver.resolve(notFoundRequest);
+    assertV0(firstMiss.tag === 'NotFound', 'first miss must be NotFound');
+    assertV0(firstMiss.cache_hit === false, 'first miss must be cache miss');
+    const secondMiss = await resolver.resolve(notFoundRequest);
+    assertV0(secondMiss.tag === 'NotFound', 'second miss must be NotFound');
+    assertV0(secondMiss.cache_hit === true, 'second miss must be cache hit');
+
+    const hitsBeforeUnsafe = new Map(stub.hitCount);
+    const slashReject = await resolver.resolve({
+      ...request,
+      name: 'demo/pkg',
+    });
+    const dotdotReject = await resolver.resolve({
+      ...request,
+      name: '../demo_pkg',
+    });
+    assertV0(slashReject.tag === 'NotFound', 'slash path must be rejected');
+    assertV0(dotdotReject.tag === 'NotFound', 'dotdot path must be rejected');
+    assertV0(
+      (stub.hitCount.get('/xetex/tex/demo/pkg') ?? 0) === 0
+      && (stub.hitCount.get('/xetex/tex/../demo_pkg') ?? 0) === 0,
+      'unsafe paths must not hit endpoint',
+    );
+    assertV0(
+      (stub.hitCount.get('/xetex/tex/demo_pkg') ?? 0) === (hitsBeforeUnsafe.get('/xetex/tex/demo_pkg') ?? 0),
+      'unsafe probes must not mutate valid-path hit count',
+    );
+
+    assertV0((stub.hitCount.get('/xetex/tex/demo_pkg') ?? 0) === 1, '200 path should be fetched once');
+    assertV0((stub.hitCount.get('/xetex/tex/missing_pkg') ?? 0) === 1, '404 path should be fetched once');
+
+    const report = {
+      endpoint: stub.endpoint,
+      resolver_id: resolver.resolverId,
+      deterministic_sha256: stub.texSha,
+      memoization: {
+        found_cache_second_hit: secondFound.cache_hit,
+        miss_cache_second_hit: secondMiss.cache_hit,
+      },
+      hit_count: {
+        '/xetex/tex/demo_pkg': stub.hitCount.get('/xetex/tex/demo_pkg') ?? 0,
+        '/xetex/tex/missing_pkg': stub.hitCount.get('/xetex/tex/missing_pkg') ?? 0,
+      },
+      path_safety: {
+        slash: slashReject.tag,
+        dotdot: dotdotReject.tag,
+      },
+    };
+    const reportPath = path.join(outDir, 'report.json');
+    await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+
+    console.log(`PASS: endpoint resolver_id ${resolver.resolverId}`);
+    console.log(`PASS: 200 memoization sha256 ${stub.texSha}`);
+    console.log('PASS: 404 memoization cache hit on second miss');
+    console.log('PASS: basename-only path safety rejects "/" and ".."');
+    console.log(`PASS: endpoint proof report ${reportPath}`);
+    console.log('PASS: on-demand endpoint v0 proof');
+  } finally {
+    await stub.close();
+  }
+}
+
+run().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`FAIL: on-demand endpoint v0 proof: ${message}`);
+  process.exit(1);
+});

--- a/scripts/proof_ondemand_endpoint_v0.sh
+++ b/scripts/proof_ondemand_endpoint_v0.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="${1:-$ROOT_DIR/target/ondemand_endpoint_v0}"
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-1700000000}"
+export SOURCE_DATE_EPOCH
+export TZ=UTC
+
+node "$ROOT_DIR/scripts/ondemand_endpoint_v0_proof.mjs" "$OUT_DIR"
+
+if [[ ! -s "$OUT_DIR/report.json" ]]; then
+  echo "FAIL: expected non-empty $OUT_DIR/report.json" >&2
+  exit 1
+fi
+
+echo "PASS: on-demand endpoint proof artifacts $OUT_DIR"
+echo "PASS: on-demand endpoint proof"

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { createCtx } from './wasm_smoke_js/ctx.mjs';
 import { createMemHelpers } from './wasm_smoke_js/mem.mjs';
 import { createAssertHelpers } from './wasm_smoke_js/assert.mjs';
-import { createOfflineOnDemandResolverV0 } from './wasm_smoke_js/ondemand_resolver_v0.mjs';
+import { createOnDemandResolverV0 } from './wasm_smoke_js/ondemand_resolver_v0.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -324,7 +324,9 @@ async function run() {
     encoding: 'utf8',
   }).trim();
   const cases = await loadFixtureCasesV0();
-  const resolver = await createOfflineOnDemandResolverV0({
+  const resolver = await createOnDemandResolverV0({
+    backend: process.env.TEXLIVE_RESOLVER_BACKEND_V0,
+    endpoint: process.env.TEXLIVE_ENDPOINT,
     rootDir,
     storeDir: path.join(rootDir, 'target', 'texlive_store_v0'),
   });

--- a/scripts/wasm_smoke_js/ondemand_resolver_v0.mjs
+++ b/scripts/wasm_smoke_js/ondemand_resolver_v0.mjs
@@ -7,6 +7,12 @@ const DEFAULT_INDEX_V0 = {
   entries: [],
 };
 
+const RESOLVER_BACKEND_OFFLINE_V0 = 'offline_store_v0';
+const RESOLVER_BACKEND_ENDPOINT_V0 = 'endpoint_v0';
+const DEFAULT_BACKEND_V0 = RESOLVER_BACKEND_OFFLINE_V0;
+const DEFAULT_TIMEOUT_MS_V0 = 3000;
+const MAX_ENDPOINT_BYTES_V0 = 4 * 1024 * 1024;
+
 function sha256HexV0(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
 }
@@ -33,12 +39,40 @@ function makeRequestKeyV0(kind, format, name, variant) {
   return `${kind}\u001f${format}\u001f${name}\u001f${variant}`;
 }
 
-export async function createOfflineOnDemandResolverV0(options = {}) {
-  const rootDir = path.resolve(options.rootDir ?? process.cwd());
-  const storeDir = path.resolve(options.storeDir ?? path.join(rootDir, 'target', 'texlive_store_v0'));
-  const indexPath = path.join(storeDir, 'index.json');
-  const blobsDir = path.join(storeDir, 'blobs');
+function makeNotFoundV0(cacheHit) {
+  return { tag: 'NotFound', cache_hit: cacheHit };
+}
 
+function buildFoundResultV0(bytes, sha256, stableId, cacheHit) {
+  return {
+    tag: 'Found',
+    bytes,
+    sha256,
+    stable_id: stableId,
+    cache_hit: cacheHit,
+  };
+}
+
+function normalizeEndpointV0(endpoint) {
+  if (typeof endpoint !== 'string') {
+    return '';
+  }
+  const trimmed = endpoint.trim();
+  if (trimmed === '') {
+    return '';
+  }
+  return trimmed.replace(/\/+$/, '');
+}
+
+function stableIdFromHeadersV0(headers, fallbackSha) {
+  const headerStableId = headers.get('fileid') ?? headers.get('fontid');
+  if (headerStableId && isSafeTokenV0(headerStableId)) {
+    return headerStableId;
+  }
+  return `sha256:${fallbackSha}`;
+}
+
+async function readIndexEntriesV0(indexPath, blobsDir) {
   await mkdir(blobsDir, { recursive: true });
 
   let indexBytes;
@@ -89,6 +123,19 @@ export async function createOfflineOnDemandResolverV0(options = {}) {
     });
   }
 
+  return {
+    indexBytes,
+    entries,
+  };
+}
+
+export async function createOfflineOnDemandResolverV0(options = {}) {
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const storeDir = path.resolve(options.storeDir ?? path.join(rootDir, 'target', 'texlive_store_v0'));
+  const indexPath = path.join(storeDir, 'index.json');
+  const blobsDir = path.join(storeDir, 'blobs');
+
+  const { indexBytes, entries } = await readIndexEntriesV0(indexPath, blobsDir);
   const indexSha256 = sha256HexV0(indexBytes);
   const resolverId = `offline-store-v0:${indexSha256}`;
   const cache = new Map();
@@ -101,22 +148,19 @@ export async function createOfflineOnDemandResolverV0(options = {}) {
     const requestResolverId = request?.resolver_id;
 
     if (!isSafeTokenV0(kind) || !isSafeTokenV0(format) || !isSafeTokenV0(name) || variant === null) {
-      return { tag: 'NotFound' };
+      return makeNotFoundV0(false);
     }
     if (requestResolverId !== resolverId) {
-      return { tag: 'NotFound' };
+      return makeNotFoundV0(false);
     }
 
     const key = makeRequestKeyV0(kind, format, name, variant);
     const cached = cache.get(key);
     if (cached) {
-      return {
-        tag: 'Found',
-        bytes: cached.bytes,
-        sha256: cached.sha256,
-        stable_id: cached.stable_id,
-        cache_hit: true,
-      };
+      if (cached.tag === 'Found') {
+        return buildFoundResultV0(cached.bytes, cached.sha256, cached.stable_id, true);
+      }
+      return makeNotFoundV0(true);
     }
 
     const found = entries.find(
@@ -127,36 +171,34 @@ export async function createOfflineOnDemandResolverV0(options = {}) {
         && entry.variant === variant,
     );
     if (!found) {
-      return { tag: 'NotFound' };
+      cache.set(key, { tag: 'NotFound' });
+      return makeNotFoundV0(false);
     }
 
     const blobPath = path.join(blobsDir, found.sha256);
     const bytes = await readFile(blobPath).catch(() => null);
     if (!bytes) {
-      return { tag: 'NotFound' };
+      cache.set(key, { tag: 'NotFound' });
+      return makeNotFoundV0(false);
     }
     const actualSha = sha256HexV0(bytes);
     if (actualSha !== found.sha256) {
-      return { tag: 'NotFound' };
+      cache.set(key, { tag: 'NotFound' });
+      return makeNotFoundV0(false);
     }
 
-    const result = {
+    const cachedFound = {
+      tag: 'Found',
       bytes: new Uint8Array(bytes),
       sha256: actualSha,
       stable_id: found.stable_id,
     };
-    cache.set(key, result);
-
-    return {
-      tag: 'Found',
-      bytes: result.bytes,
-      sha256: result.sha256,
-      stable_id: result.stable_id,
-      cache_hit: false,
-    };
+    cache.set(key, cachedFound);
+    return buildFoundResultV0(cachedFound.bytes, cachedFound.sha256, cachedFound.stable_id, false);
   }
 
   return {
+    backend: RESOLVER_BACKEND_OFFLINE_V0,
     resolverId,
     indexSha256,
     storeDir,
@@ -164,3 +206,114 @@ export async function createOfflineOnDemandResolverV0(options = {}) {
     resolve,
   };
 }
+
+export async function createEndpointOnDemandResolverV0(options = {}) {
+  const endpoint = normalizeEndpointV0(options.endpoint ?? process.env.TEXLIVE_ENDPOINT ?? '');
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const timeoutMs = Number.isInteger(options.timeoutMs) && options.timeoutMs > 0
+    ? options.timeoutMs
+    : DEFAULT_TIMEOUT_MS_V0;
+  const endpointConfigHash = sha256HexV0(
+    Buffer.from(JSON.stringify({ backend: RESOLVER_BACKEND_ENDPOINT_V0, endpoint })),
+  );
+  const resolverId = `endpoint-v0:${endpointConfigHash}`;
+  const cache = new Map();
+
+  async function resolve(request) {
+    const kind = request?.kind;
+    const format = request?.format;
+    const name = request?.name;
+    const variant = normalizeVariantV0(request?.variant);
+    const requestResolverId = request?.resolver_id;
+
+    if (!isSafeTokenV0(kind) || !isSafeTokenV0(format) || !isSafeTokenV0(name) || variant === null) {
+      return makeNotFoundV0(false);
+    }
+    if (requestResolverId !== resolverId) {
+      return makeNotFoundV0(false);
+    }
+    if (!endpoint || typeof fetchImpl !== 'function') {
+      return makeNotFoundV0(false);
+    }
+
+    const key = makeRequestKeyV0(kind, format, name, variant);
+    const cached = cache.get(key);
+    if (cached) {
+      if (cached.tag === 'Found') {
+        return buildFoundResultV0(cached.bytes, cached.sha256, cached.stable_id, true);
+      }
+      return makeNotFoundV0(true);
+    }
+
+    let relPath;
+    if (kind === 'fontconfig') {
+      if (!isSafeTokenV0(variant)) {
+        cache.set(key, { tag: 'NotFound' });
+        return makeNotFoundV0(false);
+      }
+      relPath = `fontconfig/${variant}/${name}`;
+    } else {
+      relPath = `xetex/${format}/${name}`;
+    }
+    const url = `${endpoint}/${relPath}`;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    let response;
+    try {
+      response = await fetchImpl(url, { method: 'GET', signal: controller.signal });
+    } catch {
+      cache.set(key, { tag: 'NotFound' });
+      return makeNotFoundV0(false);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    if (response.status === 404) {
+      cache.set(key, { tag: 'NotFound' });
+      return makeNotFoundV0(false);
+    }
+    if (response.status !== 200) {
+      cache.set(key, { tag: 'NotFound' });
+      return makeNotFoundV0(false);
+    }
+
+    const arrayBuffer = await response.arrayBuffer().catch(() => null);
+    if (!arrayBuffer) {
+      cache.set(key, { tag: 'NotFound' });
+      return makeNotFoundV0(false);
+    }
+    const bytes = new Uint8Array(arrayBuffer);
+    if (bytes.length === 0 || bytes.length > MAX_ENDPOINT_BYTES_V0) {
+      cache.set(key, { tag: 'NotFound' });
+      return makeNotFoundV0(false);
+    }
+
+    const sha256 = sha256HexV0(bytes);
+    const stableId = stableIdFromHeadersV0(response.headers, sha256);
+    const cachedFound = {
+      tag: 'Found',
+      bytes,
+      sha256,
+      stable_id: stableId,
+    };
+    cache.set(key, cachedFound);
+    return buildFoundResultV0(cachedFound.bytes, cachedFound.sha256, cachedFound.stable_id, false);
+  }
+
+  return {
+    backend: RESOLVER_BACKEND_ENDPOINT_V0,
+    resolverId,
+    endpoint,
+    resolve,
+  };
+}
+
+export async function createOnDemandResolverV0(options = {}) {
+  const backend = options.backend ?? process.env.TEXLIVE_RESOLVER_BACKEND_V0 ?? DEFAULT_BACKEND_V0;
+  if (backend === RESOLVER_BACKEND_ENDPOINT_V0) {
+    return createEndpointOnDemandResolverV0(options);
+  }
+  return createOfflineOnDemandResolverV0(options);
+}
+


### PR DESCRIPTION
## Summary
- add endpoint_v0 resolver backend (opt-in via TEXLIVE_RESOLVER_BACKEND_V0=endpoint_v0) with fail-closed NotFound when endpoint unset
- implement SwiftLaTeX-style 200/404 memoization by request key and include cache_hit in resolver responses
- enforce basename-only path safety and deterministic byte caps for endpoint fetches
- wire fixture gallery to select resolver backend and keep resolved_resources recording
- add local-stub endpoint proof for 200/404 memoization, sha stability, and path safety

## Proof
- ./scripts/proof_wasm_fixture_gallery_v0.sh
- ./scripts/proof_ondemand_resolver_v0.sh
- ./scripts/proof_ondemand_endpoint_v0.sh
