### PR TITLE
gallery: add graphicspath includegraphics hint coverage

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -56,6 +56,8 @@ printf 'fixture-bytes-for-appendices-apx-b-normalized\n' > "$FIXTURE_SOURCE_DIR/
 printf 'fixture-bytes-for-demo-png\n' > "$FIXTURE_SOURCE_DIR/xetex/png/demo.png"
 printf 'fixture-bytes-for-probe-figure-png\n' > "$FIXTURE_SOURCE_DIR/xetex/png/probe-figure.png"
 printf 'fixture-bytes-for-figs-diagram-pdf\n' > "$FIXTURE_SOURCE_DIR/xetex/pdf/figs__diagram.pdf"
+printf 'fixture-bytes-for-figs-demo-graphic-pdf\n' > "$FIXTURE_SOURCE_DIR/xetex/pdf/figs__demo_graphic.pdf"
+printf 'fixture-bytes-for-plots-demo-graphic-pdf\n' > "$FIXTURE_SOURCE_DIR/xetex/pdf/plots__demo_graphic.pdf"
 printf 'fixture-bytes-for-refs-bib\n' > "$FIXTURE_SOURCE_DIR/xetex/bib/refs.bib"
 printf 'fixture-bytes-for-styleprobe-refs-bib\n' > "$FIXTURE_SOURCE_DIR/xetex/bib/styleprobe_refs.bib"
 printf 'fixture-bytes-for-multiadd-refs-bib\n' > "$FIXTURE_SOURCE_DIR/xetex/bib/multiadd_refs.bib"
@@ -225,6 +227,20 @@ const graphicsOptsRequest = listA.requests.find(
 );
 if (!graphicsOptsRequest) {
   console.error('FAIL: request list must include includegraphics ext/dir hint request for figs__diagram.pdf');
+  process.exit(1);
+}
+const graphicspathRequestA = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'pdf' && request.name === 'figs__demo_graphic.pdf' && request.variant === 'typeset',
+);
+if (!graphicspathRequestA) {
+  console.error('FAIL: request list must include graphicspath hint request for figs__demo_graphic.pdf');
+  process.exit(1);
+}
+const graphicspathRequestB = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'pdf' && request.name === 'plots__demo_graphic.pdf' && request.variant === 'typeset',
+);
+if (!graphicspathRequestB) {
+  console.error('FAIL: request list must include graphicspath hint request for plots__demo_graphic.pdf');
   process.exit(1);
 }
 const nestedBibRequest = listA.requests.find(
@@ -674,6 +690,8 @@ const requiredEntries = [
   ['texmf', 'png', 'demo.png', 'typeset'],
   ['texmf', 'png', 'probe-figure.png', 'typeset'],
   ['texmf', 'pdf', 'figs__diagram.pdf', 'typeset'],
+  ['texmf', 'pdf', 'figs__demo_graphic.pdf', 'typeset'],
+  ['texmf', 'pdf', 'plots__demo_graphic.pdf', 'typeset'],
   ['fontconfig', 'name', 'FoundSans', 'public'],
 ];
 for (const [kind, format, name, variant] of requiredEntries) {
@@ -885,8 +903,8 @@ if (!(resolvedCount > resolvedCountFirst)) {
   );
   process.exit(1);
 }
-if (resolvedCount < 27) {
-  console.error(`FAIL: expected resolved_resources_count >= 27 after includeonly hint expansion, got ${resolvedCount}`);
+if (resolvedCount < 29) {
+  console.error(`FAIL: expected resolved_resources_count >= 29 after graphicspath hint expansion, got ${resolvedCount}`);
   process.exit(1);
 }
 const okStatuses = statuses.filter((entry) => entry.status === 'OK');
@@ -1120,7 +1138,7 @@ for (const status of statuses) {
 
 console.log(`PASS: resolved_resources_count ${resolvedCount}`);
 console.log(`PASS: resolved_resources_count increased from ${resolvedCountFirst} to ${resolvedCount}`);
-console.log('PASS: resolved_resources_count meets floor >= 27');
+console.log('PASS: resolved_resources_count meets floor >= 29');
 console.log(`PASS: baseline_match MATCH for all OK cases (${okStatuses.length})`);
 console.log(`PASS: typed_artifacts keys ${requiredTypedKeys.join(',')}`);
 console.log('PASS: typed_artifacts_version gate 1');

--- a/scripts/texlive_smoke/fixtures/typeset_demo_graphicspath_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_graphicspath_probe_v0.tex
@@ -1,0 +1,13 @@
+\documentclass{article}
+\usepackage{graphicx}
+\graphicspath{{figs/}{plots/}}
+
+\title{CarrelTeX Graphicspath Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+\includegraphics[ext=pdf]{demo_graphic}
+\end{document}

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -202,6 +202,11 @@ async function loadFixtureCasesV0() {
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_graphics_probe_v0.tex',
     },
     {
+      id: 'typeset_demo_graphicspath_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_graphicspath_probe_v0.tex',
+    },
+    {
       id: 'typeset_demo_pkgopt_probe_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_pkgopt_probe_v0.tex',
@@ -550,6 +555,42 @@ function parseOptionAssignmentsV0(rawValue) {
   return assignments;
 }
 
+function parseGraphicspathValuesV0(rawValue) {
+  const values = [];
+  let index = 0;
+  while (index < rawValue.length) {
+    while (index < rawValue.length && /\s/.test(rawValue[index])) {
+      index += 1;
+    }
+    if (index >= rawValue.length) {
+      break;
+    }
+    if (rawValue[index] !== '{') {
+      throw new Error(`resource_hints_v0 graphicspath has malformed entry '${rawValue}'`);
+    }
+    index += 1;
+    const start = index;
+    while (index < rawValue.length && rawValue[index] !== '}') {
+      if (rawValue[index] === '{') {
+        throw new Error(`resource_hints_v0 graphicspath rejects nested braces '${rawValue}'`);
+      }
+      index += 1;
+    }
+    if (index >= rawValue.length || rawValue[index] !== '}') {
+      throw new Error(`resource_hints_v0 graphicspath has unterminated entry '${rawValue}'`);
+    }
+    const value = rawValue.slice(start, index).trim();
+    if (value.length > 0) {
+      values.push(value);
+    }
+    index += 1;
+  }
+  if (values.length === 0) {
+    throw new Error(`resource_hints_v0 graphicspath requires at least one path '${rawValue}'`);
+  }
+  return values;
+}
+
 function addBibEntryV0(entries, entry) {
   const value = entry.kind === 'cite_key' ? entry.key : entry.value;
   const valueBytes = Buffer.from(value, 'utf8');
@@ -717,6 +758,7 @@ function addResourceHintEntryV0(entries, sourceBytes, hintType, value, startByte
 function extractResourceHintEntriesFromSourceV0(sourceBytes) {
   const entries = [];
   const seen = new Set();
+  let graphicspathPrefixes = [];
   let index = 0;
 
   const addHintValues = (hintType, values, startByte, endByte, defaultExtension = null) => {
@@ -819,12 +861,38 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
       const dirNormalized = normalizePathHintTokenV0(dirRaw, 'graphics_path');
       const candidates = [];
       for (const value of splitCommaValuesV0(graphicsGroup.value)) {
-        const withDir = dirNormalized ? `${dirNormalized}/${value}` : value;
-        const withExt = extNormalized.length > 0 ? ensureDefaultExtensionV0(withDir, extNormalized) : withDir;
-        candidates.push(withExt);
+        const useGraphicspathPrefixes = !dirNormalized
+          && graphicspathPrefixes.length > 0
+          && !value.includes('/')
+          && !value.includes('\\');
+        if (useGraphicspathPrefixes) {
+          for (const prefix of graphicspathPrefixes) {
+            const withDir = `${prefix}/${value}`;
+            const withExt = extNormalized.length > 0 ? ensureDefaultExtensionV0(withDir, extNormalized) : withDir;
+            candidates.push(withExt);
+          }
+        } else {
+          const withDir = dirNormalized ? `${dirNormalized}/${value}` : value;
+          const withExt = extNormalized.length > 0 ? ensureDefaultExtensionV0(withDir, extNormalized) : withDir;
+          candidates.push(withExt);
+        }
       }
       addHintValues('graphics_path', candidates, index, graphicsGroup.next);
       index = graphicsGroup.next;
+      continue;
+    }
+
+    if (command === 'graphicspath') {
+      const pathGroup = readBracedGroupV0(sourceBytes, commandIndex);
+      if (!pathGroup.ok || pathGroup.value.length === 0) {
+        index = commandIndex;
+        continue;
+      }
+      const prefixes = parseGraphicspathValuesV0(pathGroup.value)
+        .map((rawValue) => normalizePathHintTokenV0(rawValue, 'graphics_path'))
+        .filter((value) => value && value.length > 0);
+      graphicspathPrefixes = prefixes;
+      index = pathGroup.next;
       continue;
     }
 

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -56,6 +56,12 @@
       "purpose": "Probes graphics include seam planned for future typed artifacts."
     },
     {
+      "id": "typeset_demo_graphicspath_probe_v0",
+      "tags": ["typeset", "graphics", "graphicspath", "probe", "ni"],
+      "expected_status": "NI",
+      "purpose": "Probes graphicspath normalization and includegraphics request mapping."
+    },
+    {
       "id": "typeset_demo_pkgopt_probe_v0",
       "tags": ["typeset", "package-options", "probe", "ni"],
       "expected_status": "NI",


### PR DESCRIPTION
## Summary\n- add graphicspath-aware includegraphics resource hint extraction\n- normalize and map graphicspath-derived hints into deterministic texmf requests\n- add graphicspath probe fixture and extend gallery proof/store assertions\n\n## Proof\n- ./scripts/proof_wasm_fixture_gallery_v0.sh