### PR TITLE
tooling: consume pinned offline store in fixture gallery

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -3,17 +3,72 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_DIR="${1:-$ROOT_DIR/target/wasm_fixture_gallery_v0}"
+STORE_DIR="${OUT_DIR}_store"
+REQUEST_LIST="$OUT_DIR/requests.json"
+FIXTURE_SOURCE_DIR="$OUT_DIR/fixture_source_v0"
 SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-1700000000}"
 export SOURCE_DATE_EPOCH
 export TZ=UTC
 
 "$ROOT_DIR/scripts/wasm_smoke_build.sh"
+
+rm -rf "$OUT_DIR" "$STORE_DIR"
+mkdir -p "$OUT_DIR" "$FIXTURE_SOURCE_DIR/xetex/tex"
+
+printf 'fixture-bytes-for-typeset-minimal-v0\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/typeset_demo_minimal_v0"
+
+cat > "$REQUEST_LIST" <<'JSON'
+{
+  "version": 1,
+  "requests": [
+    { "kind": "texmf", "format": "tex", "name": "typeset_demo_minimal_v0", "variant": "typeset" },
+    { "kind": "texmf", "format": "tex", "name": "missing_demo_case", "variant": "ok" }
+  ]
+}
+JSON
+
+TEXLIVE_RESOLVER_BACKEND_V0=fixture_dir_v0 \
+TEXLIVE_STORE_SOURCE_DIR_V0="$FIXTURE_SOURCE_DIR" \
+node "$ROOT_DIR/scripts/texlive_store_gen_v0.mjs" "$REQUEST_LIST" "$STORE_DIR"
+
+TEXLIVE_RESOLVER_BACKEND_V0=offline_store_v0 \
+TEXLIVE_STORE_DIR_V0="$STORE_DIR" \
 node "$ROOT_DIR/scripts/wasm_fixture_gallery_v0.mjs" "$OUT_DIR"
 
 if [[ ! -s "$OUT_DIR/report.json" ]]; then
   echo "FAIL: expected non-empty $OUT_DIR/report.json" >&2
   exit 1
 fi
+
+node - "$OUT_DIR" <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+
+const outDir = process.argv[2];
+const entries = fs.readdirSync(outDir, { withFileTypes: true });
+const caseDirs = entries
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .filter((name) => !['fixture_source_v0', 'texlive_store_v0'].includes(name));
+
+let resolvedCount = 0;
+for (const caseId of caseDirs) {
+  const summaryPath = path.join(outDir, caseId, 'summary.json');
+  if (!fs.existsSync(summaryPath)) {
+    continue;
+  }
+  const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+  const resources = Array.isArray(summary.resolved_resources) ? summary.resolved_resources : [];
+  resolvedCount += resources.length;
+}
+
+if (resolvedCount <= 0) {
+  console.error('FAIL: expected at least one resolved resource in fixture gallery summaries');
+  process.exit(1);
+}
+
+console.log(`PASS: resolved_resources_count ${resolvedCount}`);
+NODE
 
 echo "PASS: wasm fixture gallery artifacts $OUT_DIR"
 echo "PASS: wasm fixture gallery proof"

--- a/scripts/texlive_store_gen_v0.mjs
+++ b/scripts/texlive_store_gen_v0.mjs
@@ -10,6 +10,7 @@ const __dirname = path.dirname(__filename);
 const rootDirDefaultV0 = path.resolve(__dirname, '..');
 
 const DEFAULT_SOURCE_DATE_EPOCH_V0 = 1_700_000_000;
+const STORE_BACKEND_FIXTURE_DIR_V0 = 'fixture_dir_v0';
 
 function sha256HexV0(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
@@ -38,6 +39,12 @@ function normalizeStableIdV0(stableId, sha256) {
     return stableId;
   }
   return `sha256:${sha256}`;
+}
+
+function buildFixtureStableIdV0(request, sha256) {
+  const variantPart = request.variant === '' ? 'default' : request.variant;
+  const candidate = `fixture_${request.kind}_${request.format}_${variantPart}_${request.name}`;
+  return normalizeStableIdV0(candidate, sha256);
 }
 
 function requestKeyV0(request) {
@@ -101,6 +108,88 @@ async function loadRequestListV0(requestListPath) {
   return requestsRaw.map((rawRequest, index) => normalizeRequestV0(rawRequest, index));
 }
 
+async function createFixtureDirResolverV0(options = {}) {
+  const sourceDir = options.sourceDir;
+  if (typeof sourceDir !== 'string' || sourceDir.trim() === '') {
+    throw new Error('fixture_dir_v0 backend requires sourceDir');
+  }
+  const sourceDirResolved = path.resolve(sourceDir);
+  const resolverConfigHash = sha256HexV0(
+    Buffer.from(
+      JSON.stringify({
+        backend: STORE_BACKEND_FIXTURE_DIR_V0,
+        sourceDir: sourceDirResolved,
+      }),
+      'utf8',
+    ),
+  );
+  const resolverId = `fixture-dir-v0:${resolverConfigHash}`;
+  const cache = new Map();
+
+  async function resolve(request) {
+    const kind = request?.kind;
+    const format = request?.format;
+    const name = request?.name;
+    const variant = normalizeVariantV0(request?.variant);
+    const requestResolverId = request?.resolver_id;
+    if (!isSafeTokenV0(kind) || !isSafeTokenV0(format) || !isSafeTokenV0(name) || variant === null) {
+      return { tag: 'NotFound', cache_hit: false };
+    }
+    if (requestResolverId !== resolverId) {
+      return { tag: 'NotFound', cache_hit: false };
+    }
+
+    const key = requestKeyV0({ kind, format, name, variant });
+    const cached = cache.get(key);
+    if (cached) {
+      if (cached.tag === 'Found') {
+        return {
+          tag: 'Found',
+          bytes: cached.bytes,
+          sha256: cached.sha256,
+          stable_id: cached.stable_id,
+          cache_hit: true,
+        };
+      }
+      return { tag: 'NotFound', cache_hit: true };
+    }
+
+    const relPath = kind === 'fontconfig'
+      ? path.join('fontconfig', variant, name)
+      : path.join('xetex', format, name);
+    const fullPath = path.join(sourceDirResolved, relPath);
+    const bytes = await readFile(fullPath).catch(() => null);
+    if (!bytes || bytes.length === 0) {
+      cache.set(key, { tag: 'NotFound' });
+      return { tag: 'NotFound', cache_hit: false };
+    }
+
+    const payload = new Uint8Array(bytes);
+    const sha256 = sha256HexV0(payload);
+    const stableId = buildFixtureStableIdV0({ kind, format, name, variant }, sha256);
+    const found = {
+      tag: 'Found',
+      bytes: payload,
+      sha256,
+      stable_id: stableId,
+    };
+    cache.set(key, found);
+    return {
+      tag: 'Found',
+      bytes: found.bytes,
+      sha256: found.sha256,
+      stable_id: found.stable_id,
+      cache_hit: false,
+    };
+  }
+
+  return {
+    backend: STORE_BACKEND_FIXTURE_DIR_V0,
+    resolverId,
+    resolve,
+  };
+}
+
 export async function generateTexliveStoreV0(options = {}) {
   const rootDir = path.resolve(options.rootDir ?? rootDirDefaultV0);
   const requestListPath = path.resolve(options.requestListPath);
@@ -116,14 +205,18 @@ export async function generateTexliveStoreV0(options = {}) {
   await mkdir(blobsDir, { recursive: true });
 
   const requests = await loadRequestListV0(requestListPath);
-  const resolver = await createOnDemandResolverV0({
-    rootDir,
-    storeDir,
-    backend: options.backend,
-    endpoint: options.endpoint,
-    timeoutMs: options.timeoutMs,
-    fetchImpl: options.fetchImpl,
-  });
+  const backend = options.backend ?? process.env.TEXLIVE_RESOLVER_BACKEND_V0;
+  const sourceDir = options.sourceDir ?? process.env.TEXLIVE_STORE_SOURCE_DIR_V0;
+  const resolver = backend === STORE_BACKEND_FIXTURE_DIR_V0
+    ? await createFixtureDirResolverV0({ sourceDir })
+    : await createOnDemandResolverV0({
+      rootDir,
+      storeDir,
+      backend,
+      endpoint: options.endpoint,
+      timeoutMs: options.timeoutMs,
+      fetchImpl: options.fetchImpl,
+    });
 
   const entryMap = new Map();
   const missing = [];

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -309,6 +309,7 @@ async function runCaseV0(
 
 async function run() {
   const outDir = path.resolve(process.argv[2] ?? path.join(rootDir, 'target', 'wasm_fixture_gallery_v0'));
+  const storeDir = path.resolve(process.env.TEXLIVE_STORE_DIR_V0 ?? path.join(rootDir, 'target', 'texlive_store_v0'));
   const sourceDateEpochRaw = process.env.SOURCE_DATE_EPOCH ?? `${DEFAULT_SOURCE_DATE_EPOCH_V0}`;
   const sourceDateEpoch = Number.parseInt(sourceDateEpochRaw, 10);
   if (!Number.isInteger(sourceDateEpoch) || sourceDateEpoch <= 0) {
@@ -328,7 +329,7 @@ async function run() {
     backend: process.env.TEXLIVE_RESOLVER_BACKEND_V0,
     endpoint: process.env.TEXLIVE_ENDPOINT,
     rootDir,
-    storeDir: path.join(rootDir, 'target', 'texlive_store_v0'),
+    storeDir,
   });
   const configHash = buildConfigHashV0(cases, sourceDateEpoch, resolver.resolverId);
 
@@ -359,8 +360,13 @@ async function run() {
     engine_rev: engineRev,
     source_date_epoch: sourceDateEpoch,
     resolver_id: resolver.resolverId,
+    store_dir: storeDir,
     config_hash: configHash,
     case_count: summaries.length,
+    resolved_resources_count: summaries.reduce(
+      (sum, summary) => sum + (Array.isArray(summary.resolved_resources) ? summary.resolved_resources.length : 0),
+      0,
+    ),
     statuses: summaries.map((summary) => ({
       case_id: summary.case_id,
       status: summary.status,


### PR DESCRIPTION
## Summary
- wire fixture gallery runner to accept TEXLIVE_STORE_DIR_V0 and report resolved resource counts
- extend texlive store generator with fixture_dir_v0 backend for deterministic local prefetch closure materialization
- update gallery proof to generate a pinned store, run gallery in offline_store_v0 mode, and assert non-empty resolved_resources

## Proof
- ./scripts/proof_wasm_fixture_gallery_v0.sh
- ./scripts/proof_ondemand_resolver_v0.sh
- ./scripts/proof_ondemand_endpoint_v0.sh
- ./scripts/proof_texlive_store_gen_v0.sh