### PR TITLE
tooling: extract pkgopt_v0 entries from package options

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -160,6 +160,34 @@ if (hyperrefArtifactFirst.links.length <= 0) {
   process.exit(1);
 }
 fs.writeFileSync(firstRunShaPath('hyperref_v0'), `${hyperrefShaFirst}\n`);
+
+const pkgoptSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_pkgopt_probe_v0', 'summary.json'), 'utf8'),
+);
+if (pkgoptSummary?.typed_artifacts?.pkgopt?.present !== true) {
+  console.error('FAIL: expected pkgopt typed artifact present after first run');
+  process.exit(1);
+}
+const pkgoptPath = path.join(outDir, 'typeset_demo_pkgopt_probe_v0', 'pkgopt_v0.json');
+if (!fs.existsSync(pkgoptPath)) {
+  console.error('FAIL: expected pkgopt_v0.json artifact after first run');
+  process.exit(1);
+}
+const pkgoptShaFirst = pkgoptSummary.typed_artifacts.pkgopt.artifact_sha256;
+if (typeof pkgoptShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(pkgoptShaFirst)) {
+  console.error('FAIL: expected pkgopt artifact sha256 in first summary');
+  process.exit(1);
+}
+const pkgoptArtifactFirst = JSON.parse(fs.readFileSync(pkgoptPath, 'utf8'));
+if (!Array.isArray(pkgoptArtifactFirst?.entries)) {
+  console.error('FAIL: expected pkgopt_v0.entries array in first-run artifact');
+  process.exit(1);
+}
+if (pkgoptArtifactFirst.entries.length <= 0) {
+  console.error('FAIL: expected non-empty pkgopt_v0.entries for pkgopt probe');
+  process.exit(1);
+}
+fs.writeFileSync(firstRunShaPath('pkgopt_v0'), `${pkgoptShaFirst}\n`);
 NODE
 
 node "$ROOT_DIR/scripts/texlive_smoke/baselines_v0/generate_v0.mjs" "$OUT_DIR" "$BASELINE_DIR_A"
@@ -271,11 +299,12 @@ const outDir = process.argv[2];
 const report = JSON.parse(fs.readFileSync(path.join(outDir, 'report.json'), 'utf8'));
 const statuses = Array.isArray(report.statuses) ? report.statuses : [];
 const resolvedCount = Number(report.resolved_resources_count ?? 0);
-const requiredTypedKeys = ['toc', 'labels', 'bib', 'hyperref'];
+const requiredTypedKeys = ['toc', 'labels', 'bib', 'hyperref', 'pkgopt'];
 const labelsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'labels_v0_first.sha256'), 'utf8').trim();
 const tocShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'toc_v0_first.sha256'), 'utf8').trim();
 const bibShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'bib_v0_first.sha256'), 'utf8').trim();
 const hyperrefShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'hyperref_v0_first.sha256'), 'utf8').trim();
+const pkgoptShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'pkgopt_v0_first.sha256'), 'utf8').trim();
 
 if (resolvedCount <= 0) {
   console.error('FAIL: expected at least one resolved resource in fixture gallery summaries');
@@ -409,6 +438,27 @@ if (!Array.isArray(hyperrefArtifactSecond?.links) || hyperrefArtifactSecond.link
   process.exit(1);
 }
 
+const pkgoptSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_pkgopt_probe_v0', 'summary.json'), 'utf8'),
+);
+const pkgoptArtifact = pkgoptSummary?.typed_artifacts?.pkgopt;
+if (!pkgoptArtifact || pkgoptArtifact.present !== true) {
+  console.error('FAIL: expected pkgopt typed artifact present after second run');
+  process.exit(1);
+}
+const pkgoptShaSecond = pkgoptArtifact.artifact_sha256;
+if (pkgoptShaSecond !== pkgoptShaFirst) {
+  console.error('FAIL: pkgopt_v0 artifact sha256 must be stable across reruns');
+  process.exit(1);
+}
+const pkgoptArtifactSecond = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_pkgopt_probe_v0', 'pkgopt_v0.json'), 'utf8'),
+);
+if (!Array.isArray(pkgoptArtifactSecond?.entries) || pkgoptArtifactSecond.entries.length <= 0) {
+  console.error('FAIL: expected non-empty pkgopt_v0.entries after rerun');
+  process.exit(1);
+}
+
 const reportCaseSha = report.case_artifact_sha256;
 if (!reportCaseSha || typeof reportCaseSha !== 'object') {
   console.error('FAIL: report missing top-level case_artifact_sha256');
@@ -444,6 +494,7 @@ console.log(`PASS: labels_v0 sha stable ${labelsShaSecond}`);
 console.log(`PASS: toc_v0 sha stable ${tocShaSecond}`);
 console.log(`PASS: bib_v0 sha stable ${bibShaSecond}`);
 console.log(`PASS: hyperref_v0 sha stable ${hyperrefShaSecond}`);
+console.log(`PASS: pkgopt_v0 sha stable ${pkgoptShaSecond}`);
 console.log('PASS: report top-level case_artifact_sha256 present');
 NODE
 

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -20,13 +20,16 @@ const STATUS_NI_V0 = 'NI';
 const STATUS_INVALID_V0 = 'INVALID';
 const STATUS_FAIL_V0 = 'FAIL';
 const EXPECTED_STATUS_VALUES_V0 = new Set([STATUS_OK_V0, STATUS_NI_V0, STATUS_INVALID_V0, STATUS_FAIL_V0]);
-const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'bib', 'hyperref'];
+const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'bib', 'hyperref', 'pkgopt'];
 const MAX_TOC_ENTRIES_V0 = 256;
 const MAX_TOC_TITLE_BYTES_V0 = 256;
 const MAX_LABEL_ENTRIES_V0 = 256;
 const MAX_LABEL_VALUE_BYTES_V0 = 256;
 const MAX_BIB_ENTRIES_V0 = 256;
 const MAX_BIB_VALUE_BYTES_V0 = 256;
+const MAX_PKGOPT_ENTRIES_V0 = 256;
+const MAX_PKGOPT_VALUE_BYTES_V0 = 256;
+const MAX_PKGOPT_OPTIONS_PER_ENTRY_V0 = 64;
 
 function sha256HexV0(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
@@ -437,6 +440,75 @@ function addBibEntryV0(entries, entry) {
   }
 }
 
+function addPkgoptEntryV0(entries, entry) {
+  const packageBytes = Buffer.from(entry.package, 'utf8');
+  if (packageBytes.length > MAX_PKGOPT_VALUE_BYTES_V0) {
+    throw new Error(`pkgopt_v0 package exceeds cap ${MAX_PKGOPT_VALUE_BYTES_V0}`);
+  }
+  if (entry.options.length > MAX_PKGOPT_OPTIONS_PER_ENTRY_V0) {
+    throw new Error(`pkgopt_v0 options exceed cap ${MAX_PKGOPT_OPTIONS_PER_ENTRY_V0}`);
+  }
+  for (const option of entry.options) {
+    const optionBytes = Buffer.from(option, 'utf8');
+    if (optionBytes.length > MAX_PKGOPT_VALUE_BYTES_V0) {
+      throw new Error(`pkgopt_v0 option exceeds cap ${MAX_PKGOPT_VALUE_BYTES_V0}`);
+    }
+  }
+  entries.push(entry);
+  if (entries.length > MAX_PKGOPT_ENTRIES_V0) {
+    throw new Error(`pkgopt_v0 entries exceed cap ${MAX_PKGOPT_ENTRIES_V0}`);
+  }
+}
+
+function extractPkgoptEntriesFromSourceV0(sourceBytes) {
+  const entries = [];
+  const packageCommands = new Set(['usepackage', 'RequirePackage']);
+  let index = 0;
+  while (index < sourceBytes.length) {
+    if (sourceBytes[index] !== 0x5c) {
+      index += 1;
+      continue;
+    }
+    let commandIndex = index + 1;
+    while (commandIndex < sourceBytes.length && isAsciiLetterByteV0(sourceBytes[commandIndex])) {
+      commandIndex += 1;
+    }
+    if (commandIndex === index + 1) {
+      index += 1;
+      continue;
+    }
+    const command = Buffer.from(sourceBytes.slice(index + 1, commandIndex)).toString('ascii');
+    if (!packageCommands.has(command)) {
+      index = commandIndex;
+      continue;
+    }
+
+    const optGroup = readBracketGroupV0(sourceBytes, commandIndex);
+    if (!optGroup.ok || optGroup.value.length === 0) {
+      index = commandIndex;
+      continue;
+    }
+
+    const pkgGroup = readBracedGroupV0(sourceBytes, optGroup.next);
+    if (!pkgGroup.ok || pkgGroup.value.length === 0) {
+      index = commandIndex;
+      continue;
+    }
+
+    const options = splitCommaValuesV0(optGroup.value);
+    const packages = splitCommaValuesV0(pkgGroup.value);
+    for (const pkgName of packages) {
+      addPkgoptEntryV0(entries, {
+        command,
+        package: pkgName,
+        options,
+      });
+    }
+    index = pkgGroup.next;
+  }
+  return entries;
+}
+
 function extractBibEntriesFromSourceV0(sourceBytes) {
   const entries = [];
   const citeCommands = new Set([
@@ -675,6 +747,24 @@ async function emitBibTypedArtifactV0(caseOutDir, fixtureBytes) {
   };
 }
 
+async function emitPkgoptTypedArtifactV0(caseOutDir, fixtureBytes) {
+  const payload = {
+    version: 1,
+    schema: 'pkgopt_v0',
+    entries: extractPkgoptEntriesFromSourceV0(fixtureBytes),
+  };
+  const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  const relpath = 'pkgopt_v0.json';
+  const fullPath = path.join(caseOutDir, relpath);
+  await writeFile(fullPath, bytes);
+  return {
+    present: true,
+    items: payload.entries.length,
+    artifact_relpath: relpath,
+    artifact_sha256: sha256HexV0(bytes),
+  };
+}
+
 async function emitTypedArtifactsV0(caseSpec, caseOutDir, typedArtifacts, fixtureBytes) {
   if (caseSpec.id === 'typeset_demo_toc_probe_v0') {
     typedArtifacts.toc = await emitTocTypedArtifactV0(caseOutDir, fixtureBytes);
@@ -687,6 +777,9 @@ async function emitTypedArtifactsV0(caseSpec, caseOutDir, typedArtifacts, fixtur
   }
   if (caseSpec.id === 'typeset_demo_hyperref_probe_v0') {
     typedArtifacts.hyperref = await emitHyperrefTypedArtifactV0(caseOutDir, fixtureBytes);
+  }
+  if (caseSpec.id === 'typeset_demo_pkgopt_probe_v0') {
+    typedArtifacts.pkgopt = await emitPkgoptTypedArtifactV0(caseOutDir, fixtureBytes);
   }
 }
 


### PR DESCRIPTION
## Summary\n- add pkgopt_v0 typed artifact extraction for package option bundles from usepackage/RequirePackage option forms\n- enforce deterministic ordering and strict caps for pkgopt entries/options\n- extend fixture-gallery proof to assert pkgopt_v0 is non-empty for pkgopt probe and sha-stable across reruns\n\n## Proof\n- ./scripts/proof_wasm_fixture_gallery_v0.sh\n