### PR TITLE
gallery: add input/include hint probes and strict path guards

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -27,6 +27,8 @@ rm -rf "$OUT_DIR" "$STORE_DIR" "$HINT_STORE_DIR_A" "$HINT_STORE_DIR_B" "$FIXTURE
 mkdir -p \
   "$OUT_DIR" \
   "$FIXTURE_SOURCE_DIR/xetex/tex" \
+  "$FIXTURE_SOURCE_DIR/xetex/tex/sections" \
+  "$FIXTURE_SOURCE_DIR/xetex/tex/chapters" \
   "$FIXTURE_SOURCE_DIR/xetex/bib" \
   "$FIXTURE_SOURCE_DIR/xetex/bst" \
   "$FIXTURE_SOURCE_DIR/xetex/png" \
@@ -42,6 +44,10 @@ printf 'fixture-bytes-for-chapter-intro\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chap
 printf 'fixture-bytes-for-chapter-appendix\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapter_appendix.tex"
 printf 'fixture-bytes-for-chapters-intro\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapters__intro.tex"
 printf 'fixture-bytes-for-chapters-appendix\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapters__appendix.tex"
+printf 'fixture-bytes-for-sections-intro-nested\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/sections/intro.tex"
+printf 'fixture-bytes-for-chapters-ch1-nested\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapters/ch1.tex"
+printf 'fixture-bytes-for-sections-intro-normalized\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/sections__intro.tex"
+printf 'fixture-bytes-for-chapters-ch1-normalized\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapters__ch1.tex"
 printf 'fixture-bytes-for-demo-png\n' > "$FIXTURE_SOURCE_DIR/xetex/png/demo.png"
 printf 'fixture-bytes-for-probe-figure-png\n' > "$FIXTURE_SOURCE_DIR/xetex/png/probe-figure.png"
 printf 'fixture-bytes-for-figs-diagram-pdf\n' > "$FIXTURE_SOURCE_DIR/xetex/pdf/figs__diagram.pdf"
@@ -179,6 +185,20 @@ const nestedIncludeRequest = listA.requests.find(
 );
 if (!nestedIncludeRequest) {
   console.error('FAIL: request list must include nested include hint request for chapters__appendix.tex');
+  process.exit(1);
+}
+const inputProbeRequest = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'tex' && request.name === 'sections__intro.tex' && request.variant === 'typeset',
+);
+if (!inputProbeRequest) {
+  console.error('FAIL: request list must include input probe hint request for sections__intro.tex');
+  process.exit(1);
+}
+const includeProbeRequest = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'tex' && request.name === 'chapters__ch1.tex' && request.variant === 'typeset',
+);
+if (!includeProbeRequest) {
+  console.error('FAIL: request list must include include probe hint request for chapters__ch1.tex');
   process.exit(1);
 }
 const graphicsOptsRequest = listA.requests.find(
@@ -617,6 +637,8 @@ const requiredEntries = [
   ['texmf', 'tex', 'chapter_appendix.tex', 'typeset'],
   ['texmf', 'tex', 'chapters__intro.tex', 'typeset'],
   ['texmf', 'tex', 'chapters__appendix.tex', 'typeset'],
+  ['texmf', 'tex', 'sections__intro.tex', 'typeset'],
+  ['texmf', 'tex', 'chapters__ch1.tex', 'typeset'],
   ['texmf', 'sty', 'xcolor.sty', 'typeset'],
   ['texmf', 'bib', 'refs.bib', 'typeset'],
   ['texmf', 'bib', 'styleprobe_refs.bib', 'typeset'],
@@ -840,6 +862,10 @@ if (!(resolvedCount > resolvedCountFirst)) {
   console.error(
     `FAIL: expected resolved_resources_count to increase after hint-driven store (${resolvedCountFirst} -> ${resolvedCount})`,
   );
+  process.exit(1);
+}
+if (resolvedCount < 25) {
+  console.error(`FAIL: expected resolved_resources_count >= 25 after input/include hint expansion, got ${resolvedCount}`);
   process.exit(1);
 }
 const okStatuses = statuses.filter((entry) => entry.status === 'OK');
@@ -1073,6 +1099,7 @@ for (const status of statuses) {
 
 console.log(`PASS: resolved_resources_count ${resolvedCount}`);
 console.log(`PASS: resolved_resources_count increased from ${resolvedCountFirst} to ${resolvedCount}`);
+console.log('PASS: resolved_resources_count meets floor >= 25');
 console.log(`PASS: baseline_match MATCH for all OK cases (${okStatuses.length})`);
 console.log(`PASS: typed_artifacts keys ${requiredTypedKeys.join(',')}`);
 console.log('PASS: typed_artifacts_version gate 1');

--- a/scripts/texlive_smoke/fixtures/typeset_demo_include_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_include_probe_v0.tex
@@ -1,0 +1,11 @@
+\documentclass{article}
+
+\title{CarrelTeX Include Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+\include{chapters/ch1}
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_input_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_input_probe_v0.tex
@@ -1,0 +1,11 @@
+\documentclass{article}
+
+\title{CarrelTeX Input Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+\input{sections/intro}
+\end{document}

--- a/scripts/texlive_smoke/request_list_from_hints_v0.mjs
+++ b/scripts/texlive_smoke/request_list_from_hints_v0.mjs
@@ -30,7 +30,14 @@ function normalizeTexmfNameV0(rawValue, hintType, caseId) {
   if (typeof rawValue !== 'string' || rawValue.trim() === '') {
     throw new Error(`resource hint ${hintType} in case ${caseId} must be non-empty`);
   }
-  const value = rawValue.trim().replace(/\\/g, '/');
+  const rawTrimmed = rawValue.trim();
+  if (rawTrimmed.startsWith('/') || rawTrimmed.startsWith('\\')) {
+    throw new Error(`resource hint ${hintType} in case ${caseId} rejects absolute path '${rawTrimmed}'`);
+  }
+  if (/^[A-Za-z]:([\\/]|$)/.test(rawTrimmed)) {
+    throw new Error(`resource hint ${hintType} in case ${caseId} rejects drive path '${rawTrimmed}'`);
+  }
+  const value = rawTrimmed.replace(/\\/g, '/');
   const segments = value
     .split('/')
     .map((segment) => segment.trim())
@@ -40,6 +47,9 @@ function normalizeTexmfNameV0(rawValue, hintType, caseId) {
   }
   if (segments.some((segment) => segment === '..' || segment.includes('..'))) {
     throw new Error(`resource hint ${hintType} in case ${caseId} has unsafe token '${value}'`);
+  }
+  if (segments.some((segment) => !/^[A-Za-z0-9._-]+$/.test(segment))) {
+    throw new Error(`resource hint ${hintType} in case ${caseId} has unsupported path segment '${value}'`);
   }
   const normalized = segments.join('__');
   if (!isSafeTokenV0(normalized)) {

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -212,6 +212,16 @@ async function loadFixtureCasesV0() {
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_input_include_probe_v0.tex',
     },
     {
+      id: 'typeset_demo_input_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_input_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_include_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_include_probe_v0.tex',
+    },
+    {
       id: 'typeset_demo_package_require_probe_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_package_require_probe_v0.tex',
@@ -488,6 +498,12 @@ function normalizePathHintTokenV0(rawValue, hintType) {
   if (trimmed.length === 0) {
     return null;
   }
+  if (trimmed.startsWith('/') || trimmed.startsWith('\\')) {
+    throw new Error(`resource_hints_v0 ${hintType} rejects absolute path '${trimmed}'`);
+  }
+  if (/^[A-Za-z]:([\\/]|$)/.test(trimmed)) {
+    throw new Error(`resource_hints_v0 ${hintType} rejects drive path '${trimmed}'`);
+  }
   const normalizedSeparators = trimmed.replace(/\\/g, '/');
   const segments = normalizedSeparators
     .split('/')
@@ -498,6 +514,9 @@ function normalizePathHintTokenV0(rawValue, hintType) {
   }
   if (segments.some((segment) => segment === '..' || segment.includes('..'))) {
     throw new Error(`resource_hints_v0 ${hintType} has unsafe path token '${trimmed}'`);
+  }
+  if (segments.some((segment) => !/^[A-Za-z0-9._-]+$/.test(segment))) {
+    throw new Error(`resource_hints_v0 ${hintType} has unsupported path segment '${trimmed}'`);
   }
   const normalized = segments.join('__');
   if (!isSafeResolverTokenV0(normalized)) {
@@ -697,6 +716,19 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
 
   const addHintValues = (hintType, values, startByte, endByte, defaultExtension = null) => {
     for (const rawValue of values) {
+      if (hintType === 'hyperref_url') {
+        const normalizedUrl = typeof rawValue === 'string' ? rawValue.trim() : '';
+        if (normalizedUrl.length === 0) {
+          continue;
+        }
+        const dedupeKey = `${hintType}\u0000${normalizedUrl}`;
+        if (seen.has(dedupeKey)) {
+          continue;
+        }
+        seen.add(dedupeKey);
+        addResourceHintEntryV0(entries, sourceBytes, hintType, normalizedUrl, startByte, endByte);
+        continue;
+      }
       const normalizedPath = normalizePathHintTokenV0(rawValue, hintType);
       if (!normalizedPath) {
         continue;

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -68,6 +68,18 @@
       "purpose": "Probes input/include resource-hint seam for deterministic on-demand request generation."
     },
     {
+      "id": "typeset_demo_input_probe_v0",
+      "tags": ["typeset", "input", "probe", "ni"],
+      "expected_status": "NI",
+      "purpose": "Probes input resource-hint extraction and deterministic .tex request mapping."
+    },
+    {
+      "id": "typeset_demo_include_probe_v0",
+      "tags": ["typeset", "include", "probe", "ni"],
+      "expected_status": "NI",
+      "purpose": "Probes include resource-hint extraction and deterministic .tex request mapping."
+    },
+    {
       "id": "typeset_demo_package_require_probe_v0",
       "tags": ["typeset", "packages", "requirepackage", "probe", "ni"],
       "expected_status": "NI",


### PR DESCRIPTION
## Summary\n- add dedicated input/include probe fixtures and manifest entries\n- tighten hint path normalization (reject absolute/drive/.. and unsupported segments)\n- extend gallery proof/store loop assertions for input/include requests and resolved_resources_count floor\n\n## Proof\n- ./scripts/proof_wasm_fixture_gallery_v0.sh