### PR TITLE
gallery: includegraphics multipath option hints

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -60,6 +60,9 @@ printf 'fixture-bytes-for-figs-demo-graphic-pdf\n' > "$FIXTURE_SOURCE_DIR/xetex/
 printf 'fixture-bytes-for-plots-demo-graphic-pdf\n' > "$FIXTURE_SOURCE_DIR/xetex/pdf/plots__demo_graphic.pdf"
 printf 'fixture-bytes-for-figs-banner-graphic-pdf\n' > "$FIXTURE_SOURCE_DIR/xetex/pdf/figs__banner_graphic.pdf"
 printf 'fixture-bytes-for-figs-sub-banner-graphic-pdf\n' > "$FIXTURE_SOURCE_DIR/xetex/pdf/figs__sub__banner_graphic.pdf"
+printf 'fixture-bytes-for-assets-figs-multi-probe-pdf\n' > "$FIXTURE_SOURCE_DIR/xetex/pdf/assets__figs__multi_probe.pdf"
+printf 'fixture-bytes-for-assets-plots-multi-probe-pdf\n' > "$FIXTURE_SOURCE_DIR/xetex/pdf/assets__plots__multi_probe.pdf"
+printf 'fixture-bytes-for-assets-hires-chart-pdf\n' > "$FIXTURE_SOURCE_DIR/xetex/pdf/assets__hires__chart.pdf"
 printf 'fixture-bytes-for-refs-bib\n' > "$FIXTURE_SOURCE_DIR/xetex/bib/refs.bib"
 printf 'fixture-bytes-for-styleprobe-refs-bib\n' > "$FIXTURE_SOURCE_DIR/xetex/bib/styleprobe_refs.bib"
 printf 'fixture-bytes-for-multiadd-refs-bib\n' > "$FIXTURE_SOURCE_DIR/xetex/bib/multiadd_refs.bib"
@@ -346,8 +349,33 @@ if (!graphicspathExplicitRequestB) {
   console.error('FAIL: request list must include explicit-ext graphicspath hint request for figs__sub__banner_graphic.pdf');
   process.exit(1);
 }
+const graphicsMultipathRequestA = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'pdf' && request.name === 'assets__figs__multi_probe.pdf' && request.variant === 'typeset',
+);
+if (!graphicsMultipathRequestA) {
+  console.error('FAIL: request list must include multipath graphicspath hint request for assets__figs__multi_probe.pdf');
+  process.exit(1);
+}
+const graphicsMultipathRequestB = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'pdf' && request.name === 'assets__plots__multi_probe.pdf' && request.variant === 'typeset',
+);
+if (!graphicsMultipathRequestB) {
+  console.error('FAIL: request list must include multipath graphicspath hint request for assets__plots__multi_probe.pdf');
+  process.exit(1);
+}
+const graphicsTypePathRequest = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'pdf' && request.name === 'assets__hires__chart.pdf' && request.variant === 'typeset',
+);
+if (!graphicsTypePathRequest) {
+  console.error('FAIL: request list must include includegraphics type/path hint request for assets__hires__chart.pdf');
+  process.exit(1);
+}
 if (listA.requests.some((request) => request.name === 'bad__danger_graphic.pdf' || request.name === 'abs__danger_graphic.pdf')) {
   console.error('FAIL: request list must fail-closed for unsafe graphicspath entries');
+  process.exit(1);
+}
+if (listA.requests.some((request) => request.name === 'unsafe__bad_chart.pdf')) {
+  console.error('FAIL: request list must fail-closed for unsafe includegraphics option path entries');
   process.exit(1);
 }
 if (listA.requests.some((request) => request.name === 'evil.sty' || request.name === 'evil__pkg.sty')) {
@@ -962,6 +990,9 @@ const requiredEntries = [
   ['texmf', 'pdf', 'plots__demo_graphic.pdf', 'typeset'],
   ['texmf', 'pdf', 'figs__banner_graphic.pdf', 'typeset'],
   ['texmf', 'pdf', 'figs__sub__banner_graphic.pdf', 'typeset'],
+  ['texmf', 'pdf', 'assets__figs__multi_probe.pdf', 'typeset'],
+  ['texmf', 'pdf', 'assets__plots__multi_probe.pdf', 'typeset'],
+  ['texmf', 'pdf', 'assets__hires__chart.pdf', 'typeset'],
   ['fontconfig', 'name', 'FoundSans', 'public'],
 ];
 for (const [kind, format, name, variant] of requiredEntries) {
@@ -1173,8 +1204,8 @@ if (!(resolvedCount > resolvedCountFirst)) {
   );
   process.exit(1);
 }
-if (resolvedCount < 42) {
-  console.error(`FAIL: expected resolved_resources_count >= 42 after multipackage package-option expansion, got ${resolvedCount}`);
+if (resolvedCount < 45) {
+  console.error(`FAIL: expected resolved_resources_count >= 45 after includegraphics multipath expansion, got ${resolvedCount}`);
   process.exit(1);
 }
 const okStatuses = statuses.filter((entry) => entry.status === 'OK');
@@ -1200,6 +1231,11 @@ if (!usepackageEmptyOptsInvalidStatus || usepackageEmptyOptsInvalidStatus.status
 const usepackageMultipackageInvalidStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_usepackage_multipackage_invalid_probe_v0');
 if (!usepackageMultipackageInvalidStatus || usepackageMultipackageInvalidStatus.status !== 'INVALID') {
   console.error('FAIL: expected typeset_demo_usepackage_multipackage_invalid_probe_v0 status INVALID');
+  process.exit(1);
+}
+const graphicsOptionsInvalidStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_graphics_opts_invalid_probe_v0');
+if (!graphicsOptionsInvalidStatus || graphicsOptionsInvalidStatus.status !== 'INVALID') {
+  console.error('FAIL: expected typeset_demo_graphics_opts_invalid_probe_v0 status INVALID');
   process.exit(1);
 }
 for (const status of okStatuses) {
@@ -1428,7 +1464,7 @@ for (const status of statuses) {
 
 console.log(`PASS: resolved_resources_count ${resolvedCount}`);
 console.log(`PASS: resolved_resources_count increased from ${resolvedCountFirst} to ${resolvedCount}`);
-console.log('PASS: resolved_resources_count meets floor >= 42');
+console.log('PASS: resolved_resources_count meets floor >= 45');
 console.log(`PASS: baseline_match MATCH for all OK cases (${okStatuses.length})`);
 console.log(`PASS: typed_artifacts keys ${requiredTypedKeys.join(',')}`);
 console.log('PASS: typed_artifacts_version gate 1');

--- a/scripts/texlive_smoke/fixtures/typeset_demo_graphics_multipath_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_graphics_multipath_probe_v0.tex
@@ -1,0 +1,14 @@
+\documentclass{article}
+\usepackage{graphicx}
+\graphicspath{{assets/figs/}{assets/plots/}}
+
+\title{CarrelTeX Graphics Multipath Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+\includegraphics[width=0.5\textwidth,height=2cm,keepaspectratio,page=1]{multi_probe.pdf}
+\includegraphics[path=assets/hires,type=pdf,width=0.4\textwidth]{chart}
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_graphics_opts_invalid_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_graphics_opts_invalid_probe_v0.tex
@@ -1,0 +1,13 @@
+\documentclass{article}
+\usepackage{graphicx}
+\graphicspath{{assets/figs/}{assets/plots/}}
+
+\title{CarrelTeX Graphics Invalid Options Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+\includegraphics[path=../unsafe,ext=pdf,width=0.5\textwidth]{bad_chart}
+\end{document}

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -217,6 +217,16 @@ async function loadFixtureCasesV0() {
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_graphicspath_invalid_probe_v0.tex',
     },
     {
+      id: 'typeset_demo_graphics_multipath_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_graphics_multipath_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_graphics_opts_invalid_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_graphics_opts_invalid_probe_v0.tex',
+    },
+    {
       id: 'typeset_demo_pkgopt_probe_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_pkgopt_probe_v0.tex',
@@ -676,20 +686,24 @@ function normalizePathHintTokenV0(rawValue, hintType) {
   return normalized;
 }
 
-function parseOptionAssignmentsV0(rawValue) {
+function parseIncludegraphicsOptionsStrictV0(rawValue) {
   const assignments = new Map();
-  for (const item of splitCommaValuesV0(rawValue)) {
-    const equalsIndex = item.indexOf('=');
-    if (equalsIndex <= 0 || equalsIndex === item.length - 1) {
+  for (const chunk of rawValue.split(',')) {
+    const trimmed = chunk.trim();
+    if (trimmed.length === 0) {
+      throw new Error('resource_hints_v0 includegraphics options has empty entry');
+    }
+    const equalsIndex = trimmed.indexOf('=');
+    if (equalsIndex < 0) {
       continue;
     }
-    const key = item.slice(0, equalsIndex).trim().toLowerCase();
-    let value = item.slice(equalsIndex + 1).trim();
+    const key = trimmed.slice(0, equalsIndex).trim().toLowerCase();
+    let value = trimmed.slice(equalsIndex + 1).trim();
     while (value.length >= 2 && value.startsWith('{') && value.endsWith('}')) {
       value = value.slice(1, -1).trim();
     }
     if (key.length === 0 || value.length === 0) {
-      continue;
+      throw new Error(`resource_hints_v0 includegraphics option '${trimmed}' is malformed`);
     }
     assignments.set(key, value);
   }
@@ -1122,7 +1136,7 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
     if (command === 'includegraphics') {
       let next = commandIndex;
       const optionsGroup = readBracketGroupV0(sourceBytes, next);
-      const graphicsOptions = optionsGroup.ok ? parseOptionAssignmentsV0(optionsGroup.value) : new Map();
+      const graphicsOptions = optionsGroup.ok ? parseIncludegraphicsOptionsStrictV0(optionsGroup.value) : new Map();
       if (optionsGroup.ok) {
         next = optionsGroup.next;
       }
@@ -1131,12 +1145,26 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
         index = commandIndex;
         continue;
       }
-      const extRaw = (graphicsOptions.get('ext') ?? graphicsOptions.get('extension') ?? '').trim();
-      const extNormalized = /^[a-z0-9]+$/i.test(extRaw.replace(/^\./, '')) ? extRaw.replace(/^\./, '') : '';
+      const extRaw = (
+        graphicsOptions.get('ext')
+        ?? graphicsOptions.get('extension')
+        ?? graphicsOptions.get('type')
+        ?? ''
+      ).trim();
+      let extNormalized = '';
+      if (extRaw.length > 0) {
+        const extCandidate = extRaw.replace(/^\./, '');
+        if (!/^[a-z0-9]+$/i.test(extCandidate)) {
+          throw new Error(`resource_hints_v0 includegraphics rejects extension '${extRaw}'`);
+        }
+        extNormalized = extCandidate;
+      }
       const dirRaw = (graphicsOptions.get('dir') ?? graphicsOptions.get('path') ?? '').trim();
       const dirNormalized = normalizePathHintTokenV0(dirRaw, 'graphics_path');
+      const fileRaw = (graphicsOptions.get('file') ?? graphicsOptions.get('filename') ?? '').trim();
+      const includeValues = fileRaw.length > 0 ? splitCommaValuesV0(fileRaw) : splitCommaValuesV0(graphicsGroup.value);
       const candidates = [];
-      for (const value of splitCommaValuesV0(graphicsGroup.value)) {
+      for (const value of includeValues) {
         const useGraphicspathPrefixes = !dirNormalized
           && graphicspathPrefixes.length > 0
           && !value.includes('/')

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -74,6 +74,18 @@
       "purpose": "Probes fail-closed graphicspath handling for unsafe ../ and absolute path entries."
     },
     {
+      "id": "typeset_demo_graphics_multipath_probe_v0",
+      "tags": ["typeset", "graphics", "includegraphics", "options", "graphicspath", "multi-path", "probe", "ni"],
+      "expected_status": "NI",
+      "purpose": "Probes includegraphics option parsing beyond width/height and emits per-prefix candidate graphics hints."
+    },
+    {
+      "id": "typeset_demo_graphics_opts_invalid_probe_v0",
+      "tags": ["typeset", "graphics", "includegraphics", "options", "invalid", "unsafe-path", "probe"],
+      "expected_status": "INVALID",
+      "purpose": "Probes fail-closed includegraphics option parsing by rejecting unsafe path/dir option values."
+    },
+    {
       "id": "typeset_demo_pkgopt_probe_v0",
       "tags": ["typeset", "package-options", "probe", "ni"],
       "expected_status": "NI",


### PR DESCRIPTION
## Summary\n- extend includegraphics hint parsing for additional options (type/file/path) with fail-closed validation\n- add multipath + invalid graphics option probe fixtures\n- bump gallery proof floor and seed deterministic blobs for new hint-derived requests\n\n## Proof\n- ./scripts/proof_wasm_fixture_gallery_v0.sh