### PR TITLE
gallery: normalize class options and reject empty entries

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -76,6 +76,7 @@ printf 'fixture-bytes-for-baropts-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/baropt
 printf 'fixture-bytes-for-natbib-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/natbib.sty"
 printf 'fixture-bytes-for-memoir-cls\n' > "$FIXTURE_SOURCE_DIR/xetex/cls/memoir.cls"
 printf 'fixture-bytes-for-classoptsdemo-cls\n' > "$FIXTURE_SOURCE_DIR/xetex/cls/classoptsdemo.cls"
+printf 'fixture-bytes-for-classoptsmulti-cls\n' > "$FIXTURE_SOURCE_DIR/xetex/cls/classoptsmulti.cls"
 printf 'fixture-bytes-for-memoirplus-cls\n' > "$FIXTURE_SOURCE_DIR/xetex/cls/memoirplus.cls"
 printf 'fixture-bytes-for-found-sans\n' > "$FIXTURE_SOURCE_DIR/fontconfig/public/FoundSans"
 
@@ -220,6 +221,13 @@ const memoirPlusClassRequest = listA.requests.find(
 );
 if (!memoirPlusClassRequest) {
   console.error('FAIL: request list must include class hint request for memoirplus.cls');
+  process.exit(1);
+}
+const classOptionsMultiRequest = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'cls' && request.name === 'classoptsmulti.cls' && request.variant === 'typeset',
+);
+if (!classOptionsMultiRequest) {
+  console.error('FAIL: request list must include class hint request for classoptsmulti.cls');
   process.exit(1);
 }
 const bibRequest = listA.requests.find(
@@ -654,6 +662,44 @@ if (!passOptionsClassPkgoptArtifact.entries.some((entry) => entry.package === 'm
   process.exit(1);
 }
 
+const classOptionsMultiPkgoptSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_documentclass_opts_multi_probe_v0', 'summary.json'), 'utf8'),
+);
+if (classOptionsMultiPkgoptSummary?.typed_artifacts?.pkgopt?.present !== true) {
+  console.error('FAIL: expected pkgopt typed artifact present for documentclass opts multi probe after first run');
+  process.exit(1);
+}
+const classOptionsMultiPkgoptArtifact = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_documentclass_opts_multi_probe_v0', 'pkgopt_v0.json'), 'utf8'),
+);
+if (!Array.isArray(classOptionsMultiPkgoptArtifact?.entries) || classOptionsMultiPkgoptArtifact.entries.length <= 0) {
+  console.error('FAIL: expected non-empty pkgopt_v0.entries for documentclass opts multi probe');
+  process.exit(1);
+}
+assertEntrySourceSpans('typeset_demo_documentclass_opts_multi_probe_v0', 'pkgopt_v0', classOptionsMultiPkgoptArtifact.entries);
+const passOptionsClassMultiEntry = classOptionsMultiPkgoptArtifact.entries.find(
+  (entry) => entry.command === 'PassOptionsToClass' && entry.package === 'classoptsmulti',
+);
+if (!passOptionsClassMultiEntry) {
+  console.error('FAIL: expected PassOptionsToClass pkgopt entry for classoptsmulti in multi probe');
+  process.exit(1);
+}
+if (JSON.stringify(passOptionsClassMultiEntry.options) !== JSON.stringify(['twoside', 'openright', 'draft'])) {
+  console.error('FAIL: expected PassOptionsToClass options deduped+ordered as [twoside,openright,draft]');
+  process.exit(1);
+}
+const documentclassMultiEntry = classOptionsMultiPkgoptArtifact.entries.find(
+  (entry) => entry.command === 'documentclass' && entry.package === 'classoptsmulti',
+);
+if (!documentclassMultiEntry) {
+  console.error('FAIL: expected documentclass pkgopt entry for classoptsmulti in multi probe');
+  process.exit(1);
+}
+if (JSON.stringify(documentclassMultiEntry.options) !== JSON.stringify(['openright', 'draft', 'twoside'])) {
+  console.error('FAIL: expected documentclass options deduped+ordered as [openright,draft,twoside]');
+  process.exit(1);
+}
+
 const graphicsSummary = JSON.parse(
   fs.readFileSync(path.join(outDir, 'typeset_demo_graphics_probe_v0', 'summary.json'), 'utf8'),
 );
@@ -792,6 +838,7 @@ const requiredEntries = [
   ['texmf', 'sty', 'fooopts.sty', 'typeset'],
   ['texmf', 'sty', 'baropts.sty', 'typeset'],
   ['texmf', 'cls', 'classoptsdemo.cls', 'typeset'],
+  ['texmf', 'cls', 'classoptsmulti.cls', 'typeset'],
   ['texmf', 'cls', 'memoir.cls', 'typeset'],
   ['texmf', 'cls', 'memoirplus.cls', 'typeset'],
   ['texmf', 'bib', 'refs.bib', 'typeset'],
@@ -1022,8 +1069,8 @@ if (!(resolvedCount > resolvedCountFirst)) {
   );
   process.exit(1);
 }
-if (resolvedCount < 36) {
-  console.error(`FAIL: expected resolved_resources_count >= 36 after class-option seam expansion, got ${resolvedCount}`);
+if (resolvedCount < 38) {
+  console.error(`FAIL: expected resolved_resources_count >= 38 after class-option normalization expansion, got ${resolvedCount}`);
   process.exit(1);
 }
 const okStatuses = statuses.filter((entry) => entry.status === 'OK');
@@ -1034,6 +1081,11 @@ if (okStatuses.length <= 0) {
 const documentclassInvalidStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_documentclass_invalid_probe_v0');
 if (!documentclassInvalidStatus || documentclassInvalidStatus.status !== 'INVALID') {
   console.error('FAIL: expected typeset_demo_documentclass_invalid_probe_v0 status INVALID');
+  process.exit(1);
+}
+const documentclassEmptyOptsInvalidStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_documentclass_emptyopts_invalid_probe_v0');
+if (!documentclassEmptyOptsInvalidStatus || documentclassEmptyOptsInvalidStatus.status !== 'INVALID') {
+  console.error('FAIL: expected typeset_demo_documentclass_emptyopts_invalid_probe_v0 status INVALID');
   process.exit(1);
 }
 for (const status of okStatuses) {
@@ -1262,7 +1314,7 @@ for (const status of statuses) {
 
 console.log(`PASS: resolved_resources_count ${resolvedCount}`);
 console.log(`PASS: resolved_resources_count increased from ${resolvedCountFirst} to ${resolvedCount}`);
-console.log('PASS: resolved_resources_count meets floor >= 36');
+console.log('PASS: resolved_resources_count meets floor >= 38');
 console.log(`PASS: baseline_match MATCH for all OK cases (${okStatuses.length})`);
 console.log(`PASS: typed_artifacts keys ${requiredTypedKeys.join(',')}`);
 console.log('PASS: typed_artifacts_version gate 1');

--- a/scripts/texlive_smoke/fixtures/typeset_demo_documentclass_emptyopts_invalid_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_documentclass_emptyopts_invalid_probe_v0.tex
@@ -1,0 +1,12 @@
+\documentclass[twoside,,openright]{memoir}
+\usepackage{xcolor}
+
+\title{CarrelTeX Documentclass Empty Options Invalid Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+Documentclass empty options invalid hint probe.
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_documentclass_opts_multi_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_documentclass_opts_multi_probe_v0.tex
@@ -1,0 +1,14 @@
+\PassOptionsToClass{ twoside , openright , twoside , draft }{classoptsmulti}
+\PassOptionsToClass{ openright , final }{classoptsmulti}
+\documentclass[ openright , draft , twoside , openright ]{classoptsmulti}
+\usepackage{xcolor}
+
+\title{CarrelTeX Documentclass Multi Options Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+Documentclass multi options hint probe.
+\end{document}

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -262,6 +262,11 @@ async function loadFixtureCasesV0() {
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_documentclass_opts_probe_v0.tex',
     },
     {
+      id: 'typeset_demo_documentclass_opts_multi_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_documentclass_opts_multi_probe_v0.tex',
+    },
+    {
       id: 'typeset_demo_passoptionstoclass_probe_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_passoptionstoclass_probe_v0.tex',
@@ -270,6 +275,11 @@ async function loadFixtureCasesV0() {
       id: 'typeset_demo_documentclass_invalid_probe_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_documentclass_invalid_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_documentclass_emptyopts_invalid_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_documentclass_emptyopts_invalid_probe_v0.tex',
     },
     {
       id: 'typeset_demo_package_require_invalid_probe_v0',
@@ -547,6 +557,18 @@ function dedupeValuesPreserveOrderV0(values) {
   return deduped;
 }
 
+function splitCommaOptionsStrictV0(rawValue, context) {
+  const values = [];
+  for (const chunk of rawValue.split(',')) {
+    const trimmed = chunk.trim();
+    if (trimmed.length === 0) {
+      throw new Error(`${context} has empty option entry`);
+    }
+    values.push(trimmed);
+  }
+  return dedupeValuesPreserveOrderV0(values);
+}
+
 function ensureDefaultExtensionV0(value, extension) {
   if (value.includes('.')) {
     return value;
@@ -738,7 +760,11 @@ function extractPkgoptEntriesFromSourceV0(sourceBytes) {
         index = commandIndex;
         continue;
       }
-      options = dedupeValuesPreserveOrderV0(splitCommaValuesV0(optionGroup.value));
+      if (command === 'PassOptionsToClass') {
+        options = splitCommaOptionsStrictV0(optionGroup.value, 'pkgopt_v0 PassOptionsToClass');
+      } else {
+        options = dedupeValuesPreserveOrderV0(splitCommaValuesV0(optionGroup.value));
+      }
       packages = dedupeValuesPreserveOrderV0(splitCommaValuesV0(packageGroup.value));
       endOffset = packageGroup.next;
     } else if (command === 'documentclass') {
@@ -752,7 +778,7 @@ function extractPkgoptEntriesFromSourceV0(sourceBytes) {
         index = commandIndex;
         continue;
       }
-      options = optGroup.ok ? dedupeValuesPreserveOrderV0(splitCommaValuesV0(optGroup.value)) : [];
+      options = optGroup.ok ? splitCommaOptionsStrictV0(optGroup.value, 'pkgopt_v0 documentclass options') : [];
       if (options.length === 0) {
         index = classGroup.next;
         continue;
@@ -970,6 +996,7 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
       const optGroup = readBracketGroupV0(sourceBytes, commandIndex);
       let next = commandIndex;
       if (optGroup.ok) {
+        splitCommaOptionsStrictV0(optGroup.value, 'resource_hints_v0 documentclass options');
         next = optGroup.next;
       }
       const classGroup = readBracedGroupV0(sourceBytes, next);
@@ -1015,6 +1042,7 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
         index = commandIndex;
         continue;
       }
+      splitCommaOptionsStrictV0(optionGroup.value, 'resource_hints_v0 PassOptionsToClass');
       const classGroup = readBracedGroupV0(sourceBytes, optionGroup.next);
       if (!classGroup.ok || classGroup.value.length === 0) {
         index = commandIndex;
@@ -1493,6 +1521,7 @@ async function emitTypedArtifactsV0(caseSpec, caseOutDir, typedArtifacts, fixtur
     || caseSpec.id === 'typeset_demo_pkgopt_require_pass_probe_v0'
     || caseSpec.id === 'typeset_demo_class_options_probe_v0'
     || caseSpec.id === 'typeset_demo_documentclass_opts_probe_v0'
+    || caseSpec.id === 'typeset_demo_documentclass_opts_multi_probe_v0'
     || caseSpec.id === 'typeset_demo_passoptionstoclass_probe_v0'
   ) {
     typedArtifacts.pkgopt = await emitPkgoptTypedArtifactV0(caseOutDir, fixtureBytes);

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -128,6 +128,12 @@
       "purpose": "Probes documentclass option hints for class_file requests and class-target pkgopt extraction."
     },
     {
+      "id": "typeset_demo_documentclass_opts_multi_probe_v0",
+      "tags": ["typeset", "class", "pkgopt", "documentclass", "options", "whitespace", "dedupe", "probe", "ni"],
+      "expected_status": "NI",
+      "purpose": "Probes documentclass/PassOptionsToClass option normalization with deduped stable ordering."
+    },
+    {
       "id": "typeset_demo_passoptionstoclass_probe_v0",
       "tags": ["typeset", "class", "pkgopt", "passoptionstoclass", "probe", "ni"],
       "expected_status": "NI",
@@ -138,6 +144,12 @@
       "tags": ["typeset", "class", "invalid", "unsafe-path", "probe"],
       "expected_status": "INVALID",
       "purpose": "Probes fail-closed class-file hint normalization on unsafe documentclass paths."
+    },
+    {
+      "id": "typeset_demo_documentclass_emptyopts_invalid_probe_v0",
+      "tags": ["typeset", "class", "invalid", "options", "empty-entry", "probe"],
+      "expected_status": "INVALID",
+      "purpose": "Probes fail-closed class option parsing on empty comma-separated option entries."
     },
     {
       "id": "typeset_demo_package_require_invalid_probe_v0",


### PR DESCRIPTION
## Summary\n- normalize class option parsing with stable dedupe/ordering for documentclass and PassOptionsToClass\n- add multi-option class probe and empty-option INVALID probe fixtures\n- extend proof assertions and resolved-resource floor for class option seam coverage\n\n## Proof\n- ./scripts/proof_wasm_fixture_gallery_v0.sh