### PR TITLE
gallery: add RequirePackageWithOptions and PassOptionsToPackage hints

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -71,6 +71,8 @@ printf 'fixture-bytes-for-legacy-deeprefs-bib\n' > "$FIXTURE_SOURCE_DIR/xetex/bi
 printf 'fixture-bytes-for-plain-bst\n' > "$FIXTURE_SOURCE_DIR/xetex/bst/plain.bst"
 printf 'fixture-bytes-for-xcolor-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/xcolor.sty"
 printf 'fixture-bytes-for-foo-bar-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/foo__bar.sty"
+printf 'fixture-bytes-for-fooopts-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/fooopts.sty"
+printf 'fixture-bytes-for-baropts-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/baropts.sty"
 printf 'fixture-bytes-for-natbib-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/natbib.sty"
 printf 'fixture-bytes-for-memoir-cls\n' > "$FIXTURE_SOURCE_DIR/xetex/cls/memoir.cls"
 printf 'fixture-bytes-for-found-sans\n' > "$FIXTURE_SOURCE_DIR/fontconfig/public/FoundSans"
@@ -181,6 +183,20 @@ const packagePathRequest = listA.requests.find(
 );
 if (!packagePathRequest) {
   console.error('FAIL: request list must include package hint request for foo__bar.sty');
+  process.exit(1);
+}
+const passOptionsPackageRequest = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.name === 'fooopts.sty' && request.variant === 'typeset',
+);
+if (!passOptionsPackageRequest) {
+  console.error('FAIL: request list must include package hint request for fooopts.sty');
+  process.exit(1);
+}
+const requireWithOptionsPackageRequest = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.name === 'baropts.sty' && request.variant === 'typeset',
+);
+if (!requireWithOptionsPackageRequest) {
+  console.error('FAIL: request list must include package hint request for baropts.sty');
   process.exit(1);
 }
 const bibRequest = listA.requests.find(
@@ -710,6 +726,8 @@ const requiredEntries = [
   ['texmf', 'tex', 'appendices__apx_b.tex', 'typeset'],
   ['texmf', 'sty', 'xcolor.sty', 'typeset'],
   ['texmf', 'sty', 'foo__bar.sty', 'typeset'],
+  ['texmf', 'sty', 'fooopts.sty', 'typeset'],
+  ['texmf', 'sty', 'baropts.sty', 'typeset'],
   ['texmf', 'bib', 'refs.bib', 'typeset'],
   ['texmf', 'bib', 'styleprobe_refs.bib', 'typeset'],
   ['texmf', 'bib', 'multiadd_refs.bib', 'typeset'],
@@ -938,8 +956,8 @@ if (!(resolvedCount > resolvedCountFirst)) {
   );
   process.exit(1);
 }
-if (resolvedCount < 32) {
-  console.error(`FAIL: expected resolved_resources_count >= 32 after package-path expansion, got ${resolvedCount}`);
+if (resolvedCount < 34) {
+  console.error(`FAIL: expected resolved_resources_count >= 34 after package-option seam expansion, got ${resolvedCount}`);
   process.exit(1);
 }
 const okStatuses = statuses.filter((entry) => entry.status === 'OK');
@@ -1173,7 +1191,7 @@ for (const status of statuses) {
 
 console.log(`PASS: resolved_resources_count ${resolvedCount}`);
 console.log(`PASS: resolved_resources_count increased from ${resolvedCountFirst} to ${resolvedCount}`);
-console.log('PASS: resolved_resources_count meets floor >= 32');
+console.log('PASS: resolved_resources_count meets floor >= 34');
 console.log(`PASS: baseline_match MATCH for all OK cases (${okStatuses.length})`);
 console.log(`PASS: typed_artifacts keys ${requiredTypedKeys.join(',')}`);
 console.log('PASS: typed_artifacts_version gate 1');

--- a/scripts/texlive_smoke/fixtures/typeset_demo_pkgopt_require_pass_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_pkgopt_require_pass_probe_v0.tex
@@ -1,0 +1,13 @@
+\documentclass{article}
+\PassOptionsToPackage{table,dvipsnames}{fooopts}
+\RequirePackageWithOptions{baropts}
+
+\title{CarrelTeX Pkgopt Require Pass Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+Package options + require-with-options hint probe.
+\end{document}

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -247,6 +247,11 @@ async function loadFixtureCasesV0() {
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_package_require_probe_v0.tex',
     },
     {
+      id: 'typeset_demo_pkgopt_require_pass_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_pkgopt_require_pass_probe_v0.tex',
+    },
+    {
       id: 'typeset_demo_package_require_invalid_probe_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_package_require_invalid_probe_v0.tex',
@@ -656,7 +661,7 @@ function addPkgoptEntryV0(entries, entry) {
 
 function extractPkgoptEntriesFromSourceV0(sourceBytes) {
   const entries = [];
-  const packageCommands = new Set(['usepackage', 'RequirePackage']);
+  const packageCommands = new Set(['usepackage', 'RequirePackage', 'PassOptionsToPackage', 'RequirePackageWithOptions']);
   let index = 0;
   while (index < sourceBytes.length) {
     if (sourceBytes[index] !== 0x5c) {
@@ -677,29 +682,58 @@ function extractPkgoptEntriesFromSourceV0(sourceBytes) {
       continue;
     }
 
-    const optGroup = readBracketGroupV0(sourceBytes, commandIndex);
-    if (!optGroup.ok || optGroup.value.length === 0) {
-      index = commandIndex;
-      continue;
+    let options = [];
+    let packages = [];
+    let endOffset = commandIndex;
+
+    if (command === 'PassOptionsToPackage') {
+      const optionGroup = readBracedGroupV0(sourceBytes, commandIndex);
+      if (!optionGroup.ok || optionGroup.value.length === 0) {
+        index = commandIndex;
+        continue;
+      }
+      const packageGroup = readBracedGroupV0(sourceBytes, optionGroup.next);
+      if (!packageGroup.ok || packageGroup.value.length === 0) {
+        index = commandIndex;
+        continue;
+      }
+      options = splitCommaValuesV0(optionGroup.value);
+      packages = splitCommaValuesV0(packageGroup.value);
+      endOffset = packageGroup.next;
+    } else if (command === 'RequirePackageWithOptions') {
+      const packageGroup = readBracedGroupV0(sourceBytes, commandIndex);
+      if (!packageGroup.ok || packageGroup.value.length === 0) {
+        index = commandIndex;
+        continue;
+      }
+      options = ['withoptions'];
+      packages = splitCommaValuesV0(packageGroup.value);
+      endOffset = packageGroup.next;
+    } else {
+      const optGroup = readBracketGroupV0(sourceBytes, commandIndex);
+      if (!optGroup.ok || optGroup.value.length === 0) {
+        index = commandIndex;
+        continue;
+      }
+      const pkgGroup = readBracedGroupV0(sourceBytes, optGroup.next);
+      if (!pkgGroup.ok || pkgGroup.value.length === 0) {
+        index = commandIndex;
+        continue;
+      }
+      options = splitCommaValuesV0(optGroup.value);
+      packages = splitCommaValuesV0(pkgGroup.value);
+      endOffset = pkgGroup.next;
     }
 
-    const pkgGroup = readBracedGroupV0(sourceBytes, optGroup.next);
-    if (!pkgGroup.ok || pkgGroup.value.length === 0) {
-      index = commandIndex;
-      continue;
-    }
-
-    const options = splitCommaValuesV0(optGroup.value);
-    const packages = splitCommaValuesV0(pkgGroup.value);
     for (const pkgName of packages) {
       addPkgoptEntryV0(entries, {
         command,
         package: pkgName,
         options,
-        source_span: buildSourceSpanV0(sourceBytes, index, pkgGroup.next, 'pkgopt_v0'),
+        source_span: buildSourceSpanV0(sourceBytes, index, endOffset, 'pkgopt_v0'),
       });
     }
-    index = pkgGroup.next;
+    index = endOffset;
   }
   return entries;
 }
@@ -864,6 +898,33 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
         next = optionsGroup.next;
       }
       const packageGroup = readBracedGroupV0(sourceBytes, next);
+      if (!packageGroup.ok || packageGroup.value.length === 0) {
+        index = commandIndex;
+        continue;
+      }
+      addHintValues('package_file', splitCommaValuesV0(packageGroup.value), index, packageGroup.next, 'sty', true);
+      index = packageGroup.next;
+      continue;
+    }
+
+    if (command === 'RequirePackageWithOptions') {
+      const packageGroup = readBracedGroupV0(sourceBytes, commandIndex);
+      if (!packageGroup.ok || packageGroup.value.length === 0) {
+        index = commandIndex;
+        continue;
+      }
+      addHintValues('package_file', splitCommaValuesV0(packageGroup.value), index, packageGroup.next, 'sty', true);
+      index = packageGroup.next;
+      continue;
+    }
+
+    if (command === 'PassOptionsToPackage') {
+      const optionGroup = readBracedGroupV0(sourceBytes, commandIndex);
+      if (!optionGroup.ok || optionGroup.value.length === 0) {
+        index = commandIndex;
+        continue;
+      }
+      const packageGroup = readBracedGroupV0(sourceBytes, optionGroup.next);
       if (!packageGroup.ok || packageGroup.value.length === 0) {
         index = commandIndex;
         continue;

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -110,6 +110,12 @@
       "purpose": "Probes usepackage/RequirePackage resource-hint seam for sty/cls requests."
     },
     {
+      "id": "typeset_demo_pkgopt_require_pass_probe_v0",
+      "tags": ["typeset", "packages", "pkgopt", "requirepackagewithoptions", "passoptionstopackage", "probe", "ni"],
+      "expected_status": "NI",
+      "purpose": "Probes RequirePackageWithOptions and PassOptionsToPackage seams for package hints and pkgopt artifact extraction."
+    },
+    {
       "id": "typeset_demo_package_require_invalid_probe_v0",
       "tags": ["typeset", "packages", "requirepackage", "unsafe-path", "probe", "invalid"],
       "expected_status": "INVALID",


### PR DESCRIPTION
## Summary\n- extend package hint extraction for RequirePackageWithOptions and PassOptionsToPackage\n- emit package_file + pkgopt signals for those commands\n- add probe fixture and proof/store assertions\n\n## Proof\n- ./scripts/proof_wasm_fixture_gallery_v0.sh