### PR TITLE
gallery: package path hints and unsafe usepackage probe

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -70,6 +70,7 @@ printf 'fixture-bytes-for-bib-deep-refs-local-bib\n' > "$FIXTURE_SOURCE_DIR/xete
 printf 'fixture-bytes-for-legacy-deeprefs-bib\n' > "$FIXTURE_SOURCE_DIR/xetex/bib/legacy__deeprefs.bib"
 printf 'fixture-bytes-for-plain-bst\n' > "$FIXTURE_SOURCE_DIR/xetex/bst/plain.bst"
 printf 'fixture-bytes-for-xcolor-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/xcolor.sty"
+printf 'fixture-bytes-for-foo-bar-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/foo__bar.sty"
 printf 'fixture-bytes-for-natbib-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/natbib.sty"
 printf 'fixture-bytes-for-memoir-cls\n' > "$FIXTURE_SOURCE_DIR/xetex/cls/memoir.cls"
 printf 'fixture-bytes-for-found-sans\n' > "$FIXTURE_SOURCE_DIR/fontconfig/public/FoundSans"
@@ -175,6 +176,13 @@ if (!packageRequest) {
   console.error('FAIL: request list must include package hint request for xcolor.sty');
   process.exit(1);
 }
+const packagePathRequest = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.name === 'foo__bar.sty' && request.variant === 'typeset',
+);
+if (!packagePathRequest) {
+  console.error('FAIL: request list must include package hint request for foo__bar.sty');
+  process.exit(1);
+}
 const bibRequest = listA.requests.find(
   (request) => request.kind === 'texmf' && request.format === 'bib' && request.name === 'refs.bib' && request.variant === 'typeset',
 );
@@ -261,6 +269,10 @@ if (!graphicspathExplicitRequestB) {
 }
 if (listA.requests.some((request) => request.name === 'bad__danger_graphic.pdf' || request.name === 'abs__danger_graphic.pdf')) {
   console.error('FAIL: request list must fail-closed for unsafe graphicspath entries');
+  process.exit(1);
+}
+if (listA.requests.some((request) => request.name === 'evil.sty' || request.name === 'evil__pkg.sty')) {
+  console.error('FAIL: request list must fail-closed for unsafe usepackage entries');
   process.exit(1);
 }
 const nestedBibRequest = listA.requests.find(
@@ -697,6 +709,7 @@ const requiredEntries = [
   ['texmf', 'tex', 'appendices__apx_a.tex', 'typeset'],
   ['texmf', 'tex', 'appendices__apx_b.tex', 'typeset'],
   ['texmf', 'sty', 'xcolor.sty', 'typeset'],
+  ['texmf', 'sty', 'foo__bar.sty', 'typeset'],
   ['texmf', 'bib', 'refs.bib', 'typeset'],
   ['texmf', 'bib', 'styleprobe_refs.bib', 'typeset'],
   ['texmf', 'bib', 'multiadd_refs.bib', 'typeset'],
@@ -925,8 +938,8 @@ if (!(resolvedCount > resolvedCountFirst)) {
   );
   process.exit(1);
 }
-if (resolvedCount < 31) {
-  console.error(`FAIL: expected resolved_resources_count >= 31 after graphicspath explicit-ext expansion, got ${resolvedCount}`);
+if (resolvedCount < 32) {
+  console.error(`FAIL: expected resolved_resources_count >= 32 after package-path expansion, got ${resolvedCount}`);
   process.exit(1);
 }
 const okStatuses = statuses.filter((entry) => entry.status === 'OK');
@@ -1160,7 +1173,7 @@ for (const status of statuses) {
 
 console.log(`PASS: resolved_resources_count ${resolvedCount}`);
 console.log(`PASS: resolved_resources_count increased from ${resolvedCountFirst} to ${resolvedCount}`);
-console.log('PASS: resolved_resources_count meets floor >= 31');
+console.log('PASS: resolved_resources_count meets floor >= 32');
 console.log(`PASS: baseline_match MATCH for all OK cases (${okStatuses.length})`);
 console.log(`PASS: typed_artifacts keys ${requiredTypedKeys.join(',')}`);
 console.log('PASS: typed_artifacts_version gate 1');

--- a/scripts/texlive_smoke/fixtures/typeset_demo_package_require_invalid_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_package_require_invalid_probe_v0.tex
@@ -1,0 +1,12 @@
+\documentclass{article}
+\usepackage{../evil}
+
+\title{CarrelTeX Package Require Invalid Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+Package invalid hint probe.
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_package_require_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_package_require_probe_v0.tex
@@ -1,5 +1,6 @@
 \documentclass{article}
 \usepackage{xcolor}
+\usepackage{foo/bar}
 \RequirePackage{memoir.cls}
 
 \title{CarrelTeX Package Require Probe}

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -247,6 +247,11 @@ async function loadFixtureCasesV0() {
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_package_require_probe_v0.tex',
     },
     {
+      id: 'typeset_demo_package_require_invalid_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_package_require_invalid_probe_v0.tex',
+    },
+    {
       id: 'typeset_demo_resource_hints_probe_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_resource_hints_probe_v0.tex',
@@ -771,7 +776,14 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
   let graphicspathPrefixes = [];
   let index = 0;
 
-  const addHintValues = (hintType, values, startByte, endByte, defaultExtension = null) => {
+  const addHintValues = (
+    hintType,
+    values,
+    startByte,
+    endByte,
+    defaultExtension = null,
+    ignoreInvalidPathToken = false,
+  ) => {
     for (const rawValue of values) {
       if (hintType === 'hyperref_url') {
         const normalizedUrl = typeof rawValue === 'string' ? rawValue.trim() : '';
@@ -786,7 +798,15 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
         addResourceHintEntryV0(entries, sourceBytes, hintType, normalizedUrl, startByte, endByte);
         continue;
       }
-      const normalizedPath = normalizePathHintTokenV0(rawValue, hintType);
+      let normalizedPath;
+      try {
+        normalizedPath = normalizePathHintTokenV0(rawValue, hintType);
+      } catch (error) {
+        if (ignoreInvalidPathToken) {
+          continue;
+        }
+        throw error;
+      }
       if (!normalizedPath) {
         continue;
       }
@@ -848,7 +868,7 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
         index = commandIndex;
         continue;
       }
-      addHintValues('package_file', splitCommaValuesV0(packageGroup.value), index, packageGroup.next, 'sty');
+      addHintValues('package_file', splitCommaValuesV0(packageGroup.value), index, packageGroup.next, 'sty', true);
       index = packageGroup.next;
       continue;
     }

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -110,6 +110,12 @@
       "purpose": "Probes usepackage/RequirePackage resource-hint seam for sty/cls requests."
     },
     {
+      "id": "typeset_demo_package_require_invalid_probe_v0",
+      "tags": ["typeset", "packages", "requirepackage", "unsafe-path", "probe", "invalid"],
+      "expected_status": "INVALID",
+      "purpose": "Probes fail-closed package hint normalization by rejecting unsafe usepackage paths."
+    },
+    {
       "id": "typeset_demo_resource_hints_probe_v0",
       "tags": ["typeset", "graphics", "bib", "resource-hints", "probe", "ni"],
       "expected_status": "NI",


### PR DESCRIPTION
## Summary\n- map package_file hints for path-form package names like foo/bar to deterministic sty requests\n- add fail-closed invalid package probe for unsafe ../ paths\n- extend gallery proof assertions and seeded store blobs for package path coverage\n\n## Proof\n- ./scripts/proof_wasm_fixture_gallery_v0.sh