### PR TITLE
gallery: add resource_hints_v0 schema gate v1

### DIFF
--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -871,6 +871,10 @@ if (resourceHints.version !== 1) {
   console.error('FAIL: expected report.resource_hints_v0.version=1 after first run');
   process.exit(1);
 }
+if (resourceHints.resource_hints_v0_version !== 1) {
+  console.error('FAIL: expected report.resource_hints_v0.resource_hints_v0_version=1 after first run');
+  process.exit(1);
+}
 if (!Array.isArray(resourceHints.entries)) {
   console.error('FAIL: expected report.resource_hints_v0.entries array after first run');
   process.exit(1);
@@ -879,17 +883,51 @@ if (resourceHints.entries.length <= 0) {
   console.error('FAIL: expected non-empty report.resource_hints_v0.entries after first run');
   process.exit(1);
 }
+const allowedHintTypes = new Set([
+  'tex_input',
+  'tex_include',
+  'tex_includeonly',
+  'package_file',
+  'class_file',
+  'graphics_path',
+  'bib_resource',
+  'bib_style',
+  'hyperref_url',
+]);
+const fixtureBytesByCase = new Map();
 for (const [index, entry] of resourceHints.entries.entries()) {
+  if (entry?.kind !== 'resource_hint') {
+    console.error(`FAIL: resource_hints_v0.entries[${index}] invalid kind`);
+    process.exit(1);
+  }
   if (typeof entry?.case_id !== 'string' || entry.case_id.length === 0) {
     console.error(`FAIL: resource_hints_v0.entries[${index}] invalid case_id`);
     process.exit(1);
   }
-  if (typeof entry?.hint_type !== 'string' || entry.hint_type.length === 0) {
+  if (typeof entry?.hint_type !== 'string' || !allowedHintTypes.has(entry.hint_type)) {
     console.error(`FAIL: resource_hints_v0.entries[${index}] invalid hint_type`);
     process.exit(1);
   }
   if (typeof entry?.value !== 'string' || entry.value.length === 0) {
     console.error(`FAIL: resource_hints_v0.entries[${index}] invalid value`);
+    process.exit(1);
+  }
+  const sourceSpan = entry?.source_span;
+  if (!sourceSpan || !Number.isInteger(sourceSpan.start_byte) || !Number.isInteger(sourceSpan.end_byte)) {
+    console.error(`FAIL: resource_hints_v0.entries[${index}] missing source_span`);
+    process.exit(1);
+  }
+  if (sourceSpan.start_byte < 0 || sourceSpan.end_byte <= sourceSpan.start_byte) {
+    console.error(`FAIL: resource_hints_v0.entries[${index}] source_span must satisfy start<end`);
+    process.exit(1);
+  }
+  if (!fixtureBytesByCase.has(entry.case_id)) {
+    const fixturePath = path.join(outDir, entry.case_id, 'main.tex');
+    fixtureBytesByCase.set(entry.case_id, fs.readFileSync(fixturePath));
+  }
+  const fixtureBytes = fixtureBytesByCase.get(entry.case_id);
+  if (sourceSpan.end_byte > fixtureBytes.length) {
+    console.error(`FAIL: resource_hints_v0.entries[${index}] source_span out of fixture bounds`);
     process.exit(1);
   }
 }
@@ -1176,6 +1214,10 @@ if (resourceHints.version !== 1) {
   console.error('FAIL: expected report.resource_hints_v0.version=1 after rerun');
   process.exit(1);
 }
+if (resourceHints.resource_hints_v0_version !== 1) {
+  console.error('FAIL: expected report.resource_hints_v0.resource_hints_v0_version=1 after rerun');
+  process.exit(1);
+}
 if (!Array.isArray(resourceHints.entries)) {
   console.error('FAIL: expected report.resource_hints_v0.entries array after rerun');
   process.exit(1);
@@ -1236,6 +1278,11 @@ if (!usepackageMultipackageInvalidStatus || usepackageMultipackageInvalidStatus.
 const graphicsOptionsInvalidStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_graphics_opts_invalid_probe_v0');
 if (!graphicsOptionsInvalidStatus || graphicsOptionsInvalidStatus.status !== 'INVALID') {
   console.error('FAIL: expected typeset_demo_graphics_opts_invalid_probe_v0 status INVALID');
+  process.exit(1);
+}
+const resourceHintsInvalidStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_resource_hints_invalid_probe_v0');
+if (!resourceHintsInvalidStatus || resourceHintsInvalidStatus.status !== 'INVALID') {
+  console.error('FAIL: expected typeset_demo_resource_hints_invalid_probe_v0 status INVALID');
   process.exit(1);
 }
 for (const status of okStatuses) {

--- a/scripts/texlive_smoke/fixtures/typeset_demo_resource_hints_invalid_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_resource_hints_invalid_probe_v0.tex
@@ -1,0 +1,11 @@
+\documentclass{article}
+
+\title{CarrelTeX Resource Hints Invalid Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+\input{../evil}
+\end{document}

--- a/scripts/texlive_smoke/request_list_from_hints_v0.mjs
+++ b/scripts/texlive_smoke/request_list_from_hints_v0.mjs
@@ -129,7 +129,12 @@ export async function buildRequestListFromHintsV0(options = {}) {
     throw new Error(`report typed_artifacts_version must be 1, got ${String(report?.typed_artifacts_version)}`);
   }
   const resourceHints = report?.resource_hints_v0;
-  if (!resourceHints || typeof resourceHints !== 'object' || resourceHints.version !== 1) {
+  if (
+    !resourceHints
+    || typeof resourceHints !== 'object'
+    || resourceHints.version !== 1
+    || resourceHints.resource_hints_v0_version !== 1
+  ) {
     throw new Error('report.resource_hints_v0 must exist with version=1');
   }
   if (!Array.isArray(resourceHints.entries)) {

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -35,6 +35,18 @@ const MAX_GRAPHICS_ENTRIES_V0 = 256;
 const MAX_GRAPHICS_PATH_BYTES_V0 = 256;
 const MAX_RESOURCE_HINT_ENTRIES_V0 = 512;
 const MAX_RESOURCE_HINT_VALUE_BYTES_V0 = 256;
+const RESOURCE_HINTS_V0_VERSION = 1;
+const RESOURCE_HINT_TYPE_ALLOWLIST_V0 = new Set([
+  'tex_input',
+  'tex_include',
+  'tex_includeonly',
+  'package_file',
+  'class_file',
+  'graphics_path',
+  'bib_resource',
+  'bib_style',
+  'hyperref_url',
+]);
 
 function sha256HexV0(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
@@ -330,6 +342,11 @@ async function loadFixtureCasesV0() {
       id: 'typeset_demo_graphics_opts_probe_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_graphics_opts_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_resource_hints_invalid_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_resource_hints_invalid_probe_v0.tex',
     },
   ];
 
@@ -952,13 +969,14 @@ function extractGraphicsEntriesFromSourceV0(sourceBytes) {
   return entries;
 }
 
-function addResourceHintEntryV0(entries, sourceBytes, hintType, value, startByte, endByte) {
+function addResourceHintEntryV0(entries, sourceBytes, caseId, hintType, value, startByte, endByte) {
   const valueBytes = Buffer.from(value, 'utf8');
   if (valueBytes.length > MAX_RESOURCE_HINT_VALUE_BYTES_V0) {
     throw new Error(`resource_hints_v0 value exceeds cap ${MAX_RESOURCE_HINT_VALUE_BYTES_V0}`);
   }
   entries.push({
     kind: 'resource_hint',
+    case_id: caseId,
     hint_type: hintType,
     value,
     source_span: buildSourceSpanV0(sourceBytes, startByte, endByte, 'resource_hints_v0'),
@@ -968,7 +986,7 @@ function addResourceHintEntryV0(entries, sourceBytes, hintType, value, startByte
   }
 }
 
-function extractResourceHintEntriesFromSourceV0(sourceBytes) {
+function extractResourceHintEntriesFromSourceV0(sourceBytes, caseId) {
   const entries = [];
   const seen = new Set();
   let graphicspathPrefixes = [];
@@ -993,7 +1011,7 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
           continue;
         }
         seen.add(dedupeKey);
-        addResourceHintEntryV0(entries, sourceBytes, hintType, normalizedUrl, startByte, endByte);
+        addResourceHintEntryV0(entries, sourceBytes, caseId, hintType, normalizedUrl, startByte, endByte);
         continue;
       }
       let normalizedPath;
@@ -1014,7 +1032,7 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
         continue;
       }
       seen.add(dedupeKey);
-      addResourceHintEntryV0(entries, sourceBytes, hintType, normalized, startByte, endByte);
+      addResourceHintEntryV0(entries, sourceBytes, caseId, hintType, normalized, startByte, endByte);
     }
   };
 
@@ -1265,6 +1283,34 @@ function extractResourceHintEntriesFromSourceV0(sourceBytes) {
   }
 
   return entries;
+}
+
+function validateResourceHintEntriesV0(entries, fixtureBytes, caseId) {
+  if (!Array.isArray(entries)) {
+    throw new Error(`resource_hints_v0 entries must be array for case ${caseId}`);
+  }
+  for (const [index, entry] of entries.entries()) {
+    if (entry?.kind !== 'resource_hint') {
+      throw new Error(`resource_hints_v0 entry[${index}] invalid kind for case ${caseId}`);
+    }
+    if (entry?.case_id !== caseId) {
+      throw new Error(`resource_hints_v0 entry[${index}] missing/invalid case_id for case ${caseId}`);
+    }
+    const hintType = typeof entry?.hint_type === 'string' ? entry.hint_type : '';
+    if (!RESOURCE_HINT_TYPE_ALLOWLIST_V0.has(hintType)) {
+      throw new Error(`resource_hints_v0 entry[${index}] unknown hint_type '${hintType}' for case ${caseId}`);
+    }
+    if (typeof entry?.value !== 'string' || entry.value.trim() === '') {
+      throw new Error(`resource_hints_v0 entry[${index}] missing value for case ${caseId}`);
+    }
+    const sourceSpan = entry?.source_span;
+    if (!sourceSpan || !Number.isInteger(sourceSpan.start_byte) || !Number.isInteger(sourceSpan.end_byte)) {
+      throw new Error(`resource_hints_v0 entry[${index}] missing source_span for case ${caseId}`);
+    }
+    if (sourceSpan.start_byte < 0 || sourceSpan.end_byte <= sourceSpan.start_byte || sourceSpan.end_byte > fixtureBytes.length) {
+      throw new Error(`resource_hints_v0 entry[${index}] source_span out of bounds for case ${caseId}`);
+    }
+  }
 }
 
 function extractBibEntriesFromSourceV0(sourceBytes) {
@@ -1562,10 +1608,14 @@ async function emitGraphicsTypedArtifactV0(caseOutDir, fixtureBytes) {
 }
 
 async function emitResourceHintsArtifactV0(caseOutDir, fixtureBytes, mode) {
+  const caseId = path.basename(caseOutDir);
+  const entries = mode === 'typeset' ? extractResourceHintEntriesFromSourceV0(fixtureBytes, caseId) : [];
+  validateResourceHintEntriesV0(entries, fixtureBytes, caseId);
   const payload = {
-    version: 1,
+    version: RESOURCE_HINTS_V0_VERSION,
+    resource_hints_v0_version: RESOURCE_HINTS_V0_VERSION,
     schema: 'resource_hints_v0',
-    entries: mode === 'typeset' ? extractResourceHintEntriesFromSourceV0(fixtureBytes) : [],
+    entries,
   };
   const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
   const relpath = 'resource_hints_v0.json';
@@ -1581,7 +1631,8 @@ async function emitResourceHintsArtifactV0(caseOutDir, fixtureBytes, mode) {
 
 async function emitEmptyResourceHintsArtifactV0(caseOutDir) {
   const payload = {
-    version: 1,
+    version: RESOURCE_HINTS_V0_VERSION,
+    resource_hints_v0_version: RESOURCE_HINTS_V0_VERSION,
     schema: 'resource_hints_v0',
     entries: [],
   };
@@ -1642,25 +1693,38 @@ async function buildResourceHintsRollupV0(outDir, summaries) {
 
     const bytes = await readFile(path.join(outDir, caseId, relpath));
     const payload = JSON.parse(bytes.toString('utf8'));
-    if (payload?.version !== 1 || payload?.schema !== 'resource_hints_v0' || !Array.isArray(payload?.entries)) {
+    if (
+      payload?.version !== RESOURCE_HINTS_V0_VERSION
+      || payload?.resource_hints_v0_version !== RESOURCE_HINTS_V0_VERSION
+      || payload?.schema !== 'resource_hints_v0'
+      || !Array.isArray(payload?.entries)
+    ) {
       throw new Error(`invalid resource_hints_v0 artifact for case ${caseId}`);
     }
+    const fixtureBytes = await readFile(path.join(outDir, caseId, 'main.tex'));
+    validateResourceHintEntriesV0(payload.entries, fixtureBytes, caseId);
 
     for (const entry of payload.entries) {
       const hintType = typeof entry?.hint_type === 'string' ? entry.hint_type : '';
       const value = typeof entry?.value === 'string' ? entry.value : '';
+      const sourceSpan = entry?.source_span;
       if (!hintType || !value) {
         continue;
       }
-      const dedupeKey = `${caseId}\x1f${hintType}\x1f${value}`;
+      const dedupeKey = `${caseId}\x1f${hintType}\x1f${value}\x1f${sourceSpan.start_byte}\x1f${sourceSpan.end_byte}`;
       if (seen.has(dedupeKey)) {
         continue;
       }
       seen.add(dedupeKey);
       entries.push({
+        kind: 'resource_hint',
         case_id: caseId,
         hint_type: hintType,
         value,
+        source_span: {
+          start_byte: sourceSpan.start_byte,
+          end_byte: sourceSpan.end_byte,
+        },
       });
     }
   }
@@ -1678,7 +1742,8 @@ async function buildResourceHintsRollupV0(outDir, summaries) {
   });
 
   return {
-    version: 1,
+    version: RESOURCE_HINTS_V0_VERSION,
+    resource_hints_v0_version: RESOURCE_HINTS_V0_VERSION,
     entries,
   };
 }

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -98,6 +98,12 @@
       "purpose": "Probes input/include resource-hint seam for deterministic on-demand request generation."
     },
     {
+      "id": "typeset_demo_resource_hints_invalid_probe_v0",
+      "tags": ["typeset", "resource-hints", "invalid", "unsafe-path", "probe"],
+      "expected_status": "INVALID",
+      "purpose": "Synthetic negative probe: rejects unsafe hint value ../evil under schema-gated resource_hints_v0 validation."
+    },
+    {
       "id": "typeset_demo_input_probe_v0",
       "tags": ["typeset", "input", "probe", "ni"],
       "expected_status": "NI",


### PR DESCRIPTION
## Summary\n- add resource_hints_v0 schema hardening with explicit resource_hints_v0_version\n- validate required resource hint fields, hint_type allowlist, and source_span bounds\n- add synthetic invalid resource-hints probe fixture and proof assertions\n\n## Proof\n- ./scripts/proof_wasm_fixture_gallery_v0.sh