### PR TITLE
gallery: normalize usepackage options and reject empty entries

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -73,6 +73,7 @@ printf 'fixture-bytes-for-xcolor-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/xcolor.
 printf 'fixture-bytes-for-foo-bar-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/foo__bar.sty"
 printf 'fixture-bytes-for-fooopts-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/fooopts.sty"
 printf 'fixture-bytes-for-baropts-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/baropts.sty"
+printf 'fixture-bytes-for-pkgoptsdemo-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/pkgoptsdemo.sty"
 printf 'fixture-bytes-for-natbib-sty\n' > "$FIXTURE_SOURCE_DIR/xetex/sty/natbib.sty"
 printf 'fixture-bytes-for-memoir-cls\n' > "$FIXTURE_SOURCE_DIR/xetex/cls/memoir.cls"
 printf 'fixture-bytes-for-classoptsdemo-cls\n' > "$FIXTURE_SOURCE_DIR/xetex/cls/classoptsdemo.cls"
@@ -200,6 +201,13 @@ const requireWithOptionsPackageRequest = listA.requests.find(
 );
 if (!requireWithOptionsPackageRequest) {
   console.error('FAIL: request list must include package hint request for baropts.sty');
+  process.exit(1);
+}
+const usepackageMultiOptionsRequest = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.name === 'pkgoptsdemo.sty' && request.variant === 'typeset',
+);
+if (!usepackageMultiOptionsRequest) {
+  console.error('FAIL: request list must include package hint request for pkgoptsdemo.sty');
   process.exit(1);
 }
 const classOptionsRequest = listA.requests.find(
@@ -700,6 +708,33 @@ if (JSON.stringify(documentclassMultiEntry.options) !== JSON.stringify(['openrig
   process.exit(1);
 }
 
+const usepackageMultiPkgoptSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_usepackage_opts_multi_probe_v0', 'summary.json'), 'utf8'),
+);
+if (usepackageMultiPkgoptSummary?.typed_artifacts?.pkgopt?.present !== true) {
+  console.error('FAIL: expected pkgopt typed artifact present for usepackage opts multi probe after first run');
+  process.exit(1);
+}
+const usepackageMultiPkgoptArtifact = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_usepackage_opts_multi_probe_v0', 'pkgopt_v0.json'), 'utf8'),
+);
+if (!Array.isArray(usepackageMultiPkgoptArtifact?.entries) || usepackageMultiPkgoptArtifact.entries.length <= 0) {
+  console.error('FAIL: expected non-empty pkgopt_v0.entries for usepackage opts multi probe');
+  process.exit(1);
+}
+assertEntrySourceSpans('typeset_demo_usepackage_opts_multi_probe_v0', 'pkgopt_v0', usepackageMultiPkgoptArtifact.entries);
+const usepackageMultiEntry = usepackageMultiPkgoptArtifact.entries.find(
+  (entry) => entry.command === 'usepackage' && entry.package === 'pkgoptsdemo',
+);
+if (!usepackageMultiEntry) {
+  console.error('FAIL: expected usepackage pkgopt entry for pkgoptsdemo in multi probe');
+  process.exit(1);
+}
+if (JSON.stringify(usepackageMultiEntry.options) !== JSON.stringify(['table', 'dvipsnames', 'svgnames'])) {
+  console.error('FAIL: expected usepackage options deduped+ordered as [table,dvipsnames,svgnames]');
+  process.exit(1);
+}
+
 const graphicsSummary = JSON.parse(
   fs.readFileSync(path.join(outDir, 'typeset_demo_graphics_probe_v0', 'summary.json'), 'utf8'),
 );
@@ -837,6 +872,7 @@ const requiredEntries = [
   ['texmf', 'sty', 'foo__bar.sty', 'typeset'],
   ['texmf', 'sty', 'fooopts.sty', 'typeset'],
   ['texmf', 'sty', 'baropts.sty', 'typeset'],
+  ['texmf', 'sty', 'pkgoptsdemo.sty', 'typeset'],
   ['texmf', 'cls', 'classoptsdemo.cls', 'typeset'],
   ['texmf', 'cls', 'classoptsmulti.cls', 'typeset'],
   ['texmf', 'cls', 'memoir.cls', 'typeset'],
@@ -1069,8 +1105,8 @@ if (!(resolvedCount > resolvedCountFirst)) {
   );
   process.exit(1);
 }
-if (resolvedCount < 38) {
-  console.error(`FAIL: expected resolved_resources_count >= 38 after class-option normalization expansion, got ${resolvedCount}`);
+if (resolvedCount < 39) {
+  console.error(`FAIL: expected resolved_resources_count >= 39 after usepackage-option normalization expansion, got ${resolvedCount}`);
   process.exit(1);
 }
 const okStatuses = statuses.filter((entry) => entry.status === 'OK');
@@ -1086,6 +1122,11 @@ if (!documentclassInvalidStatus || documentclassInvalidStatus.status !== 'INVALI
 const documentclassEmptyOptsInvalidStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_documentclass_emptyopts_invalid_probe_v0');
 if (!documentclassEmptyOptsInvalidStatus || documentclassEmptyOptsInvalidStatus.status !== 'INVALID') {
   console.error('FAIL: expected typeset_demo_documentclass_emptyopts_invalid_probe_v0 status INVALID');
+  process.exit(1);
+}
+const usepackageEmptyOptsInvalidStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_usepackage_emptyopts_invalid_probe_v0');
+if (!usepackageEmptyOptsInvalidStatus || usepackageEmptyOptsInvalidStatus.status !== 'INVALID') {
+  console.error('FAIL: expected typeset_demo_usepackage_emptyopts_invalid_probe_v0 status INVALID');
   process.exit(1);
 }
 for (const status of okStatuses) {
@@ -1314,7 +1355,7 @@ for (const status of statuses) {
 
 console.log(`PASS: resolved_resources_count ${resolvedCount}`);
 console.log(`PASS: resolved_resources_count increased from ${resolvedCountFirst} to ${resolvedCount}`);
-console.log('PASS: resolved_resources_count meets floor >= 38');
+console.log('PASS: resolved_resources_count meets floor >= 39');
 console.log(`PASS: baseline_match MATCH for all OK cases (${okStatuses.length})`);
 console.log(`PASS: typed_artifacts keys ${requiredTypedKeys.join(',')}`);
 console.log('PASS: typed_artifacts_version gate 1');

--- a/scripts/texlive_smoke/fixtures/typeset_demo_usepackage_emptyopts_invalid_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_usepackage_emptyopts_invalid_probe_v0.tex
@@ -1,0 +1,12 @@
+\documentclass{article}
+\usepackage[table,,dvipsnames]{pkgoptsdemo}
+
+\title{CarrelTeX Usepackage Empty Options Invalid Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+Usepackage empty options invalid hint probe.
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_usepackage_opts_multi_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_usepackage_opts_multi_probe_v0.tex
@@ -1,0 +1,13 @@
+\documentclass{article}
+\usepackage[table,dvipsnames,table]{pkgoptsdemo}
+\usepackage[svgnames,dvipsnames]{pkgoptsdemo}
+
+\title{CarrelTeX Usepackage Multi Options Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+Usepackage multi options hint probe.
+\end{document}

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -282,6 +282,16 @@ async function loadFixtureCasesV0() {
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_documentclass_emptyopts_invalid_probe_v0.tex',
     },
     {
+      id: 'typeset_demo_usepackage_opts_multi_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_usepackage_opts_multi_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_usepackage_emptyopts_invalid_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_usepackage_emptyopts_invalid_probe_v0.tex',
+    },
+    {
       id: 'typeset_demo_package_require_invalid_probe_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_package_require_invalid_probe_v0.tex',
@@ -557,6 +567,51 @@ function dedupeValuesPreserveOrderV0(values) {
   return deduped;
 }
 
+function mergePkgoptUsepackageEntriesV0(entries) {
+  const merged = [];
+  const indexByKey = new Map();
+  for (const entry of entries) {
+    const command = typeof entry?.command === 'string' ? entry.command : '';
+    if (command !== 'usepackage' && command !== 'RequirePackage') {
+      merged.push(entry);
+      continue;
+    }
+    const packageName = typeof entry?.package === 'string' ? entry.package : '';
+    const key = `${command}\u0000${packageName.toLowerCase()}`;
+    const existingIndex = indexByKey.get(key);
+    if (existingIndex === undefined) {
+      indexByKey.set(key, merged.length);
+      merged.push({
+        ...entry,
+        options: dedupeValuesPreserveOrderV0(Array.isArray(entry.options) ? entry.options : []),
+      });
+      continue;
+    }
+    const existing = merged[existingIndex];
+    const mergedOptions = dedupeValuesPreserveOrderV0([
+      ...(Array.isArray(existing.options) ? existing.options : []),
+      ...(Array.isArray(entry.options) ? entry.options : []),
+    ]);
+    const start = Math.min(
+      existing.source_span?.start_byte ?? Number.MAX_SAFE_INTEGER,
+      entry.source_span?.start_byte ?? Number.MAX_SAFE_INTEGER,
+    );
+    const end = Math.max(
+      existing.source_span?.end_byte ?? 0,
+      entry.source_span?.end_byte ?? 0,
+    );
+    merged[existingIndex] = {
+      ...existing,
+      options: mergedOptions,
+      source_span: {
+        start_byte: start,
+        end_byte: end,
+      },
+    };
+  }
+  return merged;
+}
+
 function splitCommaOptionsStrictV0(rawValue, context) {
   const values = [];
   for (const chunk of rawValue.split(',')) {
@@ -760,7 +815,7 @@ function extractPkgoptEntriesFromSourceV0(sourceBytes) {
         index = commandIndex;
         continue;
       }
-      if (command === 'PassOptionsToClass') {
+      if (command === 'PassOptionsToClass' || command === 'usepackage' || command === 'RequirePackage') {
         options = splitCommaOptionsStrictV0(optionGroup.value, 'pkgopt_v0 PassOptionsToClass');
       } else {
         options = dedupeValuesPreserveOrderV0(splitCommaValuesV0(optionGroup.value));
@@ -820,7 +875,7 @@ function extractPkgoptEntriesFromSourceV0(sourceBytes) {
     }
     index = endOffset;
   }
-  return entries;
+  return mergePkgoptUsepackageEntriesV0(entries);
 }
 
 function extractGraphicsEntriesFromSourceV0(sourceBytes) {
@@ -980,6 +1035,7 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
       let next = commandIndex;
       const optionsGroup = readBracketGroupV0(sourceBytes, next);
       if (optionsGroup.ok) {
+        splitCommaOptionsStrictV0(optionsGroup.value, 'resource_hints_v0 usepackage options');
         next = optionsGroup.next;
       }
       const packageGroup = readBracedGroupV0(sourceBytes, next);
@@ -1523,6 +1579,7 @@ async function emitTypedArtifactsV0(caseSpec, caseOutDir, typedArtifacts, fixtur
     || caseSpec.id === 'typeset_demo_documentclass_opts_probe_v0'
     || caseSpec.id === 'typeset_demo_documentclass_opts_multi_probe_v0'
     || caseSpec.id === 'typeset_demo_passoptionstoclass_probe_v0'
+    || caseSpec.id === 'typeset_demo_usepackage_opts_multi_probe_v0'
   ) {
     typedArtifacts.pkgopt = await emitPkgoptTypedArtifactV0(caseOutDir, fixtureBytes);
   }

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -152,6 +152,18 @@
       "purpose": "Probes fail-closed class option parsing on empty comma-separated option entries."
     },
     {
+      "id": "typeset_demo_usepackage_opts_multi_probe_v0",
+      "tags": ["typeset", "packages", "pkgopt", "usepackage", "options", "whitespace", "dedupe", "probe", "ni"],
+      "expected_status": "NI",
+      "purpose": "Probes usepackage option normalization with stable dedupe/ordering across repeated declarations."
+    },
+    {
+      "id": "typeset_demo_usepackage_emptyopts_invalid_probe_v0",
+      "tags": ["typeset", "packages", "invalid", "usepackage", "options", "empty-entry", "probe"],
+      "expected_status": "INVALID",
+      "purpose": "Probes fail-closed usepackage option parsing on empty comma-separated option entries."
+    },
+    {
       "id": "typeset_demo_package_require_invalid_probe_v0",
       "tags": ["typeset", "packages", "requirepackage", "unsafe-path", "probe", "invalid"],
       "expected_status": "INVALID",


### PR DESCRIPTION
## Summary\n- normalize and dedupe usepackage option parsing with stable ordering across repeated usepackage lines\n- add INVALID empty-option usepackage probe\n- extend proof assertions and resolved-resource floor for package option seam\n\n## Proof\n- ./scripts/proof_wasm_fixture_gallery_v0.sh