### PR TITLE
gallery: add includeonly hint mapping and probe

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -29,6 +29,7 @@ mkdir -p \
   "$FIXTURE_SOURCE_DIR/xetex/tex" \
   "$FIXTURE_SOURCE_DIR/xetex/tex/sections" \
   "$FIXTURE_SOURCE_DIR/xetex/tex/chapters" \
+  "$FIXTURE_SOURCE_DIR/xetex/tex/appendices" \
   "$FIXTURE_SOURCE_DIR/xetex/bib" \
   "$FIXTURE_SOURCE_DIR/xetex/bst" \
   "$FIXTURE_SOURCE_DIR/xetex/png" \
@@ -48,6 +49,10 @@ printf 'fixture-bytes-for-sections-intro-nested\n' > "$FIXTURE_SOURCE_DIR/xetex/
 printf 'fixture-bytes-for-chapters-ch1-nested\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapters/ch1.tex"
 printf 'fixture-bytes-for-sections-intro-normalized\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/sections__intro.tex"
 printf 'fixture-bytes-for-chapters-ch1-normalized\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapters__ch1.tex"
+printf 'fixture-bytes-for-appendices-apx-a-nested\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/appendices/apx_a.tex"
+printf 'fixture-bytes-for-appendices-apx-b-nested\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/appendices/apx_b.tex"
+printf 'fixture-bytes-for-appendices-apx-a-normalized\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/appendices__apx_a.tex"
+printf 'fixture-bytes-for-appendices-apx-b-normalized\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/appendices__apx_b.tex"
 printf 'fixture-bytes-for-demo-png\n' > "$FIXTURE_SOURCE_DIR/xetex/png/demo.png"
 printf 'fixture-bytes-for-probe-figure-png\n' > "$FIXTURE_SOURCE_DIR/xetex/png/probe-figure.png"
 printf 'fixture-bytes-for-figs-diagram-pdf\n' > "$FIXTURE_SOURCE_DIR/xetex/pdf/figs__diagram.pdf"
@@ -199,6 +204,20 @@ const includeProbeRequest = listA.requests.find(
 );
 if (!includeProbeRequest) {
   console.error('FAIL: request list must include include probe hint request for chapters__ch1.tex');
+  process.exit(1);
+}
+const includeOnlyProbeRequestA = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'tex' && request.name === 'appendices__apx_a.tex' && request.variant === 'typeset',
+);
+if (!includeOnlyProbeRequestA) {
+  console.error('FAIL: request list must include includeonly hint request for appendices__apx_a.tex');
+  process.exit(1);
+}
+const includeOnlyProbeRequestB = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'tex' && request.name === 'appendices__apx_b.tex' && request.variant === 'typeset',
+);
+if (!includeOnlyProbeRequestB) {
+  console.error('FAIL: request list must include includeonly hint request for appendices__apx_b.tex');
   process.exit(1);
 }
 const graphicsOptsRequest = listA.requests.find(
@@ -639,6 +658,8 @@ const requiredEntries = [
   ['texmf', 'tex', 'chapters__appendix.tex', 'typeset'],
   ['texmf', 'tex', 'sections__intro.tex', 'typeset'],
   ['texmf', 'tex', 'chapters__ch1.tex', 'typeset'],
+  ['texmf', 'tex', 'appendices__apx_a.tex', 'typeset'],
+  ['texmf', 'tex', 'appendices__apx_b.tex', 'typeset'],
   ['texmf', 'sty', 'xcolor.sty', 'typeset'],
   ['texmf', 'bib', 'refs.bib', 'typeset'],
   ['texmf', 'bib', 'styleprobe_refs.bib', 'typeset'],
@@ -864,8 +885,8 @@ if (!(resolvedCount > resolvedCountFirst)) {
   );
   process.exit(1);
 }
-if (resolvedCount < 25) {
-  console.error(`FAIL: expected resolved_resources_count >= 25 after input/include hint expansion, got ${resolvedCount}`);
+if (resolvedCount < 27) {
+  console.error(`FAIL: expected resolved_resources_count >= 27 after includeonly hint expansion, got ${resolvedCount}`);
   process.exit(1);
 }
 const okStatuses = statuses.filter((entry) => entry.status === 'OK');
@@ -1099,7 +1120,7 @@ for (const status of statuses) {
 
 console.log(`PASS: resolved_resources_count ${resolvedCount}`);
 console.log(`PASS: resolved_resources_count increased from ${resolvedCountFirst} to ${resolvedCount}`);
-console.log('PASS: resolved_resources_count meets floor >= 25');
+console.log('PASS: resolved_resources_count meets floor >= 27');
 console.log(`PASS: baseline_match MATCH for all OK cases (${okStatuses.length})`);
 console.log(`PASS: typed_artifacts keys ${requiredTypedKeys.join(',')}`);
 console.log('PASS: typed_artifacts_version gate 1');

--- a/scripts/texlive_smoke/fixtures/typeset_demo_includeonly_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_includeonly_probe_v0.tex
@@ -1,0 +1,12 @@
+\documentclass{article}
+\includeonly{appendices/apx_a,appendices/apx_b.tex}
+
+\title{CarrelTeX IncludeOnly Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+IncludeOnly probe fixture.
+\end{document}

--- a/scripts/texlive_smoke/request_list_from_hints_v0.mjs
+++ b/scripts/texlive_smoke/request_list_from_hints_v0.mjs
@@ -184,7 +184,7 @@ export async function buildRequestListFromHintsV0(options = {}) {
       continue;
     }
 
-    if (hintType === 'tex_input' || hintType === 'tex_include') {
+    if (hintType === 'tex_input' || hintType === 'tex_include' || hintType === 'tex_includeonly') {
       const name = ensureDefaultExtensionV0(normalizeTexmfNameV0(value, hintType, caseId), 'tex');
       const request = {
         kind: 'texmf',

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -222,6 +222,11 @@ async function loadFixtureCasesV0() {
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_include_probe_v0.tex',
     },
     {
+      id: 'typeset_demo_includeonly_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_includeonly_probe_v0.tex',
+    },
+    {
       id: 'typeset_demo_package_require_probe_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_package_require_probe_v0.tex',
@@ -765,6 +770,17 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
         continue;
       }
       addHintValues(command === 'input' ? 'tex_input' : 'tex_include', splitCommaValuesV0(group.value), index, group.next, 'tex');
+      index = group.next;
+      continue;
+    }
+
+    if (command === 'includeonly') {
+      const group = readBracedGroupV0(sourceBytes, commandIndex);
+      if (!group.ok || group.value.length === 0) {
+        index = commandIndex;
+        continue;
+      }
+      addHintValues('tex_includeonly', splitCommaValuesV0(group.value), index, group.next, 'tex');
       index = group.next;
       continue;
     }
@@ -1344,7 +1360,7 @@ async function collectResolverRequestsFromResourceHintsV0(caseSpec, caseOutDir, 
       addTexmfRequest(ensureDefaultExtensionV0(value, 'bib'), 'bib', hintType);
       continue;
     }
-    if (hintType === 'tex_input' || hintType === 'tex_include') {
+    if (hintType === 'tex_input' || hintType === 'tex_include' || hintType === 'tex_includeonly') {
       addTexmfRequest(ensureDefaultExtensionV0(value, 'tex'), 'tex', hintType);
       continue;
     }

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -80,6 +80,12 @@
       "purpose": "Probes include resource-hint extraction and deterministic .tex request mapping."
     },
     {
+      "id": "typeset_demo_includeonly_probe_v0",
+      "tags": ["typeset", "includeonly", "probe", "ni"],
+      "expected_status": "NI",
+      "purpose": "Probes includeonly list extraction and deterministic .tex request mapping."
+    },
+    {
       "id": "typeset_demo_package_require_probe_v0",
       "tags": ["typeset", "packages", "requirepackage", "probe", "ni"],
       "expected_status": "NI",


### PR DESCRIPTION
## Summary\n- add compile-path resource hint extraction for \includeonly lists\n- map includeonly hints to deterministic texmf tex requests in request_list_from_hints_v0\n- add includeonly probe fixture and extend proof/store loop assertions\n\n## Proof\n- ./scripts/proof_wasm_fixture_gallery_v0.sh