### PR TITLE
Gallery: add source spans to typed artifact entries

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -48,6 +48,26 @@ const outDir = process.argv[2];
 const baselineRoot = process.argv[3];
 
 const firstRunShaPath = (name) => path.join(baselineRoot, `${name}_first.sha256`);
+const assertEntrySourceSpans = (caseId, artifactName, entries) => {
+  const sourceLen = fs.readFileSync(path.join(outDir, caseId, 'main.tex')).length;
+  entries.forEach((entry, entryIndex) => {
+    const span = entry?.source_span;
+    if (!span || typeof span !== 'object') {
+      console.error(`FAIL: ${artifactName}.entries[${entryIndex}] missing source_span`);
+      process.exit(1);
+    }
+    const start = span.start_byte;
+    const end = span.end_byte;
+    if (!Number.isInteger(start) || !Number.isInteger(end)) {
+      console.error(`FAIL: ${artifactName}.entries[${entryIndex}] source_span must use integer offsets`);
+      process.exit(1);
+    }
+    if (start < 0 || end <= start || end > sourceLen) {
+      console.error(`FAIL: ${artifactName}.entries[${entryIndex}] source_span out of bounds for ${caseId}`);
+      process.exit(1);
+    }
+  });
+};
 
 const labelsSummary = JSON.parse(
   fs.readFileSync(path.join(outDir, 'typeset_demo_labels_probe_v0', 'summary.json'), 'utf8'),
@@ -75,6 +95,7 @@ if (labelsArtifactFirst.entries.length <= 0) {
   console.error('FAIL: expected non-empty labels_v0.entries for labels probe');
   process.exit(1);
 }
+assertEntrySourceSpans('typeset_demo_labels_probe_v0', 'labels_v0', labelsArtifactFirst.entries);
 fs.writeFileSync(firstRunShaPath('labels_v0'), `${labelsShaFirst}\n`);
 
 const tocSummary = JSON.parse(
@@ -103,6 +124,7 @@ if (tocArtifactFirst.entries.length <= 0) {
   console.error('FAIL: expected non-empty toc_v0.entries for toc probe');
   process.exit(1);
 }
+assertEntrySourceSpans('typeset_demo_toc_probe_v0', 'toc_v0', tocArtifactFirst.entries);
 fs.writeFileSync(firstRunShaPath('toc_v0'), `${tocShaFirst}\n`);
 
 const bibSummary = JSON.parse(
@@ -131,6 +153,7 @@ if (bibArtifactFirst.entries.length <= 0) {
   console.error('FAIL: expected non-empty bib_v0.entries for bib probe');
   process.exit(1);
 }
+assertEntrySourceSpans('typeset_demo_bib_probe_v0', 'bib_v0', bibArtifactFirst.entries);
 fs.writeFileSync(firstRunShaPath('bib_v0'), `${bibShaFirst}\n`);
 
 const hyperrefSummary = JSON.parse(
@@ -159,6 +182,7 @@ if (hyperrefArtifactFirst.entries.length <= 0) {
   console.error('FAIL: expected hyperref_v0.entries to include at least one link in probe fixture');
   process.exit(1);
 }
+assertEntrySourceSpans('typeset_demo_hyperref_probe_v0', 'hyperref_v0', hyperrefArtifactFirst.entries);
 fs.writeFileSync(firstRunShaPath('hyperref_v0'), `${hyperrefShaFirst}\n`);
 
 const pkgoptSummary = JSON.parse(
@@ -187,6 +211,7 @@ if (pkgoptArtifactFirst.entries.length <= 0) {
   console.error('FAIL: expected non-empty pkgopt_v0.entries for pkgopt probe');
   process.exit(1);
 }
+assertEntrySourceSpans('typeset_demo_pkgopt_probe_v0', 'pkgopt_v0', pkgoptArtifactFirst.entries);
 fs.writeFileSync(firstRunShaPath('pkgopt_v0'), `${pkgoptShaFirst}\n`);
 
 const graphicsSummary = JSON.parse(
@@ -215,6 +240,7 @@ if (graphicsArtifactFirst.entries.length <= 0) {
   console.error('FAIL: expected non-empty graphics_v0.entries for graphics probe');
   process.exit(1);
 }
+assertEntrySourceSpans('typeset_demo_graphics_probe_v0', 'graphics_v0', graphicsArtifactFirst.entries);
 fs.writeFileSync(firstRunShaPath('graphics_v0'), `${graphicsShaFirst}\n`);
 
 const report = JSON.parse(fs.readFileSync(path.join(outDir, 'report.json'), 'utf8'));

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -408,10 +408,7 @@ function extractTocEntriesFromSourceV0(sourceBytes) {
       entries.push({
         level,
         title: titleGroup.value,
-        source_span: {
-          start_byte: index,
-          end_byte: titleGroup.next,
-        },
+        source_span: buildSourceSpanV0(sourceBytes, index, titleGroup.next, 'toc_v0'),
       });
       if (entries.length > MAX_TOC_ENTRIES_V0) {
         throw new Error(`toc_v0 entries exceed cap ${MAX_TOC_ENTRIES_V0}`);
@@ -440,6 +437,22 @@ function addBibEntryV0(entries, entry) {
   if (entries.length > MAX_BIB_ENTRIES_V0) {
     throw new Error(`bib_v0 entries exceed cap ${MAX_BIB_ENTRIES_V0}`);
   }
+}
+
+function buildSourceSpanV0(sourceBytes, startByte, endByte, artifactName) {
+  if (!Number.isInteger(startByte) || !Number.isInteger(endByte)) {
+    throw new Error(`${artifactName} source_span must use integer byte offsets`);
+  }
+  if (startByte < 0 || endByte < 0 || endByte <= startByte) {
+    throw new Error(`${artifactName} source_span must satisfy 0 <= start < end`);
+  }
+  if (endByte > sourceBytes.length) {
+    throw new Error(`${artifactName} source_span exceeds source byte length`);
+  }
+  return {
+    start_byte: startByte,
+    end_byte: endByte,
+  };
 }
 
 function addPkgoptEntryV0(entries, entry) {
@@ -504,6 +517,7 @@ function extractPkgoptEntriesFromSourceV0(sourceBytes) {
         command,
         package: pkgName,
         options,
+        source_span: buildSourceSpanV0(sourceBytes, index, pkgGroup.next, 'pkgopt_v0'),
       });
     }
     index = pkgGroup.next;
@@ -551,6 +565,7 @@ function extractGraphicsEntriesFromSourceV0(sourceBytes) {
     entries.push({
       command,
       path: pathGroup.value,
+      source_span: buildSourceSpanV0(sourceBytes, index, pathGroup.next, 'graphics_v0'),
     });
     if (entries.length > MAX_GRAPHICS_ENTRIES_V0) {
       throw new Error(`graphics_v0 entries exceed cap ${MAX_GRAPHICS_ENTRIES_V0}`);
@@ -607,7 +622,12 @@ function extractBibEntriesFromSourceV0(sourceBytes) {
         continue;
       }
       for (const value of splitCommaValuesV0(resourceGroup.value)) {
-        addBibEntryV0(entries, { kind: 'resource_hint', command, value });
+        addBibEntryV0(entries, {
+          kind: 'resource_hint',
+          command,
+          value,
+          source_span: buildSourceSpanV0(sourceBytes, index, resourceGroup.next, 'bib_v0'),
+        });
       }
       index = resourceGroup.next;
       continue;
@@ -628,7 +648,12 @@ function extractBibEntriesFromSourceV0(sourceBytes) {
         continue;
       }
       for (const key of splitCommaValuesV0(citeGroup.value)) {
-        addBibEntryV0(entries, { kind: 'cite_key', command, key });
+        addBibEntryV0(entries, {
+          kind: 'cite_key',
+          command,
+          key,
+          source_span: buildSourceSpanV0(sourceBytes, index, citeGroup.next, 'bib_v0'),
+        });
       }
       index = citeGroup.next;
       continue;
@@ -659,7 +684,11 @@ function extractHyperrefLinksFromSourceV0(sourceBytes) {
     if (command === 'url') {
       const urlGroup = readBracedGroupV0(sourceBytes, commandIndex);
       if (urlGroup.ok && urlGroup.value.length > 0) {
-        links.push({ command: 'url', target: urlGroup.value });
+        links.push({
+          command: 'url',
+          target: urlGroup.value,
+          source_span: buildSourceSpanV0(sourceBytes, index, urlGroup.next, 'hyperref_v0'),
+        });
       }
       index = urlGroup.ok ? urlGroup.next : commandIndex;
       continue;
@@ -672,7 +701,11 @@ function extractHyperrefLinksFromSourceV0(sourceBytes) {
       }
       const textGroup = readBracedGroupV0(sourceBytes, urlGroup.next);
       if (textGroup.ok && urlGroup.value.length > 0) {
-        links.push({ command: 'href', target: urlGroup.value });
+        links.push({
+          command: 'href',
+          target: urlGroup.value,
+          source_span: buildSourceSpanV0(sourceBytes, index, textGroup.next, 'hyperref_v0'),
+        });
       }
       index = textGroup.ok ? textGroup.next : urlGroup.next;
       continue;
@@ -716,6 +749,7 @@ function extractLabelEntriesFromSourceV0(sourceBytes) {
       entries.push({
         command,
         key: keyGroup.value,
+        source_span: buildSourceSpanV0(sourceBytes, index, keyGroup.next, 'labels_v0'),
       });
       if (entries.length > MAX_LABEL_ENTRIES_V0) {
         throw new Error(`labels_v0 entries exceed cap ${MAX_LABEL_ENTRIES_V0}`);


### PR DESCRIPTION
## Summary
- add `source_span` (`start_byte`,`end_byte`) to typed artifact entries across `toc`/`labels`/`bib`/`hyperref`/`pkgopt`/`graphics`
- enforce strict source-span validation in extraction helpers
- extend fixture gallery proof to assert span presence and in-range bounds for probe fixtures

## Proof
- `./scripts/proof_wasm_fixture_gallery_v0.sh`
