### PR TITLE
gallery: add bib style/resource hint coverage

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -28,6 +28,7 @@ mkdir -p \
   "$OUT_DIR" \
   "$FIXTURE_SOURCE_DIR/xetex/tex" \
   "$FIXTURE_SOURCE_DIR/xetex/bib" \
+  "$FIXTURE_SOURCE_DIR/xetex/bst" \
   "$FIXTURE_SOURCE_DIR/xetex/png" \
   "$FIXTURE_SOURCE_DIR/xetex/pdf" \
   "$FIXTURE_SOURCE_DIR/xetex/sty" \
@@ -45,10 +46,13 @@ printf 'fixture-bytes-for-demo-png\n' > "$FIXTURE_SOURCE_DIR/xetex/png/demo.png"
 printf 'fixture-bytes-for-probe-figure-png\n' > "$FIXTURE_SOURCE_DIR/xetex/png/probe-figure.png"
 printf 'fixture-bytes-for-figs-diagram-pdf\n' > "$FIXTURE_SOURCE_DIR/xetex/pdf/figs__diagram.pdf"
 printf 'fixture-bytes-for-refs-bib\n' > "$FIXTURE_SOURCE_DIR/xetex/bib/refs.bib"
+printf 'fixture-bytes-for-styleprobe-refs-bib\n' > "$FIXTURE_SOURCE_DIR/xetex/bib/styleprobe_refs.bib"
 printf 'fixture-bytes-for-legacyrefs-bib\n' > "$FIXTURE_SOURCE_DIR/xetex/bib/legacyrefs.bib"
 printf 'fixture-bytes-for-bib-deep-refs-local-bib\n' > "$FIXTURE_SOURCE_DIR/xetex/bib/bib__deep__refs-local.bib"
 printf 'fixture-bytes-for-legacy-deeprefs-bib\n' > "$FIXTURE_SOURCE_DIR/xetex/bib/legacy__deeprefs.bib"
+printf 'fixture-bytes-for-plain-bst\n' > "$FIXTURE_SOURCE_DIR/xetex/bst/plain.bst"
 printf 'fixture-bytes-for-xcolor-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/xcolor.sty"
+printf 'fixture-bytes-for-natbib-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/natbib.sty"
 printf 'fixture-bytes-for-memoir-cls\n' > "$FIXTURE_SOURCE_DIR/xetex/cls/memoir.cls"
 printf 'fixture-bytes-for-found-sans\n' > "$FIXTURE_SOURCE_DIR/fontconfig/public/FoundSans"
 
@@ -186,6 +190,20 @@ const nestedBibRequest = listA.requests.find(
 );
 if (!nestedBibRequest) {
   console.error('FAIL: request list must include nested addbibresource hint request for bib__deep__refs-local.bib');
+  process.exit(1);
+}
+const bibStyleRequest = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'bst' && request.name === 'plain.bst' && request.variant === 'typeset',
+);
+if (!bibStyleRequest) {
+  console.error('FAIL: request list must include bibliographystyle hint request for plain.bst');
+  process.exit(1);
+}
+const bibStyleResourceRequest = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'bib' && request.name === 'styleprobe_refs.bib' && request.variant === 'typeset',
+);
+if (!bibStyleResourceRequest) {
+  console.error('FAIL: request list must include bibliography hint request for styleprobe_refs.bib');
   process.exit(1);
 }
 if (listA.requests.some((request) => request.name === 'demo-image.png')) {
@@ -573,9 +591,12 @@ const requiredEntries = [
   ['texmf', 'tex', 'chapters__appendix.tex', 'typeset'],
   ['texmf', 'sty', 'xcolor.sty', 'typeset'],
   ['texmf', 'bib', 'refs.bib', 'typeset'],
+  ['texmf', 'bib', 'styleprobe_refs.bib', 'typeset'],
   ['texmf', 'bib', 'legacyrefs.bib', 'typeset'],
   ['texmf', 'bib', 'bib__deep__refs-local.bib', 'typeset'],
   ['texmf', 'bib', 'legacy__deeprefs.bib', 'typeset'],
+  ['texmf', 'bst', 'plain.bst', 'typeset'],
+  ['texmf', 'sty', 'natbib.sty', 'typeset'],
   ['texmf', 'png', 'demo.png', 'typeset'],
   ['texmf', 'png', 'probe-figure.png', 'typeset'],
   ['texmf', 'pdf', 'figs__diagram.pdf', 'typeset'],

--- a/scripts/texlive_smoke/fixtures/typeset_demo_bibstyle_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_bibstyle_probe_v0.tex
@@ -1,0 +1,14 @@
+\documentclass{article}
+\usepackage{natbib}
+\bibliographystyle{plain}
+\bibliography{styleprobe_refs}
+
+\title{CarrelTeX Bibliography Style Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+This fixture probes bibliography style/resource hints.
+\end{document}

--- a/scripts/texlive_smoke/request_list_from_hints_v0.mjs
+++ b/scripts/texlive_smoke/request_list_from_hints_v0.mjs
@@ -162,6 +162,18 @@ export async function buildRequestListFromHintsV0(options = {}) {
       continue;
     }
 
+    if (hintType === 'bib_style') {
+      const name = ensureDefaultExtensionV0(normalizeTexmfNameV0(value, hintType, caseId), 'bst');
+      const request = {
+        kind: 'texmf',
+        format: inferTexmfFormatV0(name, 'bst'),
+        name,
+        variant,
+      };
+      requestsByKey.set(requestKeyV0(request), request);
+      continue;
+    }
+
     if (hintType === 'tex_input' || hintType === 'tex_include') {
       const name = ensureDefaultExtensionV0(normalizeTexmfNameV0(value, hintType, caseId), 'tex');
       const request = {

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -187,6 +187,11 @@ async function loadFixtureCasesV0() {
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_bib_probe_v0.tex',
     },
     {
+      id: 'typeset_demo_bibstyle_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_bibstyle_probe_v0.tex',
+    },
+    {
       id: 'typeset_demo_graphics_probe_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_graphics_probe_v0.tex',
@@ -788,6 +793,17 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
       continue;
     }
 
+    if (command === 'bibliographystyle') {
+      const styleGroup = readBracedGroupV0(sourceBytes, commandIndex);
+      if (!styleGroup.ok || styleGroup.value.length === 0) {
+        index = commandIndex;
+        continue;
+      }
+      addHintValues('bib_style', splitCommaValuesV0(styleGroup.value), index, styleGroup.next, 'bst');
+      index = styleGroup.next;
+      continue;
+    }
+
     if (command === 'url') {
       const urlGroup = readBracedGroupV0(sourceBytes, commandIndex);
       if (!urlGroup.ok || urlGroup.value.length === 0) {
@@ -833,7 +849,7 @@ function extractBibEntriesFromSourceV0(sourceBytes) {
     'citeyearpar',
     'nocite',
   ]);
-  const resourceCommands = new Set(['addbibresource', 'bibliography']);
+  const resourceCommands = new Set(['addbibresource', 'bibliography', 'bibliographystyle']);
 
   let index = 0;
   while (index < sourceBytes.length) {
@@ -864,9 +880,10 @@ function extractBibEntriesFromSourceV0(sourceBytes) {
         index = commandIndex;
         continue;
       }
+      const entryKind = command === 'bibliographystyle' ? 'style_hint' : 'resource_hint';
       for (const value of splitCommaValuesV0(resourceGroup.value)) {
         addBibEntryV0(entries, {
-          kind: 'resource_hint',
+          kind: entryKind,
           command,
           value,
           source_span: buildSourceSpanV0(sourceBytes, index, resourceGroup.next, 'bib_v0'),

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -38,6 +38,12 @@
       "purpose": "Probes bibliography and cite seam planned for future typed artifacts."
     },
     {
+      "id": "typeset_demo_bibstyle_probe_v0",
+      "tags": ["typeset", "bib", "style", "probe", "ni"],
+      "expected_status": "NI",
+      "purpose": "Probes bibliography style/resource hint extraction for deterministic bst+bib requests."
+    },
+    {
       "id": "typeset_demo_graphics_probe_v0",
       "tags": ["typeset", "graphics", "probe", "ni"],
       "expected_status": "NI",


### PR DESCRIPTION
## Summary\n- add compile-path resource hint extraction for \bibliographystyle in gallery runner\n- map new bib_style hints into deterministic texmf bst requests\n- add bibstyle probe fixture and extend gallery proof/store checks for bst+bib requests\n\n## Proof\n- ./scripts/proof_wasm_fixture_gallery_v0.sh