### PR TITLE
typeset minimal: cap justification stretch around styled runs

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -284,15 +284,13 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
             } else {
                 MARGIN_PT_V0
             };
-            let mut segment_x = line_x;
+            out.extend_from_slice(b"1 0 0 1 ");
+            out.extend_from_slice(format!("{:.2} {:.2} Tm ", line_x, y).as_bytes());
             for segment in segments {
                 if segment.bytes.is_empty() {
-                    segment_x += segment.advance_pt;
                     continue;
                 }
                 let escaped = escape_pdf_string_bytes(&segment.bytes);
-                out.extend_from_slice(b"1 0 0 1 ");
-                out.extend_from_slice(format!("{:.2} {:.2} Tm ", segment_x, y).as_bytes());
                 out.extend_from_slice(b"/");
                 out.extend_from_slice(style_font_alias_v0(segment.style));
                 out.extend_from_slice(b" ");
@@ -300,7 +298,6 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
                 out.extend_from_slice(b" Tf (");
                 out.extend_from_slice(&escaped);
                 out.extend_from_slice(b") Tj ");
-                segment_x += segment.advance_pt;
             }
             out.extend_from_slice(b"\n");
             if !in_title_block && skip_indent_after_title_block {

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -223,6 +223,57 @@ fn pdf_renderer_keeps_multi_space_line_unwrapped_under_width_limit_v0() {
     assert!(pdf.windows(b"(A     B) Tj".len()).any(|w| w == b"(A     B) Tj"));
 }
 
+fn max_tm_gap_pt_for_line_containing_v0(pdf: &[u8], needle: &str) -> Option<f32> {
+    let text = String::from_utf8_lossy(pdf);
+    for line in text.lines() {
+        if !line.contains(needle) {
+            continue;
+        }
+        let mut xs = Vec::<f32>::new();
+        let fields = line.split_whitespace().collect::<Vec<_>>();
+        let mut index = 0usize;
+        while index + 6 < fields.len() {
+            if fields[index] == "1"
+                && fields[index + 1] == "0"
+                && fields[index + 2] == "0"
+                && fields[index + 3] == "1"
+                && fields[index + 6] == "Tm"
+            {
+                let x_pt = fields[index + 4].parse::<f32>().ok()?;
+                xs.push(x_pt);
+                index += 7;
+                continue;
+            }
+            index += 1;
+        }
+        if xs.len() < 2 {
+            return Some(0.0);
+        }
+        let mut max_gap = 0.0f32;
+        for pair in xs.windows(2) {
+            let gap = pair[1] - pair[0];
+            if gap > max_gap {
+                max_gap = gap;
+            }
+        }
+        return Some(max_gap);
+    }
+    None
+}
+
+#[test]
+fn pdf_renderer_caps_segment_tm_gap_for_styled_line_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"Styled [emphasis] and {bold} run.")
+        .expect("writer should accept styled text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let max_tm_gap = max_tm_gap_pt_for_line_containing_v0(&pdf, "Styled")
+        .expect("pdf should include styled line");
+    assert!(
+        max_tm_gap <= 24.0,
+        "styled line tm gap should be capped, got {max_tm_gap}"
+    );
+}
+
 #[test]
 fn pdf_renderer_applies_hanging_indent_for_list_continuation_v0() {
     let xdv = write_dvi_v2_text_page_v0(b"- item\ncontinuation").expect("writer should accept text");

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -15,6 +15,7 @@
 
 \section{Overview}
 Hello, world. This first paragraph includes \emph{emphasis} and \textbf{bold} in supported inline forms.
+This gap-stress sentence keeps a styled run in the middle: alpha beta gamma \emph{delta epsilon} zeta eta theta and \textbf{iota kappa} lambda.
 
 \subsection{Demonstration}
 This second paragraph is intentionally plain text and separated by a blank line so paragraph flow,\linebreak

--- a/scripts/wasm_typeset_minimal_v0_emit_pdf.mjs
+++ b/scripts/wasm_typeset_minimal_v0_emit_pdf.mjs
@@ -10,6 +10,39 @@ import { createAssertHelpers } from './wasm_smoke_js/assert.mjs';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, '..');
+const MAX_SEGMENT_TM_GAP_PT_V0 = 24.0;
+
+function maxTmGapPtV0(pdfBytes) {
+  const text = Buffer.from(pdfBytes).toString('utf8');
+  let maxGapPt = 0;
+  for (const line of text.split('\n')) {
+    const fields = line.trim().split(/\s+/).filter((field) => field.length > 0);
+    const xs = [];
+    for (let index = 0; index + 6 < fields.length; index += 1) {
+      if (
+        fields[index] === '1' &&
+        fields[index + 1] === '0' &&
+        fields[index + 2] === '0' &&
+        fields[index + 3] === '1' &&
+        fields[index + 6] === 'Tm'
+      ) {
+        const parsedX = Number.parseFloat(fields[index + 4]);
+        if (!Number.isFinite(parsedX)) {
+          throw new Error(`invalid Tm x field: ${fields[index + 4]}`);
+        }
+        xs.push(parsedX);
+      }
+    }
+    if (xs.length < 2) continue;
+    for (let index = 1; index < xs.length; index += 1) {
+      const gapPt = xs[index] - xs[index - 1];
+      if (gapPt > maxGapPt) {
+        maxGapPt = gapPt;
+      }
+    }
+  }
+  return maxGapPt;
+}
 
 async function run() {
   const outDir = path.resolve(process.argv[2] ?? path.join(rootDir, 'out'));
@@ -80,6 +113,14 @@ async function run() {
     xdv_sha256: createHash('sha256').update(xdvBytes).digest('hex'),
     pdf_sha256: createHash('sha256').update(pdfBytes).digest('hex'),
   };
+  const maxTmGapPt = maxTmGapPtV0(pdfBytes);
+  if (maxTmGapPt > MAX_SEGMENT_TM_GAP_PT_V0) {
+    throw new Error(
+      `segment Tm gap too large: ${maxTmGapPt.toFixed(2)}pt > ${MAX_SEGMENT_TM_GAP_PT_V0.toFixed(2)}pt`,
+    );
+  }
+  summary.max_segment_tm_gap_pt = Number(maxTmGapPt.toFixed(2));
+  summary.max_segment_tm_gap_threshold_pt = MAX_SEGMENT_TM_GAP_PT_V0;
   await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
 
   console.log(`PASS: wasm typeset minimal emitted ${xdvPath}`);
@@ -87,6 +128,9 @@ async function run() {
   console.log(`PASS: deterministic summary ${summaryPath}`);
   console.log(`PASS: xdv_sha256 ${summary.xdv_sha256}`);
   console.log(`PASS: pdf_sha256 ${summary.pdf_sha256}`);
+  console.log(
+    `PASS: max_segment_tm_gap_pt ${summary.max_segment_tm_gap_pt.toFixed(2)} <= ${MAX_SEGMENT_TM_GAP_PT_V0.toFixed(2)}`,
+  );
 }
 
 run().catch((error) => {


### PR DESCRIPTION
## Summary\n- remove per-segment absolute Tm repositioning in PDF renderer and keep a single per-line text matrix\n- add deterministic max segment Tm-gap assertion in xdv tests and wasm emit script\n- extend minimal fixture with a styled gap-stress line\n\n## Proof\n- ./scripts/proof_wasm_typeset_minimal_v0.sh\n- ./scripts/proof_wasm_fixture_gallery_v0.sh