### PR TITLE
tooling: add probe fixtures + artifact flags (gallery v0)

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -84,6 +84,7 @@ const outDir = process.argv[2];
 const report = JSON.parse(fs.readFileSync(path.join(outDir, 'report.json'), 'utf8'));
 const statuses = Array.isArray(report.statuses) ? report.statuses : [];
 const resolvedCount = Number(report.resolved_resources_count ?? 0);
+const requiredTypedKeys = ['toc', 'labels', 'bib', 'hyperref'];
 
 if (resolvedCount <= 0) {
   console.error('FAIL: expected at least one resolved resource in fixture gallery summaries');
@@ -100,8 +101,41 @@ if (baselineMissing <= 0) {
   process.exit(1);
 }
 
+for (const status of statuses) {
+  const typedPresence = status.typed_artifacts_presence;
+  if (!typedPresence || typeof typedPresence !== 'object') {
+    console.error(`FAIL: case ${status.case_id} missing typed_artifacts_presence`);
+    process.exit(1);
+  }
+  for (const key of requiredTypedKeys) {
+    if (typeof typedPresence[key] !== 'boolean') {
+      console.error(`FAIL: case ${status.case_id} missing typed_artifacts_presence.${key} boolean`);
+      process.exit(1);
+    }
+  }
+  const summaryPath = path.join(outDir, status.case_id, 'summary.json');
+  const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+  const typedArtifacts = summary.typed_artifacts;
+  if (!typedArtifacts || typeof typedArtifacts !== 'object') {
+    console.error(`FAIL: case ${status.case_id} missing typed_artifacts`);
+    process.exit(1);
+  }
+  for (const key of requiredTypedKeys) {
+    const payload = typedArtifacts[key];
+    if (!payload || typeof payload !== 'object') {
+      console.error(`FAIL: case ${status.case_id} missing typed_artifacts.${key}`);
+      process.exit(1);
+    }
+    if (typeof payload.present !== 'boolean' || typeof payload.items !== 'number') {
+      console.error(`FAIL: case ${status.case_id} typed_artifacts.${key} schema mismatch`);
+      process.exit(1);
+    }
+  }
+}
+
 console.log(`PASS: resolved_resources_count ${resolvedCount}`);
 console.log(`PASS: baseline_match MATCH=${baselineMatches} MISSING=${baselineMissing}`);
+console.log(`PASS: typed_artifacts keys ${requiredTypedKeys.join(',')}`);
 NODE
 
 echo "PASS: wasm fixture gallery artifacts $OUT_DIR"

--- a/scripts/texlive_smoke/fixtures/typeset_demo_hyperref_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_hyperref_probe_v0.tex
@@ -1,0 +1,12 @@
+\documentclass{article}
+\usepackage{hyperref}
+
+\title{CarrelTeX Hyperref Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+Visit \url{https://example.com/carreltex}.
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_labels_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_labels_probe_v0.tex
@@ -1,0 +1,12 @@
+\documentclass{article}
+
+\title{CarrelTeX Labels Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+\section{Intro}\label{sec:intro}
+See Section~\ref{sec:intro}.
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_toc_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_toc_probe_v0.tex
@@ -1,0 +1,14 @@
+\documentclass{article}
+
+\title{CarrelTeX ToC Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+\tableofcontents
+
+\section{Intro}
+This fixture probes table-of-contents extraction support.
+\end{document}

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -20,6 +20,7 @@ const STATUS_NI_V0 = 'NI';
 const STATUS_INVALID_V0 = 'INVALID';
 const STATUS_FAIL_V0 = 'FAIL';
 const EXPECTED_STATUS_VALUES_V0 = new Set([STATUS_OK_V0, STATUS_NI_V0, STATUS_INVALID_V0, STATUS_FAIL_V0]);
+const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'bib', 'hyperref'];
 
 function sha256HexV0(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
@@ -151,6 +152,21 @@ async function loadFixtureCasesV0() {
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_capabilities_v0.tex',
     },
+    {
+      id: 'typeset_demo_toc_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_toc_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_labels_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_labels_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_hyperref_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_hyperref_probe_v0.tex',
+    },
   ];
 
   const okFixtureDir = path.join(rootDir, 'scripts', 'wasm_smoke_js', 'fixtures');
@@ -219,6 +235,17 @@ function buildConfigHashV0(cases, sourceDateEpoch, resolverId) {
     })),
   };
   return sha256HexV0(Buffer.from(JSON.stringify(config)));
+}
+
+function buildTypedArtifactsPlaceholderV0() {
+  const typedArtifacts = {};
+  for (const key of TYPED_ARTIFACT_KEYS_V0) {
+    typedArtifacts[key] = {
+      present: false,
+      items: 0,
+    };
+  }
+  return typedArtifacts;
 }
 
 async function computeBaselineMatchV0(caseId, artifactSha256, baselineDir) {
@@ -403,6 +430,7 @@ async function runCaseV0(
     },
     resolver_id: resolver.resolverId,
     resolved_resources: resolvedResources,
+    typed_artifacts: buildTypedArtifactsPlaceholderV0(),
   };
   summary.baseline_match = await computeBaselineMatchV0(caseSpec.id, summary.artifact_sha256, baselineDir);
   if (errorMessage) {
@@ -489,6 +517,9 @@ async function run() {
       expected_status: summary.expected_status,
       expected_vs_actual: summary.expected_vs_actual,
       baseline_match: summary.baseline_match,
+      typed_artifacts_presence: Object.fromEntries(
+        TYPED_ARTIFACT_KEYS_V0.map((key) => [key, summary.typed_artifacts?.[key]?.present === true]),
+      ),
       status: summary.status,
       artifact_sha256: summary.artifact_sha256,
     })),

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -14,6 +14,24 @@
       "purpose": "Capability-heavy fixture expected to remain not-implemented in minimal lane."
     },
     {
+      "id": "typeset_demo_toc_probe_v0",
+      "tags": ["typeset", "toc", "probe", "ni"],
+      "expected_status": "NI",
+      "purpose": "Probes table-of-contents seam planned for future typed artifacts."
+    },
+    {
+      "id": "typeset_demo_labels_probe_v0",
+      "tags": ["typeset", "labels", "probe", "ni"],
+      "expected_status": "NI",
+      "purpose": "Probes label/ref seam planned for future typed artifacts."
+    },
+    {
+      "id": "typeset_demo_hyperref_probe_v0",
+      "tags": ["typeset", "hyperref", "probe", "ni"],
+      "expected_status": "NI",
+      "purpose": "Probes hyperref/url seam planned for future typed artifacts."
+    },
+    {
       "id": "ok_demo_capabilities_v0",
       "tags": ["ok", "capabilities", "surface"],
       "expected_status": "OK",


### PR DESCRIPTION
Adds probe fixtures (toc/labels/hyperref) to the WASM fixture gallery, wires manifest expectations, and extends the proof to assert stable typed-artifact presence flags.\n\nProof (frozen head):\n- ./scripts/proof_wasm_fixture_gallery_v0.sh\n