### PR TITLE
Baselines: include typed artifact metadata

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -270,13 +270,14 @@ NODE
 node "$ROOT_DIR/scripts/texlive_smoke/baselines_v0/generate_v0.mjs" "$OUT_DIR" "$BASELINE_DIR_A"
 node "$ROOT_DIR/scripts/texlive_smoke/baselines_v0/generate_v0.mjs" "$OUT_DIR" "$BASELINE_DIR_B"
 
-node - "$BASELINE_DIR_A" "$BASELINE_DIR_B" <<'NODE'
+node - "$BASELINE_DIR_A" "$BASELINE_DIR_B" "$OUT_DIR" <<'NODE'
 const fs = require('node:fs');
 const path = require('node:path');
 const crypto = require('node:crypto');
 
 const baselineDirA = process.argv[2];
 const baselineDirB = process.argv[3];
+const outDir = process.argv[4];
 
 const sha256 = (bytes) => crypto.createHash('sha256').update(bytes).digest('hex');
 const readJson = (p) => JSON.parse(fs.readFileSync(p, 'utf8'));
@@ -294,6 +295,7 @@ if (indexASha !== indexBSha) {
 
 const indexA = readJson(indexAPath);
 const indexB = readJson(indexBPath);
+const report = readJson(path.join(outDir, 'report.json'));
 if (indexA.engine_rev !== indexB.engine_rev || indexA.config_hash !== indexB.config_hash) {
   console.error('FAIL: baseline generator metadata mismatch between reruns');
   process.exit(1);
@@ -305,6 +307,35 @@ if (typeof indexA.engine_rev !== 'string' || indexA.engine_rev.length !== 40) {
 if (!/^[0-9a-f]{64}$/.test(indexA.config_hash)) {
   console.error('FAIL: baseline index missing valid config_hash pin');
   process.exit(1);
+}
+if (indexA.typed_artifacts_version !== 1 || indexB.typed_artifacts_version !== 1) {
+  console.error('FAIL: baseline index missing typed_artifacts_version=1');
+  process.exit(1);
+}
+if (!indexA.typed_artifact_sha256 || typeof indexA.typed_artifact_sha256 !== 'object') {
+  console.error('FAIL: baseline index missing typed_artifact_sha256 map');
+  process.exit(1);
+}
+if (!indexB.typed_artifact_sha256 || typeof indexB.typed_artifact_sha256 !== 'object') {
+  console.error('FAIL: baseline index rerun missing typed_artifact_sha256 map');
+  process.exit(1);
+}
+const typedKeys = ['toc', 'labels', 'bib', 'hyperref', 'pkgopt', 'graphics'];
+for (const key of typedKeys) {
+  const valueA = indexA.typed_artifact_sha256[key];
+  const valueB = indexB.typed_artifact_sha256[key];
+  if (!/^[0-9a-f]{64}$/.test(valueA) || !/^[0-9a-f]{64}$/.test(valueB)) {
+    console.error(`FAIL: baseline index typed_artifact_sha256 invalid for key ${key}`);
+    process.exit(1);
+  }
+  if (valueA !== valueB) {
+    console.error(`FAIL: baseline index typed_artifact_sha256 mismatch across reruns for key ${key}`);
+    process.exit(1);
+  }
+  if (report?.typed_artifact_sha256?.[key] !== valueA) {
+    console.error(`FAIL: baseline index typed_artifact_sha256 mismatch vs report for key ${key}`);
+    process.exit(1);
+  }
 }
 
 const casesA = Array.isArray(indexA.cases) ? indexA.cases : [];
@@ -353,6 +384,8 @@ for (const caseEntry of casesA) {
 console.log(`PASS: baseline generator deterministic index_sha256 ${indexASha}`);
 console.log(`PASS: baseline generator pinned engine_rev ${indexA.engine_rev}`);
 console.log(`PASS: baseline generator pinned config_hash ${indexA.config_hash}`);
+console.log(`PASS: baseline generator typed_artifacts_version ${indexA.typed_artifacts_version}`);
+console.log('PASS: baseline generator typed_artifact_sha256 map present');
 NODE
 
 node "$ROOT_DIR/scripts/texlive_smoke/baselines_v0/generate_v0.mjs" "$OUT_DIR" "$BASELINE_AUTO_PACK_DIR"

--- a/scripts/texlive_smoke/baselines_v0/generate_v0.mjs
+++ b/scripts/texlive_smoke/baselines_v0/generate_v0.mjs
@@ -65,6 +65,8 @@ export async function generateBaselinePackV0(options = {}) {
   const engineRev = report?.engine_rev;
   const configHash = report?.config_hash;
   const sourceDateEpoch = report?.source_date_epoch;
+  const typedArtifactsVersion = report?.typed_artifacts_version;
+  const typedArtifactShaMap = report?.typed_artifact_sha256;
   const statuses = Array.isArray(report?.statuses) ? report.statuses : [];
   const caseArtifactSha = report?.case_artifact_sha256;
 
@@ -76,6 +78,23 @@ export async function generateBaselinePackV0(options = {}) {
   }
   if (!Number.isInteger(sourceDateEpoch) || sourceDateEpoch <= 0) {
     throw new Error('report.source_date_epoch must be a positive integer');
+  }
+  if (!Number.isInteger(typedArtifactsVersion) || typedArtifactsVersion <= 0) {
+    throw new Error('report.typed_artifacts_version must be a positive integer');
+  }
+  if (!typedArtifactShaMap || typeof typedArtifactShaMap !== 'object') {
+    throw new Error('report.typed_artifact_sha256 must be present');
+  }
+  const typedArtifactShaEntries = Object.entries(typedArtifactShaMap)
+    .filter(([key]) => typeof key === 'string' && key.length > 0)
+    .sort(([left], [right]) => left.localeCompare(right));
+  if (typedArtifactShaEntries.length === 0) {
+    throw new Error('report.typed_artifact_sha256 must contain at least one artifact key');
+  }
+  for (const [key, value] of typedArtifactShaEntries) {
+    if (!isSha256HexV0(value)) {
+      throw new Error(`report.typed_artifact_sha256.${key} must be sha256 hex`);
+    }
   }
   if (!Array.isArray(statuses) || statuses.length === 0) {
     throw new Error('report.statuses must be a non-empty array');
@@ -110,6 +129,8 @@ export async function generateBaselinePackV0(options = {}) {
     source: 'wasm_fixture_gallery_v0',
     engine_rev: engineRev,
     config_hash: configHash,
+    typed_artifacts_version: typedArtifactsVersion,
+    typed_artifact_sha256: Object.fromEntries(typedArtifactShaEntries),
     source_date_epoch: sourceDateEpoch,
     report_sha256: sha256HexV0(reportBytes),
     case_count: normalizedCases.length,


### PR DESCRIPTION
## Summary
- include report typed artifact metadata in baseline pack index
- store `typed_artifacts_version` and `typed_artifact_sha256` in baseline `index.json`
- extend gallery proof to assert baseline metadata presence and determinism

## Proof
- `./scripts/proof_wasm_fixture_gallery_v0.sh`
