### PR TITLE
Gallery: add graphics_v0 typed artifact extraction

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -188,6 +188,34 @@ if (pkgoptArtifactFirst.entries.length <= 0) {
   process.exit(1);
 }
 fs.writeFileSync(firstRunShaPath('pkgopt_v0'), `${pkgoptShaFirst}\n`);
+
+const graphicsSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_graphics_probe_v0', 'summary.json'), 'utf8'),
+);
+if (graphicsSummary?.typed_artifacts?.graphics?.present !== true) {
+  console.error('FAIL: expected graphics typed artifact present after first run');
+  process.exit(1);
+}
+const graphicsPath = path.join(outDir, 'typeset_demo_graphics_probe_v0', 'graphics_v0.json');
+if (!fs.existsSync(graphicsPath)) {
+  console.error('FAIL: expected graphics_v0.json artifact after first run');
+  process.exit(1);
+}
+const graphicsShaFirst = graphicsSummary.typed_artifacts.graphics.artifact_sha256;
+if (typeof graphicsShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(graphicsShaFirst)) {
+  console.error('FAIL: expected graphics artifact sha256 in first summary');
+  process.exit(1);
+}
+const graphicsArtifactFirst = JSON.parse(fs.readFileSync(graphicsPath, 'utf8'));
+if (!Array.isArray(graphicsArtifactFirst?.entries)) {
+  console.error('FAIL: expected graphics_v0.entries array in first-run artifact');
+  process.exit(1);
+}
+if (graphicsArtifactFirst.entries.length <= 0) {
+  console.error('FAIL: expected non-empty graphics_v0.entries for graphics probe');
+  process.exit(1);
+}
+fs.writeFileSync(firstRunShaPath('graphics_v0'), `${graphicsShaFirst}\n`);
 NODE
 
 node "$ROOT_DIR/scripts/texlive_smoke/baselines_v0/generate_v0.mjs" "$OUT_DIR" "$BASELINE_DIR_A"
@@ -299,12 +327,13 @@ const outDir = process.argv[2];
 const report = JSON.parse(fs.readFileSync(path.join(outDir, 'report.json'), 'utf8'));
 const statuses = Array.isArray(report.statuses) ? report.statuses : [];
 const resolvedCount = Number(report.resolved_resources_count ?? 0);
-const requiredTypedKeys = ['toc', 'labels', 'bib', 'hyperref', 'pkgopt'];
+const requiredTypedKeys = ['toc', 'labels', 'bib', 'hyperref', 'pkgopt', 'graphics'];
 const labelsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'labels_v0_first.sha256'), 'utf8').trim();
 const tocShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'toc_v0_first.sha256'), 'utf8').trim();
 const bibShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'bib_v0_first.sha256'), 'utf8').trim();
 const hyperrefShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'hyperref_v0_first.sha256'), 'utf8').trim();
 const pkgoptShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'pkgopt_v0_first.sha256'), 'utf8').trim();
+const graphicsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'graphics_v0_first.sha256'), 'utf8').trim();
 
 if (resolvedCount <= 0) {
   console.error('FAIL: expected at least one resolved resource in fixture gallery summaries');
@@ -459,6 +488,27 @@ if (!Array.isArray(pkgoptArtifactSecond?.entries) || pkgoptArtifactSecond.entrie
   process.exit(1);
 }
 
+const graphicsSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_graphics_probe_v0', 'summary.json'), 'utf8'),
+);
+const graphicsArtifact = graphicsSummary?.typed_artifacts?.graphics;
+if (!graphicsArtifact || graphicsArtifact.present !== true) {
+  console.error('FAIL: expected graphics typed artifact present after second run');
+  process.exit(1);
+}
+const graphicsShaSecond = graphicsArtifact.artifact_sha256;
+if (graphicsShaSecond !== graphicsShaFirst) {
+  console.error('FAIL: graphics_v0 artifact sha256 must be stable across reruns');
+  process.exit(1);
+}
+const graphicsArtifactSecond = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_graphics_probe_v0', 'graphics_v0.json'), 'utf8'),
+);
+if (!Array.isArray(graphicsArtifactSecond?.entries) || graphicsArtifactSecond.entries.length <= 0) {
+  console.error('FAIL: expected non-empty graphics_v0.entries after rerun');
+  process.exit(1);
+}
+
 const reportCaseSha = report.case_artifact_sha256;
 if (!reportCaseSha || typeof reportCaseSha !== 'object') {
   console.error('FAIL: report missing top-level case_artifact_sha256');
@@ -495,6 +545,7 @@ console.log(`PASS: toc_v0 sha stable ${tocShaSecond}`);
 console.log(`PASS: bib_v0 sha stable ${bibShaSecond}`);
 console.log(`PASS: hyperref_v0 sha stable ${hyperrefShaSecond}`);
 console.log(`PASS: pkgopt_v0 sha stable ${pkgoptShaSecond}`);
+console.log(`PASS: graphics_v0 sha stable ${graphicsShaSecond}`);
 console.log('PASS: report top-level case_artifact_sha256 present');
 NODE
 

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -20,7 +20,7 @@ const STATUS_NI_V0 = 'NI';
 const STATUS_INVALID_V0 = 'INVALID';
 const STATUS_FAIL_V0 = 'FAIL';
 const EXPECTED_STATUS_VALUES_V0 = new Set([STATUS_OK_V0, STATUS_NI_V0, STATUS_INVALID_V0, STATUS_FAIL_V0]);
-const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'bib', 'hyperref', 'pkgopt'];
+const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'bib', 'hyperref', 'pkgopt', 'graphics'];
 const MAX_TOC_ENTRIES_V0 = 256;
 const MAX_TOC_TITLE_BYTES_V0 = 256;
 const MAX_LABEL_ENTRIES_V0 = 256;
@@ -30,6 +30,8 @@ const MAX_BIB_VALUE_BYTES_V0 = 256;
 const MAX_PKGOPT_ENTRIES_V0 = 256;
 const MAX_PKGOPT_VALUE_BYTES_V0 = 256;
 const MAX_PKGOPT_OPTIONS_PER_ENTRY_V0 = 64;
+const MAX_GRAPHICS_ENTRIES_V0 = 256;
+const MAX_GRAPHICS_PATH_BYTES_V0 = 256;
 
 function sha256HexV0(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
@@ -509,6 +511,55 @@ function extractPkgoptEntriesFromSourceV0(sourceBytes) {
   return entries;
 }
 
+function extractGraphicsEntriesFromSourceV0(sourceBytes) {
+  const entries = [];
+  let index = 0;
+  while (index < sourceBytes.length) {
+    if (sourceBytes[index] !== 0x5c) {
+      index += 1;
+      continue;
+    }
+    let commandIndex = index + 1;
+    while (commandIndex < sourceBytes.length && isAsciiLetterByteV0(sourceBytes[commandIndex])) {
+      commandIndex += 1;
+    }
+    if (commandIndex === index + 1) {
+      index += 1;
+      continue;
+    }
+    const command = Buffer.from(sourceBytes.slice(index + 1, commandIndex)).toString('ascii');
+    if (command !== 'includegraphics') {
+      index = commandIndex;
+      continue;
+    }
+
+    let next = commandIndex;
+    const optGroup = readBracketGroupV0(sourceBytes, next);
+    if (optGroup.ok) {
+      next = optGroup.next;
+    }
+
+    const pathGroup = readBracedGroupV0(sourceBytes, next);
+    if (!pathGroup.ok || pathGroup.value.length === 0) {
+      index = commandIndex;
+      continue;
+    }
+    const pathBytes = Buffer.from(pathGroup.value, 'utf8');
+    if (pathBytes.length > MAX_GRAPHICS_PATH_BYTES_V0) {
+      throw new Error(`graphics_v0 path exceeds cap ${MAX_GRAPHICS_PATH_BYTES_V0}`);
+    }
+    entries.push({
+      command,
+      path: pathGroup.value,
+    });
+    if (entries.length > MAX_GRAPHICS_ENTRIES_V0) {
+      throw new Error(`graphics_v0 entries exceed cap ${MAX_GRAPHICS_ENTRIES_V0}`);
+    }
+    index = pathGroup.next;
+  }
+  return entries;
+}
+
 function extractBibEntriesFromSourceV0(sourceBytes) {
   const entries = [];
   const citeCommands = new Set([
@@ -765,6 +816,24 @@ async function emitPkgoptTypedArtifactV0(caseOutDir, fixtureBytes) {
   };
 }
 
+async function emitGraphicsTypedArtifactV0(caseOutDir, fixtureBytes) {
+  const payload = {
+    version: 1,
+    schema: 'graphics_v0',
+    entries: extractGraphicsEntriesFromSourceV0(fixtureBytes),
+  };
+  const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  const relpath = 'graphics_v0.json';
+  const fullPath = path.join(caseOutDir, relpath);
+  await writeFile(fullPath, bytes);
+  return {
+    present: true,
+    items: payload.entries.length,
+    artifact_relpath: relpath,
+    artifact_sha256: sha256HexV0(bytes),
+  };
+}
+
 async function emitTypedArtifactsV0(caseSpec, caseOutDir, typedArtifacts, fixtureBytes) {
   if (caseSpec.id === 'typeset_demo_toc_probe_v0') {
     typedArtifacts.toc = await emitTocTypedArtifactV0(caseOutDir, fixtureBytes);
@@ -780,6 +849,9 @@ async function emitTypedArtifactsV0(caseSpec, caseOutDir, typedArtifacts, fixtur
   }
   if (caseSpec.id === 'typeset_demo_pkgopt_probe_v0') {
     typedArtifacts.pkgopt = await emitPkgoptTypedArtifactV0(caseOutDir, fixtureBytes);
+  }
+  if (caseSpec.id === 'typeset_demo_graphics_probe_v0') {
+    typedArtifacts.graphics = await emitGraphicsTypedArtifactV0(caseOutDir, fixtureBytes);
   }
 }
 


### PR DESCRIPTION
## Summary
- add graphics_v0 typed artifact extraction for includegraphics resource hints
- wire graphics_v0 into gallery typed artifact keys and per-case emission
- extend fixture gallery proof to assert graphics_v0 non-empty and sha-stable across reruns

## Proof
- ./scripts/proof_wasm_fixture_gallery_v0.sh
