### PR TITLE
gallery: extend compile-path resource hints for bib + graphics options

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -29,6 +29,7 @@ mkdir -p \
   "$FIXTURE_SOURCE_DIR/xetex/tex" \
   "$FIXTURE_SOURCE_DIR/xetex/bib" \
   "$FIXTURE_SOURCE_DIR/xetex/png" \
+  "$FIXTURE_SOURCE_DIR/xetex/pdf" \
   "$FIXTURE_SOURCE_DIR/xetex/sty" \
   "$FIXTURE_SOURCE_DIR/xetex/cls" \
   "$FIXTURE_SOURCE_DIR/fontconfig/public" \
@@ -38,10 +39,15 @@ mkdir -p \
 printf 'fixture-bytes-for-typeset-minimal-v0\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/typeset_demo_minimal_v0"
 printf 'fixture-bytes-for-chapter-intro\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapter_intro.tex"
 printf 'fixture-bytes-for-chapter-appendix\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapter_appendix.tex"
+printf 'fixture-bytes-for-chapters-intro\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapters__intro.tex"
+printf 'fixture-bytes-for-chapters-appendix\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapters__appendix.tex"
 printf 'fixture-bytes-for-demo-png\n' > "$FIXTURE_SOURCE_DIR/xetex/png/demo.png"
 printf 'fixture-bytes-for-probe-figure-png\n' > "$FIXTURE_SOURCE_DIR/xetex/png/probe-figure.png"
+printf 'fixture-bytes-for-figs-diagram-pdf\n' > "$FIXTURE_SOURCE_DIR/xetex/pdf/figs__diagram.pdf"
 printf 'fixture-bytes-for-refs-bib\n' > "$FIXTURE_SOURCE_DIR/xetex/bib/refs.bib"
 printf 'fixture-bytes-for-legacyrefs-bib\n' > "$FIXTURE_SOURCE_DIR/xetex/bib/legacyrefs.bib"
+printf 'fixture-bytes-for-bib-deep-refs-local-bib\n' > "$FIXTURE_SOURCE_DIR/xetex/bib/bib__deep__refs-local.bib"
+printf 'fixture-bytes-for-legacy-deeprefs-bib\n' > "$FIXTURE_SOURCE_DIR/xetex/bib/legacy__deeprefs.bib"
 printf 'fixture-bytes-for-xcolor-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/xcolor.sty"
 printf 'fixture-bytes-for-memoir-cls\n' > "$FIXTURE_SOURCE_DIR/xetex/cls/memoir.cls"
 printf 'fixture-bytes-for-found-sans\n' > "$FIXTURE_SOURCE_DIR/fontconfig/public/FoundSans"
@@ -152,6 +158,34 @@ const bibRequest = listA.requests.find(
 );
 if (!bibRequest) {
   console.error('FAIL: request list must include bib hint request for refs.bib');
+  process.exit(1);
+}
+const nestedInputRequest = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'tex' && request.name === 'chapters__intro.tex' && request.variant === 'typeset',
+);
+if (!nestedInputRequest) {
+  console.error('FAIL: request list must include nested input hint request for chapters__intro.tex');
+  process.exit(1);
+}
+const nestedIncludeRequest = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'tex' && request.name === 'chapters__appendix.tex' && request.variant === 'typeset',
+);
+if (!nestedIncludeRequest) {
+  console.error('FAIL: request list must include nested include hint request for chapters__appendix.tex');
+  process.exit(1);
+}
+const graphicsOptsRequest = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'pdf' && request.name === 'figs__diagram.pdf' && request.variant === 'typeset',
+);
+if (!graphicsOptsRequest) {
+  console.error('FAIL: request list must include includegraphics ext/dir hint request for figs__diagram.pdf');
+  process.exit(1);
+}
+const nestedBibRequest = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'bib' && request.name === 'bib__deep__refs-local.bib' && request.variant === 'typeset',
+);
+if (!nestedBibRequest) {
+  console.error('FAIL: request list must include nested addbibresource hint request for bib__deep__refs-local.bib');
   process.exit(1);
 }
 if (listA.requests.some((request) => request.name === 'demo-image.png')) {
@@ -535,9 +569,16 @@ const requiredEntries = [
   ['texmf', 'tex', 'typeset_demo_minimal_v0', 'typeset'],
   ['texmf', 'tex', 'chapter_intro.tex', 'typeset'],
   ['texmf', 'tex', 'chapter_appendix.tex', 'typeset'],
+  ['texmf', 'tex', 'chapters__intro.tex', 'typeset'],
+  ['texmf', 'tex', 'chapters__appendix.tex', 'typeset'],
   ['texmf', 'sty', 'xcolor.sty', 'typeset'],
   ['texmf', 'bib', 'refs.bib', 'typeset'],
+  ['texmf', 'bib', 'legacyrefs.bib', 'typeset'],
+  ['texmf', 'bib', 'bib__deep__refs-local.bib', 'typeset'],
+  ['texmf', 'bib', 'legacy__deeprefs.bib', 'typeset'],
   ['texmf', 'png', 'demo.png', 'typeset'],
+  ['texmf', 'png', 'probe-figure.png', 'typeset'],
+  ['texmf', 'pdf', 'figs__diagram.pdf', 'typeset'],
   ['fontconfig', 'name', 'FoundSans', 'public'],
 ];
 for (const [kind, format, name, variant] of requiredEntries) {

--- a/scripts/texlive_smoke/fixtures/typeset_demo_graphics_opts_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_graphics_opts_probe_v0.tex
@@ -1,0 +1,12 @@
+\documentclass{article}
+\usepackage{graphicx}
+
+\title{CarrelTeX Graphics Options Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+\includegraphics[dir=figs/,ext=.pdf,width=0.6\textwidth]{diagram}
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_nested_path_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_nested_path_probe_v0.tex
@@ -1,0 +1,15 @@
+\documentclass{article}
+
+\title{CarrelTeX Nested Path Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\addbibresource{bib/deep/refs-local}
+
+\begin{document}
+\maketitle
+
+\input{chapters/intro}
+\include{chapters/appendix}
+\bibliography{legacy/deeprefs}
+\end{document}

--- a/scripts/texlive_smoke/request_list_from_hints_v0.mjs
+++ b/scripts/texlive_smoke/request_list_from_hints_v0.mjs
@@ -30,11 +30,22 @@ function normalizeTexmfNameV0(rawValue, hintType, caseId) {
   if (typeof rawValue !== 'string' || rawValue.trim() === '') {
     throw new Error(`resource hint ${hintType} in case ${caseId} must be non-empty`);
   }
-  const value = rawValue.trim();
-  if (!isSafeTokenV0(value)) {
+  const value = rawValue.trim().replace(/\\/g, '/');
+  const segments = value
+    .split('/')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0 && segment !== '.');
+  if (segments.length === 0) {
+    throw new Error(`resource hint ${hintType} in case ${caseId} has empty path token`);
+  }
+  if (segments.some((segment) => segment === '..' || segment.includes('..'))) {
     throw new Error(`resource hint ${hintType} in case ${caseId} has unsafe token '${value}'`);
   }
-  return value;
+  const normalized = segments.join('__');
+  if (!isSafeTokenV0(normalized)) {
+    throw new Error(`resource hint ${hintType} in case ${caseId} has unsafe normalized token '${normalized}'`);
+  }
+  return normalized;
 }
 
 function ensureDefaultExtensionV0(name, extension) {

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -211,6 +211,16 @@ async function loadFixtureCasesV0() {
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_resource_hints_probe_v0.tex',
     },
+    {
+      id: 'typeset_demo_nested_path_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_nested_path_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_graphics_opts_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_graphics_opts_probe_v0.tex',
+    },
   ];
 
   const okFixtureDir = path.join(rootDir, 'scripts', 'wasm_smoke_js', 'fixtures');
@@ -460,6 +470,52 @@ function ensureDefaultExtensionV0(value, extension) {
   return `${value}.${extension}`;
 }
 
+function normalizePathHintTokenV0(rawValue, hintType) {
+  if (typeof rawValue !== 'string') {
+    return null;
+  }
+  const trimmed = rawValue.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const normalizedSeparators = trimmed.replace(/\\/g, '/');
+  const segments = normalizedSeparators
+    .split('/')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0 && segment !== '.');
+  if (segments.length === 0) {
+    return null;
+  }
+  if (segments.some((segment) => segment === '..' || segment.includes('..'))) {
+    throw new Error(`resource_hints_v0 ${hintType} has unsafe path token '${trimmed}'`);
+  }
+  const normalized = segments.join('__');
+  if (!isSafeResolverTokenV0(normalized)) {
+    throw new Error(`resource_hints_v0 ${hintType} normalized token is unsafe '${normalized}'`);
+  }
+  return normalized;
+}
+
+function parseOptionAssignmentsV0(rawValue) {
+  const assignments = new Map();
+  for (const item of splitCommaValuesV0(rawValue)) {
+    const equalsIndex = item.indexOf('=');
+    if (equalsIndex <= 0 || equalsIndex === item.length - 1) {
+      continue;
+    }
+    const key = item.slice(0, equalsIndex).trim().toLowerCase();
+    let value = item.slice(equalsIndex + 1).trim();
+    while (value.length >= 2 && value.startsWith('{') && value.endsWith('}')) {
+      value = value.slice(1, -1).trim();
+    }
+    if (key.length === 0 || value.length === 0) {
+      continue;
+    }
+    assignments.set(key, value);
+  }
+  return assignments;
+}
+
 function addBibEntryV0(entries, entry) {
   const value = entry.kind === 'cite_key' ? entry.key : entry.value;
   const valueBytes = Buffer.from(value, 'utf8');
@@ -631,8 +687,12 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
 
   const addHintValues = (hintType, values, startByte, endByte, defaultExtension = null) => {
     for (const rawValue of values) {
-      const normalized = defaultExtension ? ensureDefaultExtensionV0(rawValue, defaultExtension) : rawValue;
-      const dedupeKey = `${hintType}\u0000${normalized}`;
+      const normalizedPath = normalizePathHintTokenV0(rawValue, hintType);
+      if (!normalizedPath) {
+        continue;
+      }
+      const normalized = defaultExtension ? ensureDefaultExtensionV0(normalizedPath, defaultExtension) : normalizedPath;
+      const dedupeKey = `${hintType}\u0000${normalized.toLowerCase()}`;
       if (seen.has(dedupeKey)) {
         continue;
       }
@@ -686,6 +746,7 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
     if (command === 'includegraphics') {
       let next = commandIndex;
       const optionsGroup = readBracketGroupV0(sourceBytes, next);
+      const graphicsOptions = optionsGroup.ok ? parseOptionAssignmentsV0(optionsGroup.value) : new Map();
       if (optionsGroup.ok) {
         next = optionsGroup.next;
       }
@@ -694,7 +755,17 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
         index = commandIndex;
         continue;
       }
-      addHintValues('graphics_path', splitCommaValuesV0(graphicsGroup.value), index, graphicsGroup.next);
+      const extRaw = (graphicsOptions.get('ext') ?? graphicsOptions.get('extension') ?? '').trim();
+      const extNormalized = /^[a-z0-9]+$/i.test(extRaw.replace(/^\./, '')) ? extRaw.replace(/^\./, '') : '';
+      const dirRaw = (graphicsOptions.get('dir') ?? graphicsOptions.get('path') ?? '').trim();
+      const dirNormalized = normalizePathHintTokenV0(dirRaw, 'graphics_path');
+      const candidates = [];
+      for (const value of splitCommaValuesV0(graphicsGroup.value)) {
+        const withDir = dirNormalized ? `${dirNormalized}/${value}` : value;
+        const withExt = extNormalized.length > 0 ? ensureDefaultExtensionV0(withDir, extNormalized) : withDir;
+        candidates.push(withExt);
+      }
+      addHintValues('graphics_path', candidates, index, graphicsGroup.next);
       index = graphicsGroup.next;
       continue;
     }

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -68,6 +68,18 @@
       "purpose": "Probes includegraphics and bibliography resource-hint seams in one deterministic NI fixture."
     },
     {
+      "id": "typeset_demo_nested_path_probe_v0",
+      "tags": ["typeset", "input", "include", "nested-path", "probe", "invalid"],
+      "expected_status": "INVALID",
+      "purpose": "Probes nested path normalization for input/include and bibliography resource hints."
+    },
+    {
+      "id": "typeset_demo_graphics_opts_probe_v0",
+      "tags": ["typeset", "graphics", "options", "ext-dir", "probe", "ni"],
+      "expected_status": "NI",
+      "purpose": "Probes includegraphics ext/dir option hint normalization for deterministic resource requests."
+    },
+    {
       "id": "ok_demo_capabilities_v0",
       "tags": ["ok", "capabilities", "surface"],
       "expected_status": "OK",


### PR DESCRIPTION
## Summary
- extend compile-path `resource_hints_v0` normalization for nested path tokens (`/` and `\\` -> `__`) with fail-closed `..` rejection
- extend compile-path `\includegraphics` hint extraction to use option-derived `dir` and `ext` hints deterministically
- keep compile-path bib hint extraction for both `\addbibresource{...}` and `\bibliography{...}` and normalize nested paths
- add two probe fixtures and manifest entries (`typeset_demo_nested_path_probe_v0`, `typeset_demo_graphics_opts_probe_v0`)
- extend `request_list_from_hints_v0` nested path normalization so generated request names stay safe and deterministic
- extend gallery proof fixture store + assertions to verify new request/store loop coverage deterministically

## Proof
- `./scripts/proof_wasm_fixture_gallery_v0.sh`
