### PR TITLE
Gallery: add resource_hints_v0 report rollup

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -43,11 +43,13 @@ node "$ROOT_DIR/scripts/wasm_fixture_gallery_v0.mjs" "$OUT_DIR"
 node - "$OUT_DIR" "$BASELINE_ROOT" <<'NODE'
 const fs = require('node:fs');
 const path = require('node:path');
+const crypto = require('node:crypto');
 
 const outDir = process.argv[2];
 const baselineRoot = process.argv[3];
 
 const firstRunShaPath = (name) => path.join(baselineRoot, `${name}_first.sha256`);
+const sha256 = (bytes) => crypto.createHash('sha256').update(bytes).digest('hex');
 const assertEntrySourceSpans = (caseId, artifactName, entries) => {
   const sourceLen = fs.readFileSync(path.join(outDir, caseId, 'main.tex')).length;
   entries.forEach((entry, entryIndex) => {
@@ -248,6 +250,38 @@ if (report?.typed_artifacts_version !== 1) {
   console.error('FAIL: expected report.typed_artifacts_version=1 after first run');
   process.exit(1);
 }
+const resourceHints = report?.resource_hints_v0;
+if (!resourceHints || typeof resourceHints !== 'object') {
+  console.error('FAIL: expected report.resource_hints_v0 after first run');
+  process.exit(1);
+}
+if (resourceHints.version !== 1) {
+  console.error('FAIL: expected report.resource_hints_v0.version=1 after first run');
+  process.exit(1);
+}
+if (!Array.isArray(resourceHints.entries)) {
+  console.error('FAIL: expected report.resource_hints_v0.entries array after first run');
+  process.exit(1);
+}
+if (resourceHints.entries.length <= 0) {
+  console.error('FAIL: expected non-empty report.resource_hints_v0.entries after first run');
+  process.exit(1);
+}
+for (const [index, entry] of resourceHints.entries.entries()) {
+  if (typeof entry?.case_id !== 'string' || entry.case_id.length === 0) {
+    console.error(`FAIL: resource_hints_v0.entries[${index}] invalid case_id`);
+    process.exit(1);
+  }
+  if (typeof entry?.hint_type !== 'string' || entry.hint_type.length === 0) {
+    console.error(`FAIL: resource_hints_v0.entries[${index}] invalid hint_type`);
+    process.exit(1);
+  }
+  if (typeof entry?.value !== 'string' || entry.value.length === 0) {
+    console.error(`FAIL: resource_hints_v0.entries[${index}] invalid value`);
+    process.exit(1);
+  }
+}
+fs.writeFileSync(firstRunShaPath('resource_hints_v0'), `${sha256(Buffer.from(JSON.stringify(resourceHints)))}\n`);
 const typedArtifactShaMap = report?.typed_artifact_sha256;
 if (!typedArtifactShaMap || typeof typedArtifactShaMap !== 'object') {
   console.error('FAIL: expected report.typed_artifact_sha256 map after first run');
@@ -404,13 +438,34 @@ fi
 node - "$OUT_DIR" <<'NODE'
 const fs = require('node:fs');
 const path = require('node:path');
+const crypto = require('node:crypto');
 
 const outDir = process.argv[2];
 const report = JSON.parse(fs.readFileSync(path.join(outDir, 'report.json'), 'utf8'));
 const statuses = Array.isArray(report.statuses) ? report.statuses : [];
 const resolvedCount = Number(report.resolved_resources_count ?? 0);
+const sha256 = (bytes) => crypto.createHash('sha256').update(bytes).digest('hex');
 if (report?.typed_artifacts_version !== 1) {
   console.error('FAIL: expected report.typed_artifacts_version=1 after rerun');
+  process.exit(1);
+}
+const resourceHints = report?.resource_hints_v0;
+if (!resourceHints || typeof resourceHints !== 'object') {
+  console.error('FAIL: expected report.resource_hints_v0 after rerun');
+  process.exit(1);
+}
+if (resourceHints.version !== 1) {
+  console.error('FAIL: expected report.resource_hints_v0.version=1 after rerun');
+  process.exit(1);
+}
+if (!Array.isArray(resourceHints.entries)) {
+  console.error('FAIL: expected report.resource_hints_v0.entries array after rerun');
+  process.exit(1);
+}
+const resourceHintsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'resource_hints_v0_first.sha256'), 'utf8').trim();
+const resourceHintsShaSecond = sha256(Buffer.from(JSON.stringify(resourceHints)));
+if (resourceHintsShaSecond !== resourceHintsShaFirst) {
+  console.error('FAIL: report.resource_hints_v0 must be stable across reruns');
   process.exit(1);
 }
 const requiredTypedKeys = ['toc', 'labels', 'bib', 'hyperref', 'pkgopt', 'graphics'];
@@ -433,6 +488,13 @@ if (okStatuses.length <= 0) {
 for (const status of okStatuses) {
   if (status.baseline_match !== 'MATCH') {
     console.error(`FAIL: expected baseline_match=MATCH for OK case ${status.case_id}`);
+    process.exit(1);
+  }
+}
+const okCaseIds = new Set(okStatuses.map((entry) => entry.case_id));
+for (const entry of resourceHints.entries) {
+  if (okCaseIds.has(entry.case_id)) {
+    console.error(`FAIL: expected no resource_hints_v0 entries for OK case ${entry.case_id}`);
     process.exit(1);
   }
 }
@@ -654,6 +716,8 @@ console.log(`PASS: resolved_resources_count ${resolvedCount}`);
 console.log(`PASS: baseline_match MATCH for all OK cases (${okStatuses.length})`);
 console.log(`PASS: typed_artifacts keys ${requiredTypedKeys.join(',')}`);
 console.log('PASS: typed_artifacts_version gate 1');
+console.log(`PASS: resource_hints_v0 sha stable ${resourceHintsShaSecond}`);
+console.log('PASS: resource_hints_v0 empty for OK cases');
 console.log(`PASS: labels_v0 sha stable ${labelsShaSecond}`);
 console.log(`PASS: toc_v0 sha stable ${tocShaSecond}`);
 console.log(`PASS: bib_v0 sha stable ${bibShaSecond}`);

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -890,6 +890,106 @@ async function emitTypedArtifactsV0(caseSpec, caseOutDir, typedArtifacts, fixtur
   }
 }
 
+async function buildResourceHintsRollupV0(outDir, summaries) {
+  const entries = [];
+  const seen = new Set();
+  const sortedSummaries = [...summaries].sort((left, right) => left.case_id.localeCompare(right.case_id));
+
+  for (const summary of sortedSummaries) {
+    const caseId = summary.case_id;
+    const typedArtifacts = summary.typed_artifacts ?? {};
+
+    const graphicsRelpath = typedArtifacts.graphics?.artifact_relpath;
+    if (typedArtifacts.graphics?.present === true && typeof graphicsRelpath === 'string' && graphicsRelpath.length > 0) {
+      const graphicsBytes = await readFile(path.join(outDir, caseId, graphicsRelpath));
+      const graphicsPayload = JSON.parse(graphicsBytes.toString('utf8'));
+      const graphicsEntries = Array.isArray(graphicsPayload?.entries) ? graphicsPayload.entries : [];
+      for (const entry of graphicsEntries) {
+        const value = typeof entry?.path === 'string' ? entry.path : '';
+        if (!value) {
+          continue;
+        }
+        const dedupeKey = `${caseId}\x1fgraphics_path\x1f${value}`;
+        if (seen.has(dedupeKey)) {
+          continue;
+        }
+        seen.add(dedupeKey);
+        entries.push({
+          case_id: caseId,
+          hint_type: 'graphics_path',
+          value,
+        });
+      }
+    }
+
+    const bibRelpath = typedArtifacts.bib?.artifact_relpath;
+    if (typedArtifacts.bib?.present === true && typeof bibRelpath === 'string' && bibRelpath.length > 0) {
+      const bibBytes = await readFile(path.join(outDir, caseId, bibRelpath));
+      const bibPayload = JSON.parse(bibBytes.toString('utf8'));
+      const bibEntries = Array.isArray(bibPayload?.entries) ? bibPayload.entries : [];
+      for (const entry of bibEntries) {
+        if (entry?.kind !== 'resource_hint') {
+          continue;
+        }
+        const value = typeof entry?.value === 'string' ? entry.value : '';
+        if (!value) {
+          continue;
+        }
+        const dedupeKey = `${caseId}\x1fbib_resource\x1f${value}`;
+        if (seen.has(dedupeKey)) {
+          continue;
+        }
+        seen.add(dedupeKey);
+        entries.push({
+          case_id: caseId,
+          hint_type: 'bib_resource',
+          value,
+        });
+      }
+    }
+
+    const hyperrefRelpath = typedArtifacts.hyperref?.artifact_relpath;
+    if (typedArtifacts.hyperref?.present === true && typeof hyperrefRelpath === 'string' && hyperrefRelpath.length > 0) {
+      const hyperrefBytes = await readFile(path.join(outDir, caseId, hyperrefRelpath));
+      const hyperrefPayload = JSON.parse(hyperrefBytes.toString('utf8'));
+      const hyperrefEntries = Array.isArray(hyperrefPayload?.entries) ? hyperrefPayload.entries : [];
+      for (const entry of hyperrefEntries) {
+        const value = typeof entry?.target === 'string' ? entry.target : '';
+        if (!value) {
+          continue;
+        }
+        const dedupeKey = `${caseId}\x1fhyperref_url\x1f${value}`;
+        if (seen.has(dedupeKey)) {
+          continue;
+        }
+        seen.add(dedupeKey);
+        entries.push({
+          case_id: caseId,
+          hint_type: 'hyperref_url',
+          value,
+        });
+      }
+    }
+  }
+
+  entries.sort((left, right) => {
+    const caseCmp = left.case_id.localeCompare(right.case_id);
+    if (caseCmp !== 0) {
+      return caseCmp;
+    }
+    const typeCmp = left.hint_type.localeCompare(right.hint_type);
+    if (typeCmp !== 0) {
+      return typeCmp;
+    }
+    return left.value.localeCompare(right.value);
+  });
+
+  return {
+    version: 1,
+    entries,
+  };
+}
+
 async function computeBaselineMatchV0(caseId, artifactSha256, baselineDir) {
   if (!baselineDir) {
     return null;
@@ -1186,6 +1286,7 @@ async function run() {
         return [key, sha256HexV0(Buffer.from(JSON.stringify(digestPayload), 'utf8'))];
       }),
     ),
+    resource_hints_v0: await buildResourceHintsRollupV0(outDir, summaries),
     statuses: summaries.map((summary) => ({
       typed_artifacts_version: summary.typed_artifacts_version,
       case_id: summary.case_id,


### PR DESCRIPTION
## Summary
- add deterministic report-level `resource_hints_v0` rollup derived from typed artifacts
- include hints from graphics paths, bib resource hints, and hyperref URLs
- extend proof to assert rollup determinism and empty hints for OK cases

## Proof
- `./scripts/proof_wasm_fixture_gallery_v0.sh`
