### PR TITLE
Gallery: drive store loop from resource hints

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_DIR="${1:-$ROOT_DIR/target/wasm_fixture_gallery_v0}"
 STORE_DIR="${OUT_DIR}_store"
+HINT_STORE_DIR_A="${OUT_DIR}_store_from_hints_a"
+HINT_STORE_DIR_B="${OUT_DIR}_store_from_hints_b"
 BASELINE_ROOT="${OUT_DIR}_baseline"
 BASELINE_DIR_A="$BASELINE_ROOT/run1"
 BASELINE_DIR_B="$BASELINE_ROOT/run2"
@@ -12,17 +14,19 @@ BASELINE_AUTO_PACK_DIR="${BASELINE_PACKS_ROOT}/auto_pack"
 REQUEST_LIST="$OUT_DIR/requests.json"
 HINT_REQUEST_LIST_A="$OUT_DIR/request_list_from_hints_a.json"
 HINT_REQUEST_LIST_B="$OUT_DIR/request_list_from_hints_b.json"
-FIXTURE_SOURCE_DIR="$OUT_DIR/fixture_source_v0"
+FIXTURE_SOURCE_DIR="${OUT_DIR}_fixture_source_v0"
 SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-1700000000}"
 export SOURCE_DATE_EPOCH
 export TZ=UTC
 
 "$ROOT_DIR/scripts/wasm_smoke_build.sh"
 
-rm -rf "$OUT_DIR" "$STORE_DIR" "$BASELINE_ROOT"
-mkdir -p "$OUT_DIR" "$FIXTURE_SOURCE_DIR/xetex/tex" "$BASELINE_ROOT" "$BASELINE_PACKS_ROOT"
+rm -rf "$OUT_DIR" "$STORE_DIR" "$HINT_STORE_DIR_A" "$HINT_STORE_DIR_B" "$FIXTURE_SOURCE_DIR" "$BASELINE_ROOT"
+mkdir -p "$OUT_DIR" "$FIXTURE_SOURCE_DIR/xetex/tex" "$FIXTURE_SOURCE_DIR/xetex/bib" "$FIXTURE_SOURCE_DIR/xetex/png" "$BASELINE_ROOT" "$BASELINE_PACKS_ROOT"
 
 printf 'fixture-bytes-for-typeset-minimal-v0\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/typeset_demo_minimal_v0"
+printf '%s\n' '% placeholder bib fixture for hints proof' > "$FIXTURE_SOURCE_DIR/xetex/bib/refs.bib"
+printf 'fixture-bytes-for-demo-image-png\n' > "$FIXTURE_SOURCE_DIR/xetex/png/demo-image.png"
 
 cat > "$REQUEST_LIST" <<'JSON'
 {
@@ -365,7 +369,48 @@ fs.writeFileSync(
   path.join(baselineRoot, 'typed_artifact_sha256_first.json'),
   `${JSON.stringify(typedArtifactShaMap, null, 2)}\n`,
 );
+fs.writeFileSync(firstRunShaPath('resolved_resources_count'), `${Number(report.resolved_resources_count ?? 0)}\n`);
 NODE
+
+TEXLIVE_RESOLVER_BACKEND_V0=fixture_dir_v0 \
+TEXLIVE_STORE_SOURCE_DIR_V0="$FIXTURE_SOURCE_DIR" \
+node "$ROOT_DIR/scripts/texlive_store_gen_v0.mjs" "$HINT_REQUEST_LIST_A" "$HINT_STORE_DIR_A"
+TEXLIVE_RESOLVER_BACKEND_V0=fixture_dir_v0 \
+TEXLIVE_STORE_SOURCE_DIR_V0="$FIXTURE_SOURCE_DIR" \
+node "$ROOT_DIR/scripts/texlive_store_gen_v0.mjs" "$HINT_REQUEST_LIST_B" "$HINT_STORE_DIR_B"
+
+node - "$HINT_STORE_DIR_A" "$HINT_STORE_DIR_B" <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const storeDirA = process.argv[2];
+const storeDirB = process.argv[3];
+const sha256 = (bytes) => crypto.createHash('sha256').update(bytes).digest('hex');
+
+const indexAPath = path.join(storeDirA, 'index.json');
+const indexBPath = path.join(storeDirB, 'index.json');
+const summaryAPath = path.join(storeDirA, 'summary.json');
+const summaryBPath = path.join(storeDirB, 'summary.json');
+const indexASha = sha256(fs.readFileSync(indexAPath));
+const indexBSha = sha256(fs.readFileSync(indexBPath));
+if (indexASha !== indexBSha) {
+  console.error('FAIL: texlive_store_gen_v0 from hints must be deterministic');
+  process.exit(1);
+}
+const summaryA = JSON.parse(fs.readFileSync(summaryAPath, 'utf8'));
+const summaryB = JSON.parse(fs.readFileSync(summaryBPath, 'utf8'));
+if (summaryA.index_sha256 !== summaryB.index_sha256 || summaryA.found_count !== summaryB.found_count) {
+  console.error('FAIL: texlive_store_gen_v0 hint summaries must match across reruns');
+  process.exit(1);
+}
+console.log(`PASS: texlive_store_gen_v0 from hints deterministic index_sha256 ${indexASha}`);
+console.log(`PASS: texlive_store_gen_v0 from hints found=${summaryA.found_count} missing=${summaryA.missing_count}`);
+NODE
+
+TEXLIVE_RESOLVER_BACKEND_V0=offline_store_v0 \
+TEXLIVE_STORE_DIR_V0="$HINT_STORE_DIR_A" \
+node "$ROOT_DIR/scripts/wasm_fixture_gallery_v0.mjs" "$OUT_DIR"
 
 node "$ROOT_DIR/scripts/texlive_smoke/baselines_v0/generate_v0.mjs" "$OUT_DIR" "$BASELINE_DIR_A"
 node "$ROOT_DIR/scripts/texlive_smoke/baselines_v0/generate_v0.mjs" "$OUT_DIR" "$BASELINE_DIR_B"
@@ -490,6 +535,9 @@ NODE
 
 node "$ROOT_DIR/scripts/texlive_smoke/baselines_v0/generate_v0.mjs" "$OUT_DIR" "$BASELINE_AUTO_PACK_DIR"
 
+rm -rf "$STORE_DIR"
+cp -R "$HINT_STORE_DIR_A" "$STORE_DIR"
+
 WASM_FIXTURE_GALLERY_SKIP_PROOF_V0=1 \
 WASM_FIXTURE_GALLERY_NO_OPEN_V0=1 \
 WASM_FIXTURE_GALLERY_AUTO_BASELINE_PACK_V0=1 \
@@ -510,6 +558,9 @@ const outDir = process.argv[2];
 const report = JSON.parse(fs.readFileSync(path.join(outDir, 'report.json'), 'utf8'));
 const statuses = Array.isArray(report.statuses) ? report.statuses : [];
 const resolvedCount = Number(report.resolved_resources_count ?? 0);
+const resolvedCountFirst = Number(
+  fs.readFileSync(path.join(`${outDir}_baseline`, 'resolved_resources_count_first.sha256'), 'utf8').trim(),
+);
 const sha256 = (bytes) => crypto.createHash('sha256').update(bytes).digest('hex');
 if (report?.typed_artifacts_version !== 1) {
   console.error('FAIL: expected report.typed_artifacts_version=1 after rerun');
@@ -544,6 +595,12 @@ const graphicsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'graphi
 
 if (resolvedCount <= 0) {
   console.error('FAIL: expected at least one resolved resource in fixture gallery summaries');
+  process.exit(1);
+}
+if (!(resolvedCount > resolvedCountFirst)) {
+  console.error(
+    `FAIL: expected resolved_resources_count to increase after hint-driven store (${resolvedCountFirst} -> ${resolvedCount})`,
+  );
   process.exit(1);
 }
 const okStatuses = statuses.filter((entry) => entry.status === 'OK');
@@ -779,6 +836,7 @@ for (const status of statuses) {
 }
 
 console.log(`PASS: resolved_resources_count ${resolvedCount}`);
+console.log(`PASS: resolved_resources_count increased from ${resolvedCountFirst} to ${resolvedCount}`);
 console.log(`PASS: baseline_match MATCH for all OK cases (${okStatuses.length})`);
 console.log(`PASS: typed_artifacts keys ${requiredTypedKeys.join(',')}`);
 console.log('PASS: typed_artifacts_version gate 1');

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -297,6 +297,14 @@ function isAsciiLetterByteV0(byte) {
   return (byte >= 0x41 && byte <= 0x5a) || (byte >= 0x61 && byte <= 0x7a);
 }
 
+function isSafeResolverTokenV0(value) {
+  return typeof value === 'string'
+    && value.length > 0
+    && !value.includes('/')
+    && !value.includes('\\')
+    && !value.includes('..');
+}
+
 function skipSpacesV0(bytes, start) {
   let index = start;
   while (index < bytes.length && (bytes[index] === 0x20 || bytes[index] === 0x09 || bytes[index] === 0x0a || bytes[index] === 0x0d)) {
@@ -990,6 +998,109 @@ async function buildResourceHintsRollupV0(outDir, summaries) {
   };
 }
 
+function inferTexmfFormatFromNameV0(name, fallback) {
+  const dotIndex = name.lastIndexOf('.');
+  if (dotIndex <= 0 || dotIndex === name.length - 1) {
+    return fallback;
+  }
+  const ext = name.slice(dotIndex + 1).toLowerCase();
+  if (!/^[a-z0-9]+$/.test(ext)) {
+    return fallback;
+  }
+  return ext;
+}
+
+function parseFontconfigHintTokenV0(value) {
+  const prefix = 'fontconfig:';
+  if (!value.startsWith(prefix)) {
+    return null;
+  }
+  const payload = value.slice(prefix.length);
+  const firstColon = payload.indexOf(':');
+  if (firstColon <= 0 || firstColon === payload.length - 1) {
+    return null;
+  }
+  const variant = payload.slice(0, firstColon).trim();
+  const name = payload.slice(firstColon + 1).trim();
+  if (!isSafeResolverTokenV0(variant) || !isSafeResolverTokenV0(name)) {
+    return null;
+  }
+  return {
+    kind: 'fontconfig',
+    format: 'name',
+    name,
+    variant,
+    hint_type: 'hyperref_url',
+  };
+}
+
+function resolverRequestKeyV0(request) {
+  return `${request.kind}\u0000${request.format}\u0000${request.name}\u0000${request.variant}`;
+}
+
+async function collectResolverRequestsFromTypedArtifactsV0(caseSpec, caseOutDir, typedArtifacts) {
+  const requestsByKey = new Map();
+
+  const addTexmfRequest = (name, fallbackFormat, hintType) => {
+    if (!isSafeResolverTokenV0(name)) {
+      throw new Error(`unsafe resource hint token for ${hintType} in case ${caseSpec.id}`);
+    }
+    const format = inferTexmfFormatFromNameV0(name, fallbackFormat);
+    if (!isSafeResolverTokenV0(format)) {
+      throw new Error(`unsafe format token '${format}' for ${hintType} in case ${caseSpec.id}`);
+    }
+    const variant = caseSpec.mode;
+    const request = {
+      kind: 'texmf',
+      format,
+      name,
+      variant,
+      hint_type: hintType,
+    };
+    requestsByKey.set(resolverRequestKeyV0(request), request);
+  };
+
+  const graphicsRelpath = typedArtifacts?.graphics?.artifact_relpath;
+  if (typedArtifacts?.graphics?.present === true && typeof graphicsRelpath === 'string' && graphicsRelpath.length > 0) {
+    const graphicsPayload = JSON.parse((await readFile(path.join(caseOutDir, graphicsRelpath))).toString('utf8'));
+    const graphicsEntries = Array.isArray(graphicsPayload?.entries) ? graphicsPayload.entries : [];
+    for (const entry of graphicsEntries) {
+      if (typeof entry?.path === 'string' && entry.path.length > 0) {
+        addTexmfRequest(entry.path, 'graphic', 'graphics_path');
+      }
+    }
+  }
+
+  const bibRelpath = typedArtifacts?.bib?.artifact_relpath;
+  if (typedArtifacts?.bib?.present === true && typeof bibRelpath === 'string' && bibRelpath.length > 0) {
+    const bibPayload = JSON.parse((await readFile(path.join(caseOutDir, bibRelpath))).toString('utf8'));
+    const bibEntries = Array.isArray(bibPayload?.entries) ? bibPayload.entries : [];
+    for (const entry of bibEntries) {
+      if (entry?.kind === 'resource_hint' && typeof entry?.value === 'string' && entry.value.length > 0) {
+        addTexmfRequest(entry.value, 'bib', 'bib_resource');
+      }
+    }
+  }
+
+  const hyperrefRelpath = typedArtifacts?.hyperref?.artifact_relpath;
+  if (typedArtifacts?.hyperref?.present === true && typeof hyperrefRelpath === 'string' && hyperrefRelpath.length > 0) {
+    const hyperrefPayload = JSON.parse((await readFile(path.join(caseOutDir, hyperrefRelpath))).toString('utf8'));
+    const hyperrefEntries = Array.isArray(hyperrefPayload?.entries) ? hyperrefPayload.entries : [];
+    for (const entry of hyperrefEntries) {
+      if (typeof entry?.target !== 'string' || entry.target.length === 0) {
+        continue;
+      }
+      const fontconfigRequest = parseFontconfigHintTokenV0(entry.target);
+      if (!fontconfigRequest) {
+        continue;
+      }
+      requestsByKey.set(resolverRequestKeyV0(fontconfigRequest), fontconfigRequest);
+    }
+  }
+
+  return [...requestsByKey.values()].sort((left, right) => resolverRequestKeyV0(left).localeCompare(resolverRequestKeyV0(right)));
+}
+
 async function computeBaselineMatchV0(caseId, artifactSha256, baselineDir) {
   if (!baselineDir) {
     return null;
@@ -1176,6 +1287,32 @@ async function runCaseV0(
     typed_artifacts: buildTypedArtifactsPlaceholderV0(),
   };
   await emitTypedArtifactsV0(caseSpec, caseOutDir, summary.typed_artifacts, fixtureBytes);
+  const typedArtifactRequests = await collectResolverRequestsFromTypedArtifactsV0(
+    caseSpec,
+    caseOutDir,
+    summary.typed_artifacts,
+  );
+  for (const request of typedArtifactRequests) {
+    const resolutionFromHint = await resolver.resolve({
+      kind: request.kind,
+      format: request.format,
+      name: request.name,
+      variant: request.variant,
+      resolver_id: resolver.resolverId,
+    });
+    if (resolutionFromHint.tag !== 'Found') {
+      continue;
+    }
+    resolvedResources.push({
+      kind: request.kind,
+      format: request.format,
+      name: request.name,
+      variant: request.variant,
+      stable_id: resolutionFromHint.stable_id,
+      sha256: resolutionFromHint.sha256,
+      cache_hit: resolutionFromHint.cache_hit,
+    });
+  }
   summary.baseline_match = await computeBaselineMatchV0(caseSpec.id, summary.artifact_sha256, baselineDir);
   if (errorMessage) {
     summary.error = errorMessage;


### PR DESCRIPTION
## Summary
- resolve additional resources per case from typed-artifact hints during gallery runs
- extend fixture-gallery proof to build hint-based request list, generate store from hints, rerun gallery, and assert deterministic resolved-resource increase
- keep flow offline-first by generating hint stores via `fixture_dir_v0`

## Proof
- `./scripts/proof_wasm_fixture_gallery_v0.sh`
