### PR TITLE
tooling: add bib/graphics/pkgopt NI probe fixtures

### DIFF
--- a/scripts/open_wasm_fixture_gallery_v0.sh
+++ b/scripts/open_wasm_fixture_gallery_v0.sh
@@ -3,15 +3,51 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_DIR="${1:-$ROOT_DIR/target/wasm_fixture_gallery_v0}"
+STORE_DIR="${OUT_DIR}_store"
+REPORT_PATH="$OUT_DIR/report.json"
+AUTO_BASELINE="${WASM_FIXTURE_GALLERY_AUTO_BASELINE_PACK_V0:-0}"
+BASELINE_PACKS_ROOT="${TEXLIVE_BASELINE_PACKS_DIR_V0:-$ROOT_DIR/target/texlive_smoke/baselines_v0}"
+SKIP_PROOF="${WASM_FIXTURE_GALLERY_SKIP_PROOF_V0:-0}"
+NO_OPEN="${WASM_FIXTURE_GALLERY_NO_OPEN_V0:-0}"
+SELECTED_BASELINE_DIR=""
 
-"$ROOT_DIR/scripts/proof_wasm_fixture_gallery_v0.sh" "$OUT_DIR"
+if [[ "$SKIP_PROOF" != "1" ]]; then
+  "$ROOT_DIR/scripts/proof_wasm_fixture_gallery_v0.sh" "$OUT_DIR"
+fi
+
+if [[ "$AUTO_BASELINE" == "1" ]]; then
+  if [[ ! -s "$REPORT_PATH" ]]; then
+    echo "FAIL: expected non-empty report at $REPORT_PATH before baseline auto-select" >&2
+    exit 1
+  fi
+  SELECTED_BASELINE_DIR="$(
+    node "$ROOT_DIR/scripts/texlive_smoke/baselines_v0/select_v0.mjs" \
+      "$REPORT_PATH" \
+      "$BASELINE_PACKS_ROOT"
+  )"
+  if [[ -z "$SELECTED_BASELINE_DIR" ]]; then
+    echo "FAIL: baseline selector returned empty path" >&2
+    exit 1
+  fi
+  TEXLIVE_RESOLVER_BACKEND_V0=offline_store_v0 \
+  TEXLIVE_STORE_DIR_V0="$STORE_DIR" \
+  TEXLIVE_BASELINE_DIR="$SELECTED_BASELINE_DIR" \
+  node "$ROOT_DIR/scripts/wasm_fixture_gallery_v0.mjs" "$OUT_DIR"
+fi
 
 OUT_DIR_ABS="$(cd "$OUT_DIR" && pwd)"
+REPORT_PATH_ABS="$(cd "$(dirname "$REPORT_PATH")" && pwd)/$(basename "$REPORT_PATH")"
 
-if [[ "$(uname -s)" == "Darwin" ]] && command -v open >/dev/null 2>&1; then
-  open -R "$OUT_DIR_ABS" >/dev/null 2>&1 || open "$OUT_DIR_ABS" >/dev/null 2>&1 || true
+if [[ "$NO_OPEN" == "1" ]]; then
+  :
+elif [[ "$(uname -s)" == "Darwin" ]] && command -v open >/dev/null 2>&1; then
+  open -R "$REPORT_PATH_ABS" >/dev/null 2>&1 || open -R "$OUT_DIR_ABS" >/dev/null 2>&1 || open "$OUT_DIR_ABS" >/dev/null 2>&1 || true
 else
+  echo "INFO: gallery report $REPORT_PATH_ABS"
   echo "INFO: gallery directory $OUT_DIR_ABS"
 fi
 
+if [[ -n "$SELECTED_BASELINE_DIR" ]]; then
+  echo "PASS: baseline pack selected $SELECTED_BASELINE_DIR"
+fi
 echo "PASS: wasm fixture gallery open $OUT_DIR_ABS"

--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -7,6 +7,8 @@ STORE_DIR="${OUT_DIR}_store"
 BASELINE_ROOT="${OUT_DIR}_baseline"
 BASELINE_DIR_A="$BASELINE_ROOT/run1"
 BASELINE_DIR_B="$BASELINE_ROOT/run2"
+BASELINE_PACKS_ROOT="${BASELINE_ROOT}/packs"
+BASELINE_AUTO_PACK_DIR="${BASELINE_PACKS_ROOT}/auto_pack"
 REQUEST_LIST="$OUT_DIR/requests.json"
 FIXTURE_SOURCE_DIR="$OUT_DIR/fixture_source_v0"
 SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-1700000000}"
@@ -16,7 +18,7 @@ export TZ=UTC
 "$ROOT_DIR/scripts/wasm_smoke_build.sh"
 
 rm -rf "$OUT_DIR" "$STORE_DIR" "$BASELINE_ROOT"
-mkdir -p "$OUT_DIR" "$FIXTURE_SOURCE_DIR/xetex/tex" "$BASELINE_ROOT"
+mkdir -p "$OUT_DIR" "$FIXTURE_SOURCE_DIR/xetex/tex" "$BASELINE_ROOT" "$BASELINE_PACKS_ROOT"
 
 printf 'fixture-bytes-for-typeset-minimal-v0\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/typeset_demo_minimal_v0"
 
@@ -212,10 +214,13 @@ console.log(`PASS: baseline generator pinned engine_rev ${indexA.engine_rev}`);
 console.log(`PASS: baseline generator pinned config_hash ${indexA.config_hash}`);
 NODE
 
-TEXLIVE_RESOLVER_BACKEND_V0=offline_store_v0 \
-TEXLIVE_STORE_DIR_V0="$STORE_DIR" \
-TEXLIVE_BASELINE_DIR="$BASELINE_DIR_A" \
-node "$ROOT_DIR/scripts/wasm_fixture_gallery_v0.mjs" "$OUT_DIR"
+node "$ROOT_DIR/scripts/texlive_smoke/baselines_v0/generate_v0.mjs" "$OUT_DIR" "$BASELINE_AUTO_PACK_DIR"
+
+WASM_FIXTURE_GALLERY_SKIP_PROOF_V0=1 \
+WASM_FIXTURE_GALLERY_NO_OPEN_V0=1 \
+WASM_FIXTURE_GALLERY_AUTO_BASELINE_PACK_V0=1 \
+TEXLIVE_BASELINE_PACKS_DIR_V0="$BASELINE_PACKS_ROOT" \
+"$ROOT_DIR/scripts/open_wasm_fixture_gallery_v0.sh" "$OUT_DIR"
 
 if [[ ! -s "$OUT_DIR/report.json" ]]; then
   echo "FAIL: expected non-empty $OUT_DIR/report.json" >&2

--- a/scripts/texlive_smoke/baselines_v0/select_v0.mjs
+++ b/scripts/texlive_smoke/baselines_v0/select_v0.mjs
@@ -1,0 +1,102 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDirDefaultV0 = path.resolve(__dirname, '..', '..', '..');
+
+function isSafeSegmentV0(name) {
+  return typeof name === 'string'
+    && name.length > 0
+    && !name.includes('/')
+    && !name.includes('\\')
+    && !name.includes('..');
+}
+
+async function readJsonV0(filePath) {
+  const bytes = await readFile(filePath);
+  try {
+    return JSON.parse(bytes.toString('utf8'));
+  } catch {
+    throw new Error(`invalid json: ${filePath}`);
+  }
+}
+
+async function collectCandidateDirsV0(rootDir) {
+  const entries = await readdir(rootDir, { withFileTypes: true }).catch(() => []);
+  const dirs = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !isSafeSegmentV0(entry.name)) {
+      continue;
+    }
+    dirs.push(path.join(rootDir, entry.name));
+  }
+  return dirs.sort((left, right) => left.localeCompare(right));
+}
+
+export async function selectBaselinePackForReportV0(options = {}) {
+  const rootDir = path.resolve(options.rootDir ?? rootDirDefaultV0);
+  const reportPath = path.resolve(options.reportPath);
+  const baselinesRoot = path.resolve(
+    options.baselinesRoot
+      ?? path.join(rootDir, 'target', 'texlive_smoke', 'baselines_v0'),
+  );
+
+  const report = await readJsonV0(reportPath);
+  const engineRev = report?.engine_rev;
+  const configHash = report?.config_hash;
+  if (typeof engineRev !== 'string' || engineRev.length !== 40) {
+    throw new Error(`report missing valid engine_rev: ${reportPath}`);
+  }
+  if (typeof configHash !== 'string' || !/^[0-9a-f]{64}$/.test(configHash)) {
+    throw new Error(`report missing valid config_hash: ${reportPath}`);
+  }
+
+  const candidateDirs = await collectCandidateDirsV0(baselinesRoot);
+  let selected = '';
+  for (const candidateDir of candidateDirs) {
+    const indexPath = path.join(candidateDir, 'index.json');
+    const index = await readJsonV0(indexPath).catch(() => null);
+    if (!index || typeof index !== 'object') {
+      continue;
+    }
+    if (index?.source !== 'wasm_fixture_gallery_v0') {
+      continue;
+    }
+    if (index?.engine_rev !== engineRev || index?.config_hash !== configHash) {
+      continue;
+    }
+    selected = candidateDir;
+    break;
+  }
+  if (!selected) {
+    throw new Error(
+      `no baseline pack matches engine_rev=${engineRev} config_hash=${configHash} under ${baselinesRoot}`,
+    );
+  }
+  return selected;
+}
+
+async function runCliV0() {
+  const reportArg = process.argv[2];
+  if (!reportArg) {
+    console.error('usage: node scripts/texlive_smoke/baselines_v0/select_v0.mjs <gallery_report_json> [baselines_root]');
+    process.exit(2);
+  }
+  const baselinesRoot = process.argv[3];
+  const selected = await selectBaselinePackForReportV0({
+    reportPath: reportArg,
+    baselinesRoot,
+  });
+  console.log(selected);
+}
+
+const entryHref = process.argv[1] ? new URL(`file://${path.resolve(process.argv[1])}`).href : '';
+if (import.meta.url === entryHref) {
+  runCliV0().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`FAIL: baseline pack selector v0: ${message}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Adds three new NI probe fixtures (bib, graphics, package options) to expand the fixture gallery corpus and manifest coverage.\n\nProof (frozen head):\n- ./scripts/proof_wasm_fixture_gallery_v0.sh\n