### PR TITLE
Gallery: add typed artifacts version gate

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -244,6 +244,10 @@ assertEntrySourceSpans('typeset_demo_graphics_probe_v0', 'graphics_v0', graphics
 fs.writeFileSync(firstRunShaPath('graphics_v0'), `${graphicsShaFirst}\n`);
 
 const report = JSON.parse(fs.readFileSync(path.join(outDir, 'report.json'), 'utf8'));
+if (report?.typed_artifacts_version !== 1) {
+  console.error('FAIL: expected report.typed_artifacts_version=1 after first run');
+  process.exit(1);
+}
 const typedArtifactShaMap = report?.typed_artifact_sha256;
 if (!typedArtifactShaMap || typeof typedArtifactShaMap !== 'object') {
   console.error('FAIL: expected report.typed_artifact_sha256 map after first run');
@@ -372,6 +376,10 @@ const outDir = process.argv[2];
 const report = JSON.parse(fs.readFileSync(path.join(outDir, 'report.json'), 'utf8'));
 const statuses = Array.isArray(report.statuses) ? report.statuses : [];
 const resolvedCount = Number(report.resolved_resources_count ?? 0);
+if (report?.typed_artifacts_version !== 1) {
+  console.error('FAIL: expected report.typed_artifacts_version=1 after rerun');
+  process.exit(1);
+}
 const requiredTypedKeys = ['toc', 'labels', 'bib', 'hyperref', 'pkgopt', 'graphics'];
 const labelsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'labels_v0_first.sha256'), 'utf8').trim();
 const tocShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'toc_v0_first.sha256'), 'utf8').trim();
@@ -397,6 +405,10 @@ for (const status of okStatuses) {
 }
 
 for (const status of statuses) {
+  if (status?.typed_artifacts_version !== 1) {
+    console.error(`FAIL: case ${status.case_id} status missing typed_artifacts_version=1`);
+    process.exit(1);
+  }
   const typedPresence = status.typed_artifacts_presence;
   if (!typedPresence || typeof typedPresence !== 'object') {
     console.error(`FAIL: case ${status.case_id} missing typed_artifacts_presence`);
@@ -410,6 +422,10 @@ for (const status of statuses) {
   }
   const summaryPath = path.join(outDir, status.case_id, 'summary.json');
   const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+  if (summary?.typed_artifacts_version !== 1) {
+    console.error(`FAIL: case ${status.case_id} summary missing typed_artifacts_version=1`);
+    process.exit(1);
+  }
   const typedArtifacts = summary.typed_artifacts;
   if (!typedArtifacts || typeof typedArtifacts !== 'object') {
     console.error(`FAIL: case ${status.case_id} missing typed_artifacts`);
@@ -604,6 +620,7 @@ for (const status of statuses) {
 console.log(`PASS: resolved_resources_count ${resolvedCount}`);
 console.log(`PASS: baseline_match MATCH for all OK cases (${okStatuses.length})`);
 console.log(`PASS: typed_artifacts keys ${requiredTypedKeys.join(',')}`);
+console.log('PASS: typed_artifacts_version gate 1');
 console.log(`PASS: labels_v0 sha stable ${labelsShaSecond}`);
 console.log(`PASS: toc_v0 sha stable ${tocShaSecond}`);
 console.log(`PASS: bib_v0 sha stable ${bibShaSecond}`);

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -21,6 +21,7 @@ const STATUS_INVALID_V0 = 'INVALID';
 const STATUS_FAIL_V0 = 'FAIL';
 const EXPECTED_STATUS_VALUES_V0 = new Set([STATUS_OK_V0, STATUS_NI_V0, STATUS_INVALID_V0, STATUS_FAIL_V0]);
 const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'bib', 'hyperref', 'pkgopt', 'graphics'];
+const TYPED_ARTIFACTS_VERSION_V0 = 1;
 const MAX_TOC_ENTRIES_V0 = 256;
 const MAX_TOC_TITLE_BYTES_V0 = 256;
 const MAX_LABEL_ENTRIES_V0 = 256;
@@ -276,7 +277,7 @@ function buildTypedArtifactsPlaceholderV0() {
 
 async function emitPlaceholderTypedArtifactV0(caseOutDir, artifactName, schemaName) {
   const payload = {
-    version: 1,
+    version: TYPED_ARTIFACTS_VERSION_V0,
     schema: schemaName,
     entries: [],
   };
@@ -762,7 +763,7 @@ function extractLabelEntriesFromSourceV0(sourceBytes) {
 
 async function emitLabelsTypedArtifactV0(caseOutDir, fixtureBytes) {
   const payload = {
-    version: 1,
+    version: TYPED_ARTIFACTS_VERSION_V0,
     schema: 'labels_v0',
     entries: extractLabelEntriesFromSourceV0(fixtureBytes),
   };
@@ -780,7 +781,7 @@ async function emitLabelsTypedArtifactV0(caseOutDir, fixtureBytes) {
 
 async function emitTocTypedArtifactV0(caseOutDir, fixtureBytes) {
   const payload = {
-    version: 1,
+    version: TYPED_ARTIFACTS_VERSION_V0,
     schema: 'toc_v0',
     entries: extractTocEntriesFromSourceV0(fixtureBytes),
   };
@@ -798,7 +799,7 @@ async function emitTocTypedArtifactV0(caseOutDir, fixtureBytes) {
 
 async function emitHyperrefTypedArtifactV0(caseOutDir, fixtureBytes) {
   const payload = {
-    version: 1,
+    version: TYPED_ARTIFACTS_VERSION_V0,
     schema: 'hyperref_v0',
     entries: extractHyperrefLinksFromSourceV0(fixtureBytes),
   };
@@ -816,7 +817,7 @@ async function emitHyperrefTypedArtifactV0(caseOutDir, fixtureBytes) {
 
 async function emitBibTypedArtifactV0(caseOutDir, fixtureBytes) {
   const payload = {
-    version: 1,
+    version: TYPED_ARTIFACTS_VERSION_V0,
     schema: 'bib_v0',
     entries: extractBibEntriesFromSourceV0(fixtureBytes),
   };
@@ -834,7 +835,7 @@ async function emitBibTypedArtifactV0(caseOutDir, fixtureBytes) {
 
 async function emitPkgoptTypedArtifactV0(caseOutDir, fixtureBytes) {
   const payload = {
-    version: 1,
+    version: TYPED_ARTIFACTS_VERSION_V0,
     schema: 'pkgopt_v0',
     entries: extractPkgoptEntriesFromSourceV0(fixtureBytes),
   };
@@ -852,7 +853,7 @@ async function emitPkgoptTypedArtifactV0(caseOutDir, fixtureBytes) {
 
 async function emitGraphicsTypedArtifactV0(caseOutDir, fixtureBytes) {
   const payload = {
-    version: 1,
+    version: TYPED_ARTIFACTS_VERSION_V0,
     schema: 'graphics_v0',
     entries: extractGraphicsEntriesFromSourceV0(fixtureBytes),
   };
@@ -1071,6 +1072,7 @@ async function runCaseV0(
     },
     resolver_id: resolver.resolverId,
     resolved_resources: resolvedResources,
+    typed_artifacts_version: TYPED_ARTIFACTS_VERSION_V0,
     typed_artifacts: buildTypedArtifactsPlaceholderV0(),
   };
   await emitTypedArtifactsV0(caseSpec, caseOutDir, summary.typed_artifacts, fixtureBytes);
@@ -1148,6 +1150,7 @@ async function run() {
     baseline_dir: baselineDir || null,
     manifest_path: manifestPath,
     config_hash: configHash,
+    typed_artifacts_version: TYPED_ARTIFACTS_VERSION_V0,
     case_count: summaries.length,
     resolved_resources_count: summaries.reduce(
       (sum, summary) => sum + (Array.isArray(summary.resolved_resources) ? summary.resolved_resources.length : 0),
@@ -1184,6 +1187,7 @@ async function run() {
       }),
     ),
     statuses: summaries.map((summary) => ({
+      typed_artifacts_version: summary.typed_artifacts_version,
       case_id: summary.case_id,
       tags: summary.tags,
       expected_status: summary.expected_status,
@@ -1196,6 +1200,13 @@ async function run() {
       artifact_sha256: summary.artifact_sha256,
     })),
   };
+  for (const summary of summaries) {
+    if (summary.typed_artifacts_version !== TYPED_ARTIFACTS_VERSION_V0) {
+      throw new Error(
+        `typed_artifacts_version mismatch for case ${summary.case_id}: expected ${TYPED_ARTIFACTS_VERSION_V0}, got ${summary.typed_artifacts_version}`,
+      );
+    }
+  }
   await writeFile(path.join(outDir, 'report.json'), `${JSON.stringify(report, null, 2)}\n`);
 
   if (summaries.some((summary) => summary.status === STATUS_FAIL_V0)) {


### PR DESCRIPTION
## Summary
- add typed_artifacts_version=1 to per-case summary and report
- fail closed if any case summary version mismatches expected v1
- extend fixture gallery proof to assert typed_artifacts_version gate

## Proof
- ./scripts/proof_wasm_fixture_gallery_v0.sh
