### PR TITLE
Gallery: tighten typed artifact schema and report sha map

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -151,12 +151,12 @@ if (typeof hyperrefShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(hyperrefShaFi
   process.exit(1);
 }
 const hyperrefArtifactFirst = JSON.parse(fs.readFileSync(hyperrefPath, 'utf8'));
-if (!Array.isArray(hyperrefArtifactFirst?.links)) {
-  console.error('FAIL: expected hyperref_v0.links array in first-run artifact');
+if (!Array.isArray(hyperrefArtifactFirst?.entries)) {
+  console.error('FAIL: expected hyperref_v0.entries array in first-run artifact');
   process.exit(1);
 }
-if (hyperrefArtifactFirst.links.length <= 0) {
-  console.error('FAIL: expected hyperref_v0.links to include at least one link in probe fixture');
+if (hyperrefArtifactFirst.entries.length <= 0) {
+  console.error('FAIL: expected hyperref_v0.entries to include at least one link in probe fixture');
   process.exit(1);
 }
 fs.writeFileSync(firstRunShaPath('hyperref_v0'), `${hyperrefShaFirst}\n`);
@@ -216,6 +216,25 @@ if (graphicsArtifactFirst.entries.length <= 0) {
   process.exit(1);
 }
 fs.writeFileSync(firstRunShaPath('graphics_v0'), `${graphicsShaFirst}\n`);
+
+const report = JSON.parse(fs.readFileSync(path.join(outDir, 'report.json'), 'utf8'));
+const typedArtifactShaMap = report?.typed_artifact_sha256;
+if (!typedArtifactShaMap || typeof typedArtifactShaMap !== 'object') {
+  console.error('FAIL: expected report.typed_artifact_sha256 map after first run');
+  process.exit(1);
+}
+const typedKeys = ['toc', 'labels', 'bib', 'hyperref', 'pkgopt', 'graphics'];
+for (const key of typedKeys) {
+  const value = typedArtifactShaMap[key];
+  if (typeof value !== 'string' || !/^[0-9a-f]{64}$/.test(value)) {
+    console.error(`FAIL: expected report.typed_artifact_sha256.${key} sha256 after first run`);
+    process.exit(1);
+  }
+}
+fs.writeFileSync(
+  path.join(baselineRoot, 'typed_artifact_sha256_first.json'),
+  `${JSON.stringify(typedArtifactShaMap, null, 2)}\n`,
+);
 NODE
 
 node "$ROOT_DIR/scripts/texlive_smoke/baselines_v0/generate_v0.mjs" "$OUT_DIR" "$BASELINE_DIR_A"
@@ -462,8 +481,8 @@ if (hyperrefShaSecond !== hyperrefShaFirst) {
 const hyperrefArtifactSecond = JSON.parse(
   fs.readFileSync(path.join(outDir, 'typeset_demo_hyperref_probe_v0', 'hyperref_v0.json'), 'utf8'),
 );
-if (!Array.isArray(hyperrefArtifactSecond?.links) || hyperrefArtifactSecond.links.length <= 0) {
-  console.error('FAIL: expected non-empty hyperref_v0.links array after rerun');
+if (!Array.isArray(hyperrefArtifactSecond?.entries) || hyperrefArtifactSecond.entries.length <= 0) {
+  console.error('FAIL: expected non-empty hyperref_v0.entries array after rerun');
   process.exit(1);
 }
 
@@ -514,6 +533,25 @@ if (!reportCaseSha || typeof reportCaseSha !== 'object') {
   console.error('FAIL: report missing top-level case_artifact_sha256');
   process.exit(1);
 }
+const reportTypedSha = report.typed_artifact_sha256;
+if (!reportTypedSha || typeof reportTypedSha !== 'object') {
+  console.error('FAIL: report missing top-level typed_artifact_sha256');
+  process.exit(1);
+}
+const reportTypedShaFirst = JSON.parse(
+  fs.readFileSync(path.join(`${outDir}_baseline`, 'typed_artifact_sha256_first.json'), 'utf8'),
+);
+for (const key of requiredTypedKeys) {
+  const value = reportTypedSha[key];
+  if (typeof value !== 'string' || !/^[0-9a-f]{64}$/.test(value)) {
+    console.error(`FAIL: report typed_artifact_sha256.${key} missing or invalid`);
+    process.exit(1);
+  }
+  if (value !== reportTypedShaFirst[key]) {
+    console.error(`FAIL: report typed_artifact_sha256.${key} must be stable across reruns`);
+    process.exit(1);
+  }
+}
 for (const status of statuses) {
   const caseSha = reportCaseSha[status.case_id];
   if (!caseSha || typeof caseSha !== 'object') {
@@ -546,6 +584,7 @@ console.log(`PASS: bib_v0 sha stable ${bibShaSecond}`);
 console.log(`PASS: hyperref_v0 sha stable ${hyperrefShaSecond}`);
 console.log(`PASS: pkgopt_v0 sha stable ${pkgoptShaSecond}`);
 console.log(`PASS: graphics_v0 sha stable ${graphicsShaSecond}`);
+console.log('PASS: report typed_artifact_sha256 map present and stable');
 console.log('PASS: report top-level case_artifact_sha256 present');
 NODE
 

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -766,7 +766,7 @@ async function emitHyperrefTypedArtifactV0(caseOutDir, fixtureBytes) {
   const payload = {
     version: 1,
     schema: 'hyperref_v0',
-    links: extractHyperrefLinksFromSourceV0(fixtureBytes),
+    entries: extractHyperrefLinksFromSourceV0(fixtureBytes),
   };
   const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
   const relpath = 'hyperref_v0.json';
@@ -774,7 +774,7 @@ async function emitHyperrefTypedArtifactV0(caseOutDir, fixtureBytes) {
   await writeFile(fullPath, bytes);
   return {
     present: true,
-    items: payload.links.length,
+    items: payload.entries.length,
     artifact_relpath: relpath,
     artifact_sha256: sha256HexV0(bytes),
   };
@@ -1133,6 +1133,21 @@ async function run() {
           ),
         },
       ]),
+    ),
+    typed_artifact_sha256: Object.fromEntries(
+      TYPED_ARTIFACT_KEYS_V0.map((key) => {
+        const digestPayload = {
+          version: 1,
+          schema: `${key}_sha_rollup_v0`,
+          entries: summaries
+            .map((summary) => ({
+              case_id: summary.case_id,
+              artifact_sha256: summary.typed_artifacts?.[key]?.artifact_sha256 ?? null,
+            }))
+            .sort((left, right) => left.case_id.localeCompare(right.case_id)),
+        };
+        return [key, sha256HexV0(Buffer.from(JSON.stringify(digestPayload), 'utf8'))];
+      }),
     ),
     statuses: summaries.map((summary) => ({
       case_id: summary.case_id,


### PR DESCRIPTION
## Summary
- enforce consistent typed artifact payload shape as `{version,schema,entries}` (including `hyperref_v0`)
- add top-level `report.typed_artifact_sha256` rollup map for dashboard diffing
- extend gallery proof to assert map presence/keys and rerun stability

## Proof
- `./scripts/proof_wasm_fixture_gallery_v0.sh`
