### PR TITLE
tooling: add bib/graphics/pkgopt NI probe fixtures

### DIFF
--- a/scripts/texlive_smoke/fixtures/typeset_demo_bib_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_bib_probe_v0.tex
@@ -1,0 +1,14 @@
+\documentclass{article}
+\usepackage{biblatex}
+\addbibresource{refs.bib}
+
+\title{CarrelTeX Bibliography Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+See \cite{demo-key}.
+\printbibliography
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_graphics_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_graphics_probe_v0.tex
@@ -1,0 +1,12 @@
+\documentclass{article}
+\usepackage{graphicx}
+
+\title{CarrelTeX Graphics Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+\includegraphics[width=0.5\textwidth]{demo-image.png}
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_pkgopt_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_pkgopt_probe_v0.tex
@@ -1,0 +1,13 @@
+\PassOptionsToPackage{dvipsnames}{xcolor}
+\RequirePackage[table]{xcolor}
+\documentclass{article}
+
+\title{CarrelTeX Package Options Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+\textcolor{ForestGreen}{Package option plumbing probe.}
+\end{document}

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -167,6 +167,21 @@ async function loadFixtureCasesV0() {
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_hyperref_probe_v0.tex',
     },
+    {
+      id: 'typeset_demo_bib_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_bib_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_graphics_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_graphics_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_pkgopt_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_pkgopt_probe_v0.tex',
+    },
   ];
 
   const okFixtureDir = path.join(rootDir, 'scripts', 'wasm_smoke_js', 'fixtures');

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -32,6 +32,24 @@
       "purpose": "Probes hyperref/url seam planned for future typed artifacts."
     },
     {
+      "id": "typeset_demo_bib_probe_v0",
+      "tags": ["typeset", "bib", "cite", "probe", "ni"],
+      "expected_status": "NI",
+      "purpose": "Probes bibliography and cite seam planned for future typed artifacts."
+    },
+    {
+      "id": "typeset_demo_graphics_probe_v0",
+      "tags": ["typeset", "graphics", "probe", "ni"],
+      "expected_status": "NI",
+      "purpose": "Probes graphics include seam planned for future typed artifacts."
+    },
+    {
+      "id": "typeset_demo_pkgopt_probe_v0",
+      "tags": ["typeset", "package-options", "probe", "ni"],
+      "expected_status": "NI",
+      "purpose": "Probes preamble package-option plumbing seam planned for future typed artifacts."
+    },
+    {
       "id": "ok_demo_capabilities_v0",
       "tags": ["ok", "capabilities", "surface"],
       "expected_status": "OK",


### PR DESCRIPTION
## Summary\n- add three new NI probe fixtures for bibliography/citation, graphics, and package-options seams\n- wire probe fixtures into wasm fixture gallery case discovery\n- extend gallery manifest with expected_status=NI, tags, and purpose for each new case\n\n## Proof\n- ./scripts/proof_wasm_fixture_gallery_v0.sh\n