### PR TITLE
tooling: labels_v0 typed artifact placeholder (fixture gallery)

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -64,6 +64,25 @@ fs.writeFileSync(
   path.join(baselineDir, missingCase, 'main.xdv.sha256'),
   '0'.repeat(64) + '\n',
 );
+
+const labelsSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_labels_probe_v0', 'summary.json'), 'utf8'),
+);
+if (labelsSummary?.typed_artifacts?.labels?.present !== true) {
+  console.error('FAIL: expected labels typed artifact present after first run');
+  process.exit(1);
+}
+const labelsPath = path.join(outDir, 'typeset_demo_labels_probe_v0', 'labels_v0.json');
+if (!fs.existsSync(labelsPath)) {
+  console.error('FAIL: expected labels_v0.json artifact after first run');
+  process.exit(1);
+}
+const labelsShaFirst = labelsSummary.typed_artifacts.labels.artifact_sha256;
+if (typeof labelsShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(labelsShaFirst)) {
+  console.error('FAIL: expected labels artifact sha256 in first summary');
+  process.exit(1);
+}
+fs.writeFileSync(path.join(baselineDir, 'labels_v0_first.sha256'), `${labelsShaFirst}\n`);
 NODE
 
 TEXLIVE_RESOLVER_BACKEND_V0=offline_store_v0 \
@@ -85,6 +104,7 @@ const report = JSON.parse(fs.readFileSync(path.join(outDir, 'report.json'), 'utf
 const statuses = Array.isArray(report.statuses) ? report.statuses : [];
 const resolvedCount = Number(report.resolved_resources_count ?? 0);
 const requiredTypedKeys = ['toc', 'labels', 'bib', 'hyperref'];
+const labelsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'labels_v0_first.sha256'), 'utf8').trim();
 
 if (resolvedCount <= 0) {
   console.error('FAIL: expected at least one resolved resource in fixture gallery summaries');
@@ -133,9 +153,24 @@ for (const status of statuses) {
   }
 }
 
+const labelsSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_labels_probe_v0', 'summary.json'), 'utf8'),
+);
+const labelsArtifact = labelsSummary?.typed_artifacts?.labels;
+if (!labelsArtifact || labelsArtifact.present !== true) {
+  console.error('FAIL: expected labels typed artifact present after second run');
+  process.exit(1);
+}
+const labelsShaSecond = labelsArtifact.artifact_sha256;
+if (labelsShaSecond !== labelsShaFirst) {
+  console.error('FAIL: labels_v0 artifact sha256 must be stable across reruns');
+  process.exit(1);
+}
+
 console.log(`PASS: resolved_resources_count ${resolvedCount}`);
 console.log(`PASS: baseline_match MATCH=${baselineMatches} MISSING=${baselineMissing}`);
 console.log(`PASS: typed_artifacts keys ${requiredTypedKeys.join(',')}`);
+console.log(`PASS: labels_v0 sha stable ${labelsShaSecond}`);
 NODE
 
 echo "PASS: wasm fixture gallery artifacts $OUT_DIR"

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -248,6 +248,26 @@ function buildTypedArtifactsPlaceholderV0() {
   return typedArtifacts;
 }
 
+async function emitTypedArtifactsV0(caseSpec, caseOutDir, typedArtifacts) {
+  if (caseSpec.id !== 'typeset_demo_labels_probe_v0') {
+    return;
+  }
+  const labelsPayload = {
+    version: 1,
+    schema: 'labels_v0',
+    entries: [],
+  };
+  const labelsBytes = Buffer.from(`${JSON.stringify(labelsPayload, null, 2)}\n`, 'utf8');
+  const labelsPath = path.join(caseOutDir, 'labels_v0.json');
+  await writeFile(labelsPath, labelsBytes);
+  typedArtifacts.labels = {
+    present: true,
+    items: labelsPayload.entries.length,
+    artifact_relpath: 'labels_v0.json',
+    artifact_sha256: sha256HexV0(labelsBytes),
+  };
+}
+
 async function computeBaselineMatchV0(caseId, artifactSha256, baselineDir) {
   if (!baselineDir) {
     return null;
@@ -432,6 +452,7 @@ async function runCaseV0(
     resolved_resources: resolvedResources,
     typed_artifacts: buildTypedArtifactsPlaceholderV0(),
   };
+  await emitTypedArtifactsV0(caseSpec, caseOutDir, summary.typed_artifacts);
   summary.baseline_match = await computeBaselineMatchV0(caseSpec.id, summary.artifact_sha256, baselineDir);
   if (errorMessage) {
     summary.error = errorMessage;


### PR DESCRIPTION
Adds a schema-stable  typed artifact placeholder to the WASM fixture gallery, and extends the proof to assert its presence.\n\nProof (frozen head):\n- ./scripts/proof_wasm_fixture_gallery_v0.sh\n