### PR TITLE
tooling: bib_v0 + hyperref_v0 typed artifact placeholders (fixture gallery)

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -102,6 +102,44 @@ if (typeof tocShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(tocShaFirst)) {
   process.exit(1);
 }
 fs.writeFileSync(path.join(baselineDir, 'toc_v0_first.sha256'), `${tocShaFirst}\n`);
+
+const bibSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_capabilities_v0', 'summary.json'), 'utf8'),
+);
+if (bibSummary?.typed_artifacts?.bib?.present !== true) {
+  console.error('FAIL: expected bib typed artifact present after first run');
+  process.exit(1);
+}
+const bibPath = path.join(outDir, 'typeset_demo_capabilities_v0', 'bib_v0.json');
+if (!fs.existsSync(bibPath)) {
+  console.error('FAIL: expected bib_v0.json artifact after first run');
+  process.exit(1);
+}
+const bibShaFirst = bibSummary.typed_artifacts.bib.artifact_sha256;
+if (typeof bibShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(bibShaFirst)) {
+  console.error('FAIL: expected bib artifact sha256 in first summary');
+  process.exit(1);
+}
+fs.writeFileSync(path.join(baselineDir, 'bib_v0_first.sha256'), `${bibShaFirst}\n`);
+
+const hyperrefSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_hyperref_probe_v0', 'summary.json'), 'utf8'),
+);
+if (hyperrefSummary?.typed_artifacts?.hyperref?.present !== true) {
+  console.error('FAIL: expected hyperref typed artifact present after first run');
+  process.exit(1);
+}
+const hyperrefPath = path.join(outDir, 'typeset_demo_hyperref_probe_v0', 'hyperref_v0.json');
+if (!fs.existsSync(hyperrefPath)) {
+  console.error('FAIL: expected hyperref_v0.json artifact after first run');
+  process.exit(1);
+}
+const hyperrefShaFirst = hyperrefSummary.typed_artifacts.hyperref.artifact_sha256;
+if (typeof hyperrefShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(hyperrefShaFirst)) {
+  console.error('FAIL: expected hyperref artifact sha256 in first summary');
+  process.exit(1);
+}
+fs.writeFileSync(path.join(baselineDir, 'hyperref_v0_first.sha256'), `${hyperrefShaFirst}\n`);
 NODE
 
 TEXLIVE_RESOLVER_BACKEND_V0=offline_store_v0 \
@@ -125,6 +163,8 @@ const resolvedCount = Number(report.resolved_resources_count ?? 0);
 const requiredTypedKeys = ['toc', 'labels', 'bib', 'hyperref'];
 const labelsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'labels_v0_first.sha256'), 'utf8').trim();
 const tocShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'toc_v0_first.sha256'), 'utf8').trim();
+const bibShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'bib_v0_first.sha256'), 'utf8').trim();
+const hyperrefShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'hyperref_v0_first.sha256'), 'utf8').trim();
 
 if (resolvedCount <= 0) {
   console.error('FAIL: expected at least one resolved resource in fixture gallery summaries');
@@ -201,11 +241,70 @@ if (tocShaSecond !== tocShaFirst) {
   process.exit(1);
 }
 
+const bibSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_capabilities_v0', 'summary.json'), 'utf8'),
+);
+const bibArtifact = bibSummary?.typed_artifacts?.bib;
+if (!bibArtifact || bibArtifact.present !== true) {
+  console.error('FAIL: expected bib typed artifact present after second run');
+  process.exit(1);
+}
+const bibShaSecond = bibArtifact.artifact_sha256;
+if (bibShaSecond !== bibShaFirst) {
+  console.error('FAIL: bib_v0 artifact sha256 must be stable across reruns');
+  process.exit(1);
+}
+
+const hyperrefSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_hyperref_probe_v0', 'summary.json'), 'utf8'),
+);
+const hyperrefArtifact = hyperrefSummary?.typed_artifacts?.hyperref;
+if (!hyperrefArtifact || hyperrefArtifact.present !== true) {
+  console.error('FAIL: expected hyperref typed artifact present after second run');
+  process.exit(1);
+}
+const hyperrefShaSecond = hyperrefArtifact.artifact_sha256;
+if (hyperrefShaSecond !== hyperrefShaFirst) {
+  console.error('FAIL: hyperref_v0 artifact sha256 must be stable across reruns');
+  process.exit(1);
+}
+
+const reportCaseSha = report.case_artifact_sha256;
+if (!reportCaseSha || typeof reportCaseSha !== 'object') {
+  console.error('FAIL: report missing top-level case_artifact_sha256');
+  process.exit(1);
+}
+for (const status of statuses) {
+  const caseSha = reportCaseSha[status.case_id];
+  if (!caseSha || typeof caseSha !== 'object') {
+    console.error(`FAIL: report missing case_artifact_sha256 for ${status.case_id}`);
+    process.exit(1);
+  }
+  if (typeof caseSha.main_xdv !== 'string' || typeof caseSha.main_pdf !== 'string') {
+    console.error(`FAIL: report case_artifact_sha256 malformed for ${status.case_id}`);
+    process.exit(1);
+  }
+  if (!caseSha.typed_artifacts || typeof caseSha.typed_artifacts !== 'object') {
+    console.error(`FAIL: report case_artifact_sha256 missing typed_artifacts for ${status.case_id}`);
+    process.exit(1);
+  }
+  for (const key of requiredTypedKeys) {
+    const value = caseSha.typed_artifacts[key];
+    if (!(value === null || (typeof value === 'string' && /^[0-9a-f]{64}$/.test(value)))) {
+      console.error(`FAIL: report typed artifact sha invalid for ${status.case_id}.${key}`);
+      process.exit(1);
+    }
+  }
+}
+
 console.log(`PASS: resolved_resources_count ${resolvedCount}`);
 console.log(`PASS: baseline_match MATCH=${baselineMatches} MISSING=${baselineMissing}`);
 console.log(`PASS: typed_artifacts keys ${requiredTypedKeys.join(',')}`);
 console.log(`PASS: labels_v0 sha stable ${labelsShaSecond}`);
 console.log(`PASS: toc_v0 sha stable ${tocShaSecond}`);
+console.log(`PASS: bib_v0 sha stable ${bibShaSecond}`);
+console.log(`PASS: hyperref_v0 sha stable ${hyperrefShaSecond}`);
+console.log('PASS: report top-level case_artifact_sha256 present');
 NODE
 
 echo "PASS: wasm fixture gallery artifacts $OUT_DIR"

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -248,38 +248,36 @@ function buildTypedArtifactsPlaceholderV0() {
   return typedArtifacts;
 }
 
+async function emitPlaceholderTypedArtifactV0(caseOutDir, artifactName, schemaName) {
+  const payload = {
+    version: 1,
+    schema: schemaName,
+    entries: [],
+  };
+  const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  const relpath = `${artifactName}.json`;
+  const fullPath = path.join(caseOutDir, relpath);
+  await writeFile(fullPath, bytes);
+  return {
+    present: true,
+    items: payload.entries.length,
+    artifact_relpath: relpath,
+    artifact_sha256: sha256HexV0(bytes),
+  };
+}
+
 async function emitTypedArtifactsV0(caseSpec, caseOutDir, typedArtifacts) {
   if (caseSpec.id === 'typeset_demo_toc_probe_v0') {
-    const tocPayload = {
-      version: 1,
-      schema: 'toc_v0',
-      entries: [],
-    };
-    const tocBytes = Buffer.from(`${JSON.stringify(tocPayload, null, 2)}\n`, 'utf8');
-    const tocPath = path.join(caseOutDir, 'toc_v0.json');
-    await writeFile(tocPath, tocBytes);
-    typedArtifacts.toc = {
-      present: true,
-      items: tocPayload.entries.length,
-      artifact_relpath: 'toc_v0.json',
-      artifact_sha256: sha256HexV0(tocBytes),
-    };
+    typedArtifacts.toc = await emitPlaceholderTypedArtifactV0(caseOutDir, 'toc_v0', 'toc_v0');
   }
   if (caseSpec.id === 'typeset_demo_labels_probe_v0') {
-    const labelsPayload = {
-      version: 1,
-      schema: 'labels_v0',
-      entries: [],
-    };
-    const labelsBytes = Buffer.from(`${JSON.stringify(labelsPayload, null, 2)}\n`, 'utf8');
-    const labelsPath = path.join(caseOutDir, 'labels_v0.json');
-    await writeFile(labelsPath, labelsBytes);
-    typedArtifacts.labels = {
-      present: true,
-      items: labelsPayload.entries.length,
-      artifact_relpath: 'labels_v0.json',
-      artifact_sha256: sha256HexV0(labelsBytes),
-    };
+    typedArtifacts.labels = await emitPlaceholderTypedArtifactV0(caseOutDir, 'labels_v0', 'labels_v0');
+  }
+  if (caseSpec.id === 'typeset_demo_capabilities_v0') {
+    typedArtifacts.bib = await emitPlaceholderTypedArtifactV0(caseOutDir, 'bib_v0', 'bib_v0');
+  }
+  if (caseSpec.id === 'typeset_demo_hyperref_probe_v0') {
+    typedArtifacts.hyperref = await emitPlaceholderTypedArtifactV0(caseOutDir, 'hyperref_v0', 'hyperref_v0');
   }
 }
 
@@ -546,6 +544,21 @@ async function run() {
     resolved_resources_count: summaries.reduce(
       (sum, summary) => sum + (Array.isArray(summary.resolved_resources) ? summary.resolved_resources.length : 0),
       0,
+    ),
+    case_artifact_sha256: Object.fromEntries(
+      summaries.map((summary) => [
+        summary.case_id,
+        {
+          main_xdv: summary.artifact_sha256.main_xdv,
+          main_pdf: summary.artifact_sha256.main_pdf,
+          typed_artifacts: Object.fromEntries(
+            TYPED_ARTIFACT_KEYS_V0.map((key) => [
+              key,
+              summary.typed_artifacts?.[key]?.artifact_sha256 ?? null,
+            ]),
+          ),
+        },
+      ]),
     ),
     statuses: summaries.map((summary) => ({
       case_id: summary.case_id,


### PR DESCRIPTION
Adds schema-stable bib_v0 + hyperref_v0 typed artifact placeholders to the WASM fixture gallery, extends the proof to assert stable sha, and exposes artifact sha summaries for the dashboard.\n\nProof (frozen head):\n- ./scripts/proof_wasm_fixture_gallery_v0.sh\n