### PR TITLE
typeset minimal: no indent for first paragraph after heading

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -19,6 +19,7 @@ const CENTER_ENV_V0: &[u8] = b"center";
 const CENTERLINE_CONTROL_V0: &[u8] = b"centerline";
 const FLUSHRIGHT_ENV_V0: &[u8] = b"flushright";
 const RIGHTLINE_CONTROL_V0: &[u8] = b"rightline";
+const NOINDENT_PREFIX_MARKER_V0: &[u8] = b"~ ";
 const ITALIC_START_MARKER_V0: u8 = b'[';
 const ITALIC_END_MARKER_V0: u8 = b']';
 const BOLD_START_MARKER_V0: u8 = b'{';
@@ -1011,6 +1012,7 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
     }
 
     let mut body = Vec::<u8>::new();
+    let mut pending_noindent_after_heading = false;
     loop {
         match tokens.get(index) {
             Some(TokenV0::Space) => {
@@ -1019,6 +1021,7 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"maketitle" => {
                 emit_maketitle_block_v0(&mut body, &meta);
+                pending_noindent_after_heading = false;
                 index += 1;
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == END_CONTROL_V0 => {
@@ -1026,6 +1029,7 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
                 break;
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == BEGIN_CONTROL_V0 => {
+                pending_noindent_after_heading = false;
                 index = consume_body_environment_v0(tokens, index, &mut body)?;
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == CARRELPAR_MARKER_CONTROL_V0 => {
@@ -1033,15 +1037,28 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
                 index += 1;
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == CENTERLINE_CONTROL_V0 => {
+                pending_noindent_after_heading = false;
                 index = consume_centerline_command_v0(tokens, index, &mut body)?;
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == RIGHTLINE_CONTROL_V0 => {
+                pending_noindent_after_heading = false;
                 index = consume_rightline_command_v0(tokens, index, &mut body)?;
             }
             Some(TokenV0::ControlSeq(name)) if is_heading_control_v0(name.as_slice()) => {
                 index = consume_heading_command_v0(tokens, index, &mut body)?;
+                pending_noindent_after_heading = true;
             }
             Some(_) => {
+                if pending_noindent_after_heading
+                    && (body.is_empty()
+                        || matches!(
+                            body.last().copied(),
+                            Some(NEWLINE_MARKER_V0 | PAGE_BREAK_MARKER_V0)
+                        ))
+                {
+                    body.extend_from_slice(NOINDENT_PREFIX_MARKER_V0);
+                    pending_noindent_after_heading = false;
+                }
                 index = consume_fragment_token_v0(tokens, index, &mut body, false, true)?;
             }
             None => return None,

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -96,7 +96,7 @@ fn typeset_minimal_headings_emit_bold_with_paragraph_breaks() {
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
     assert!(
-        text.contains("Before.\n\n{Intro}\n\n{A [B]}\n\nAfter."),
+        text.contains("Before.\n\n{Intro}\n\n{A [B]}\n\n~ After."),
         "body={text:?}"
     );
 }
@@ -107,7 +107,18 @@ fn typeset_minimal_heading_at_start_has_no_leading_blank_lines() {
         b"\\documentclass{article}\\begin{document}\\paragraph{Lead in}Body text.\\end{document}";
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
-    assert!(text.starts_with("{Lead in}\n\nBody text."), "body={text:?}");
+    assert!(text.starts_with("{Lead in}\n\n~ Body text."), "body={text:?}");
+}
+
+#[test]
+fn typeset_minimal_first_paragraph_after_heading_uses_noindent_marker() {
+    let main = b"\\documentclass{article}\n\\begin{document}\n\\section{Intro}First paragraph.\\par Second paragraph.\n\\end{document}\n";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("{Intro}\n\n~ First paragraph.\n\nSecond paragraph."),
+        "body={text:?}"
+    );
 }
 
 #[test]

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -11,6 +11,7 @@ const TITLE_FONT_SIZE_PT_V0: f32 = 18.0;
 const INDENT_PT_V0: f32 = FONT_SIZE_PT_V0 * 2.0;
 const LEADING_PT_V0: f32 = 14.0;
 const TITLE_EXTRA_GAP_PT_V0: f32 = LEADING_PT_V0;
+const NOINDENT_PREFIX_MARKER_V0: u8 = b'~';
 const ITALIC_START_MARKER_V0: u8 = b'[';
 const ITALIC_END_MARKER_V0: u8 = b']';
 const BOLD_START_MARKER_V0: u8 = b'{';
@@ -205,6 +206,10 @@ fn has_right_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
     glyphs.len() >= 2 && glyphs[0].byte == b'|' && glyphs[1].byte == b' '
 }
 
+fn has_noindent_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() >= 2 && glyphs[0].byte == NOINDENT_PREFIX_MARKER_V0 && glyphs[1].byte == b' '
+}
+
 fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
     let mut out = Vec::new();
     out.extend_from_slice(b"BT\n");
@@ -232,11 +237,18 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
             && quote_prefix_advance_pt.is_none()
             && !center_prefixed
             && has_right_prefix_v0(&line.glyphs);
+        let noindent_prefixed = line_index >= title_block_len
+            && quote_prefix_advance_pt.is_none()
+            && !center_prefixed
+            && !right_prefixed
+            && has_noindent_prefix_v0(&line.glyphs);
         let render_glyphs: &[GlyphPlanV0] = if quote_prefix_advance_pt.is_some() {
             &line.glyphs[2..]
         } else if center_prefixed {
             &line.glyphs[2..]
         } else if right_prefixed {
+            &line.glyphs[2..]
+        } else if noindent_prefixed {
             &line.glyphs[2..]
         } else {
             &line.glyphs
@@ -273,6 +285,10 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
                 MARGIN_PT_V0 + active_quote_indent_pt
             } else if let Some(prefix_advance_pt) = list_prefix_advance_pt {
                 active_hang_indent_pt = prefix_advance_pt;
+                active_quote_indent_pt = 0.0;
+                MARGIN_PT_V0
+            } else if noindent_prefixed {
+                active_hang_indent_pt = 0.0;
                 active_quote_indent_pt = 0.0;
                 MARGIN_PT_V0
             } else if active_quote_indent_pt > 0.0 {

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -396,15 +396,19 @@ fn pdf_renderer_paragraph_indent_and_line_gap_invariants_v0() {
 #[test]
 fn pdf_renderer_section_heading_spacing_invariants_v0() {
     let demo_text =
-        b"Title\nAuthor\n2026-03-05\n\nIntro paragraph.\n\n{Section Heading}\n\nBody after heading.";
+        b"Title\nAuthor\n2026-03-05\n\nIntro paragraph.\n\n{Section Heading}\n\n~ Body after heading.";
     let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept heading text");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
 
-    let (_, intro_y) =
+    let (intro_x, intro_y) =
         tm_position_for_line_containing_text_v0(&pdf, "(Intro paragraph.)").expect("intro position");
     let (_, heading_y) = tm_position_for_line_containing_text_v0(&pdf, "(Section Heading)")
         .expect("heading position");
-    let (_, body_y) = tm_position_for_line_containing_text_v0(&pdf, "(Body after heading.)")
+    assert!(
+        !pdf.windows(b"(~ Body after heading.) Tj".len())
+            .any(|w| w == b"(~ Body after heading.) Tj")
+    );
+    let (body_x, body_y) = tm_position_for_line_containing_text_v0(&pdf, "(Body after heading.)")
         .expect("body position");
 
     assert!(
@@ -414,6 +418,11 @@ fn pdf_renderer_section_heading_spacing_invariants_v0() {
     assert!(
         (heading_y - body_y - 28.0).abs() <= 0.02,
         "heading->body y-gap mismatch: heading_y={heading_y}, body_y={body_y}"
+    );
+    assert!((intro_x - 72.0).abs() <= 0.02, "intro x mismatch: {intro_x}");
+    assert!(
+        (body_x - 72.0).abs() <= 0.02,
+        "first paragraph after heading should not indent: {body_x}"
     );
 }
 


### PR DESCRIPTION
## Summary\n- mark first paragraph after headings as no-indent in typeset-minimal extraction\n- hide no-indent internal prefix during PDF rendering\n- tighten spacing/indent invariants in engine+xdv tests\n\n## Proof\n- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests\n- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml pdf_renderer_section_heading_spacing_invariants_v0\n- ./scripts/proof_wasm_typeset_minimal_v0.sh\n- ./scripts/proof_wasm_fixture_gallery_v0.sh