### PR TITLE
tooling: extract labels_v0 entries from labels/refs

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -66,6 +66,15 @@ if (typeof labelsShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(labelsShaFirst)
   console.error('FAIL: expected labels artifact sha256 in first summary');
   process.exit(1);
 }
+const labelsArtifactFirst = JSON.parse(fs.readFileSync(labelsPath, 'utf8'));
+if (!Array.isArray(labelsArtifactFirst?.entries)) {
+  console.error('FAIL: expected labels_v0.entries array in first-run artifact');
+  process.exit(1);
+}
+if (labelsArtifactFirst.entries.length <= 0) {
+  console.error('FAIL: expected non-empty labels_v0.entries for labels probe');
+  process.exit(1);
+}
 fs.writeFileSync(firstRunShaPath('labels_v0'), `${labelsShaFirst}\n`);
 
 const tocSummary = JSON.parse(
@@ -309,6 +318,13 @@ if (!labelsArtifact || labelsArtifact.present !== true) {
 const labelsShaSecond = labelsArtifact.artifact_sha256;
 if (labelsShaSecond !== labelsShaFirst) {
   console.error('FAIL: labels_v0 artifact sha256 must be stable across reruns');
+  process.exit(1);
+}
+const labelsArtifactSecond = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_labels_probe_v0', 'labels_v0.json'), 'utf8'),
+);
+if (!Array.isArray(labelsArtifactSecond?.entries) || labelsArtifactSecond.entries.length <= 0) {
+  console.error('FAIL: expected non-empty labels_v0.entries after rerun');
   process.exit(1);
 }
 

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -21,6 +21,8 @@ const STATUS_INVALID_V0 = 'INVALID';
 const STATUS_FAIL_V0 = 'FAIL';
 const EXPECTED_STATUS_VALUES_V0 = new Set([STATUS_OK_V0, STATUS_NI_V0, STATUS_INVALID_V0, STATUS_FAIL_V0]);
 const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'bib', 'hyperref'];
+const MAX_LABEL_ENTRIES_V0 = 256;
+const MAX_LABEL_VALUE_BYTES_V0 = 256;
 
 function sha256HexV0(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
@@ -360,6 +362,68 @@ function extractHyperrefLinksFromSourceV0(sourceBytes) {
   return links;
 }
 
+function extractLabelEntriesFromSourceV0(sourceBytes) {
+  const entries = [];
+  let index = 0;
+  while (index < sourceBytes.length) {
+    if (sourceBytes[index] !== 0x5c) {
+      index += 1;
+      continue;
+    }
+    let commandIndex = index + 1;
+    while (commandIndex < sourceBytes.length && isAsciiLetterByteV0(sourceBytes[commandIndex])) {
+      commandIndex += 1;
+    }
+    if (commandIndex === index + 1) {
+      index += 1;
+      continue;
+    }
+    const command = Buffer.from(sourceBytes.slice(index + 1, commandIndex)).toString('ascii');
+    if (command !== 'label' && command !== 'ref') {
+      index = commandIndex;
+      continue;
+    }
+    const keyGroup = readBracedGroupV0(sourceBytes, commandIndex);
+    if (!keyGroup.ok) {
+      index = commandIndex;
+      continue;
+    }
+    if (keyGroup.value.length > 0) {
+      const valueBytes = Buffer.from(keyGroup.value, 'utf8');
+      if (valueBytes.length > MAX_LABEL_VALUE_BYTES_V0) {
+        throw new Error(`labels_v0 value exceeds cap ${MAX_LABEL_VALUE_BYTES_V0}`);
+      }
+      entries.push({
+        command,
+        key: keyGroup.value,
+      });
+      if (entries.length > MAX_LABEL_ENTRIES_V0) {
+        throw new Error(`labels_v0 entries exceed cap ${MAX_LABEL_ENTRIES_V0}`);
+      }
+    }
+    index = keyGroup.next;
+  }
+  return entries;
+}
+
+async function emitLabelsTypedArtifactV0(caseOutDir, fixtureBytes) {
+  const payload = {
+    version: 1,
+    schema: 'labels_v0',
+    entries: extractLabelEntriesFromSourceV0(fixtureBytes),
+  };
+  const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  const relpath = 'labels_v0.json';
+  const fullPath = path.join(caseOutDir, relpath);
+  await writeFile(fullPath, bytes);
+  return {
+    present: true,
+    items: payload.entries.length,
+    artifact_relpath: relpath,
+    artifact_sha256: sha256HexV0(bytes),
+  };
+}
+
 async function emitHyperrefTypedArtifactV0(caseOutDir, fixtureBytes) {
   const payload = {
     version: 1,
@@ -383,7 +447,7 @@ async function emitTypedArtifactsV0(caseSpec, caseOutDir, typedArtifacts, fixtur
     typedArtifacts.toc = await emitPlaceholderTypedArtifactV0(caseOutDir, 'toc_v0', 'toc_v0');
   }
   if (caseSpec.id === 'typeset_demo_labels_probe_v0') {
-    typedArtifacts.labels = await emitPlaceholderTypedArtifactV0(caseOutDir, 'labels_v0', 'labels_v0');
+    typedArtifacts.labels = await emitLabelsTypedArtifactV0(caseOutDir, fixtureBytes);
   }
   if (caseSpec.id === 'typeset_demo_capabilities_v0') {
     typedArtifacts.bib = await emitPlaceholderTypedArtifactV0(caseOutDir, 'bib_v0', 'bib_v0');


### PR DESCRIPTION
## Summary\n- replace labels_v0 placeholder with deterministic extraction of \label{...} and \ref{...} entries\n- enforce strict caps for labels_v0 entries and key bytes\n- extend fixture-gallery proof to assert labels_v0 is non-empty on labels probe and stable across reruns\n\n## Proof\n- ./scripts/proof_wasm_fixture_gallery_v0.sh\n