### PR TITLE
typeset minimal: tighten list indentation and numbering alignment

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -133,6 +133,15 @@ fn typeset_minimal_lists_emit_expected_itemize_and_enumerate_lines() {
 }
 
 #[test]
+fn typeset_minimal_enumerate_emits_double_digit_items() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{enumerate}\\item One\\item Two\\item Three\\item Four\\item Five\\item Six\\item Seven\\item Eight\\item Nine\\item Ten\\end{enumerate}\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("9. Nine"), "body={text:?}");
+    assert!(text.contains("10. Ten"), "body={text:?}");
+}
+
+#[test]
 fn typeset_minimal_rejects_nested_lists() {
     let main = b"\\documentclass{article}\\begin{document}\\begin{itemize}\\item Outer\\begin{enumerate}\\item Inner\\end{enumerate}\\end{itemize}\\end{document}";
     let result = compile_typeset(main);

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -9,6 +9,8 @@ const MARGIN_PT_V0: f32 = 72.0;
 const FONT_SIZE_PT_V0: f32 = 12.0;
 const TITLE_FONT_SIZE_PT_V0: f32 = 18.0;
 const INDENT_PT_V0: f32 = FONT_SIZE_PT_V0 * 2.0;
+const LIST_BODY_INDENT_PT_V0: f32 = INDENT_PT_V0;
+const ENUM_NUMBER_COLUMN_RIGHT_PT_V0: f32 = MARGIN_PT_V0 + (FONT_SIZE_PT_V0 * 1.5);
 const LEADING_PT_V0: f32 = 14.0;
 const TITLE_EXTRA_GAP_PT_V0: f32 = LEADING_PT_V0;
 const NOINDENT_PREFIX_MARKER_V0: u8 = b'~';
@@ -165,12 +167,26 @@ fn centered_line_x_v0(line_width_pt: f32) -> f32 {
     centered.clamp(MARGIN_PT_V0, PAGE_WIDTH_PT_V0 - MARGIN_PT_V0)
 }
 
-fn detect_list_prefix_advance_pt_v0(glyphs: &[GlyphPlanV0]) -> Option<f32> {
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ListPrefixKindV0 {
+    Itemize,
+    Enumerate,
+}
+
+#[derive(Clone, Copy)]
+struct ListPrefixV0 {
+    kind: ListPrefixKindV0,
+    prefix_len: usize,
+    display_prefix_len: usize,
+}
+
+fn detect_list_prefix_v0(glyphs: &[GlyphPlanV0]) -> Option<ListPrefixV0> {
     if glyphs.len() >= 2 && glyphs[0].byte == b'-' && glyphs[1].byte == b' ' {
-        let prefix_sp = glyphs[0]
-            .advance_sp
-            .checked_add(glyphs[1].advance_sp)?;
-        return Some((prefix_sp as f32) / 65_536.0);
+        return Some(ListPrefixV0 {
+            kind: ListPrefixKindV0::Itemize,
+            prefix_len: 2,
+            display_prefix_len: 1,
+        });
     }
 
     let mut index = 0usize;
@@ -183,11 +199,11 @@ fn detect_list_prefix_advance_pt_v0(glyphs: &[GlyphPlanV0]) -> Option<f32> {
     if glyphs[index].byte != b'.' || glyphs[index + 1].byte != b' ' {
         return None;
     }
-    let mut prefix_sp = 0i32;
-    for glyph in &glyphs[..=index + 1] {
-        prefix_sp = prefix_sp.checked_add(glyph.advance_sp)?;
-    }
-    Some((prefix_sp as f32) / 65_536.0)
+    Some(ListPrefixV0 {
+        kind: ListPrefixKindV0::Enumerate,
+        prefix_len: index + 2,
+        display_prefix_len: index + 1,
+    })
 }
 
 fn detect_quote_prefix_advance_pt_v0(glyphs: &[GlyphPlanV0]) -> Option<f32> {
@@ -208,6 +224,40 @@ fn has_right_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
 
 fn has_noindent_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
     glyphs.len() >= 2 && glyphs[0].byte == NOINDENT_PREFIX_MARKER_V0 && glyphs[1].byte == b' '
+}
+
+fn glyphs_advance_pt_v0(glyphs: &[GlyphPlanV0]) -> f32 {
+    glyphs
+        .iter()
+        .map(|glyph| (glyph.advance_sp as f32) / 65_536.0)
+        .sum()
+}
+
+fn emit_styled_segments_v0(
+    out: &mut Vec<u8>,
+    segments: &[PdfStyledSegmentV0],
+    x_pt: f32,
+    y_pt: f32,
+    font_size_pt: f32,
+) {
+    if segments.is_empty() {
+        return;
+    }
+    out.extend_from_slice(b"1 0 0 1 ");
+    out.extend_from_slice(format!("{:.2} {:.2} Tm ", x_pt, y_pt).as_bytes());
+    for segment in segments {
+        if segment.bytes.is_empty() {
+            continue;
+        }
+        let escaped = escape_pdf_string_bytes(&segment.bytes);
+        out.extend_from_slice(b"/");
+        out.extend_from_slice(style_font_alias_v0(segment.style));
+        out.extend_from_slice(b" ");
+        out.extend_from_slice(format!("{font_size_pt}").as_bytes());
+        out.extend_from_slice(b" Tf (");
+        out.extend_from_slice(&escaped);
+        out.extend_from_slice(b") Tj ");
+    }
 }
 
 fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
@@ -242,7 +292,7 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
             && !center_prefixed
             && !right_prefixed
             && has_noindent_prefix_v0(&line.glyphs);
-        let render_glyphs: &[GlyphPlanV0] = if quote_prefix_advance_pt.is_some() {
+        let render_glyphs_base: &[GlyphPlanV0] = if quote_prefix_advance_pt.is_some() {
             &line.glyphs[2..]
         } else if center_prefixed {
             &line.glyphs[2..]
@@ -252,6 +302,23 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
             &line.glyphs[2..]
         } else {
             &line.glyphs
+        };
+        let list_prefix = if line_index >= title_block_len
+            && quote_prefix_advance_pt.is_none()
+            && !center_prefixed
+            && !right_prefixed
+            && !noindent_prefixed
+        {
+            detect_list_prefix_v0(render_glyphs_base)
+        } else {
+            None
+        };
+        let render_glyphs: &[GlyphPlanV0] = if quote_prefix_advance_pt.is_some() {
+            render_glyphs_base
+        } else if let Some(prefix) = list_prefix {
+            &render_glyphs_base[prefix.prefix_len..]
+        } else {
+            render_glyphs_base
         };
 
         let segments = parse_styled_segments_v0(render_glyphs)?;
@@ -264,11 +331,6 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
         };
         if !line_is_empty {
             let line_width_pt: f32 = segments.iter().map(|segment| segment.advance_pt).sum();
-            let list_prefix_advance_pt = if in_title_block {
-                None
-            } else {
-                detect_list_prefix_advance_pt_v0(render_glyphs)
-            };
             let line_x = if in_title_block {
                 centered_line_x_v0(line_width_pt)
             } else if center_prefixed {
@@ -283,10 +345,10 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
                 active_quote_indent_pt = (FONT_SIZE_PT_V0 * 2.0).max(prefix_advance_pt);
                 active_hang_indent_pt = 0.0;
                 MARGIN_PT_V0 + active_quote_indent_pt
-            } else if let Some(prefix_advance_pt) = list_prefix_advance_pt {
-                active_hang_indent_pt = prefix_advance_pt;
+            } else if list_prefix.is_some() {
+                active_hang_indent_pt = LIST_BODY_INDENT_PT_V0;
                 active_quote_indent_pt = 0.0;
-                MARGIN_PT_V0
+                MARGIN_PT_V0 + LIST_BODY_INDENT_PT_V0
             } else if noindent_prefixed {
                 active_hang_indent_pt = 0.0;
                 active_quote_indent_pt = 0.0;
@@ -300,21 +362,17 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
             } else {
                 MARGIN_PT_V0
             };
-            out.extend_from_slice(b"1 0 0 1 ");
-            out.extend_from_slice(format!("{:.2} {:.2} Tm ", line_x, y).as_bytes());
-            for segment in segments {
-                if segment.bytes.is_empty() {
-                    continue;
-                }
-                let escaped = escape_pdf_string_bytes(&segment.bytes);
-                out.extend_from_slice(b"/");
-                out.extend_from_slice(style_font_alias_v0(segment.style));
-                out.extend_from_slice(b" ");
-                out.extend_from_slice(format!("{font_size_pt}").as_bytes());
-                out.extend_from_slice(b" Tf (");
-                out.extend_from_slice(&escaped);
-                out.extend_from_slice(b") Tj ");
+            if let Some(prefix) = list_prefix {
+                let display_prefix_glyphs = &render_glyphs_base[..prefix.display_prefix_len];
+                let display_prefix_segments = parse_styled_segments_v0(display_prefix_glyphs)?;
+                let prefix_width_pt = glyphs_advance_pt_v0(display_prefix_glyphs);
+                let prefix_x = match prefix.kind {
+                    ListPrefixKindV0::Itemize => MARGIN_PT_V0,
+                    ListPrefixKindV0::Enumerate => ENUM_NUMBER_COLUMN_RIGHT_PT_V0 - prefix_width_pt,
+                };
+                emit_styled_segments_v0(&mut out, &display_prefix_segments, prefix_x, y, font_size_pt);
             }
+            emit_styled_segments_v0(&mut out, &segments, line_x, y, font_size_pt);
             out.extend_from_slice(b"\n");
             if !in_title_block && skip_indent_after_title_block {
                 skip_indent_after_title_block = false;

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -296,6 +296,57 @@ fn tm_position_for_line_containing_text_v0(pdf: &[u8], needle: &str) -> Option<(
     None
 }
 
+fn tm_xs_for_segment_text_v0(pdf: &[u8], segment_text: &str) -> Vec<f32> {
+    let target_token = format!("({segment_text})");
+    let text = String::from_utf8_lossy(pdf);
+    let mut xs = Vec::<f32>::new();
+    for line in text.lines() {
+        if !line.contains(&target_token) || !line.contains(" Tm ") {
+            continue;
+        }
+        let fields = line.split_whitespace().collect::<Vec<_>>();
+        let mut index = 0usize;
+        while index + 6 < fields.len() {
+            let is_tm = fields[index] == "1"
+                && fields[index + 1] == "0"
+                && fields[index + 2] == "0"
+                && fields[index + 3] == "1"
+                && fields[index + 6] == "Tm";
+            if !is_tm {
+                index += 1;
+                continue;
+            }
+            let Some(x_pt) = fields[index + 4].parse::<f32>().ok() else {
+                index += 7;
+                continue;
+            };
+            let mut cursor = index + 7;
+            let mut matched = false;
+            while cursor < fields.len() {
+                if fields[cursor] == "1"
+                    && cursor + 6 < fields.len()
+                    && fields[cursor + 1] == "0"
+                    && fields[cursor + 2] == "0"
+                    && fields[cursor + 3] == "1"
+                    && fields[cursor + 6] == "Tm"
+                {
+                    break;
+                }
+                if fields[cursor] == target_token {
+                    matched = true;
+                    break;
+                }
+                cursor += 1;
+            }
+            if matched {
+                xs.push(x_pt);
+            }
+            index += 7;
+        }
+    }
+    xs
+}
+
 fn expected_center_x_pt_v0(width_sp: u32) -> f32 {
     let width_pt = (width_sp as f32) / 65_536.0;
     ((612.0 - width_pt) * 0.5).clamp(72.0, 612.0 - 72.0)
@@ -448,6 +499,81 @@ fn pdf_renderer_applies_hanging_indent_for_list_continuation_v0() {
     assert!(xs.len() >= 2, "expected at least two text lines, got {xs:?}");
     assert!((xs[0] - 72.0).abs() <= 0.02, "first list line x={}", xs[0]);
     assert!(xs[1] > xs[0], "continuation should hang-indent: {xs:?}");
+}
+
+#[test]
+fn pdf_renderer_itemize_bullet_and_body_x_offsets_invariants_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"- alpha\ncontinuation\n- beta\ncontinuationtwo")
+        .expect("writer should accept list text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    assert!(
+        !pdf.windows(b"(- alpha) Tj".len()).any(|w| w == b"(- alpha) Tj"),
+        "prefix should be split from body"
+    );
+
+    let bullet_xs = tm_xs_for_segment_text_v0(&pdf, "-");
+    let alpha_xs = tm_xs_for_segment_text_v0(&pdf, "alpha");
+    let beta_xs = tm_xs_for_segment_text_v0(&pdf, "beta");
+    let continuation_xs = tm_xs_for_segment_text_v0(&pdf, "continuation");
+    let continuation_two_xs = tm_xs_for_segment_text_v0(&pdf, "continuationtwo");
+
+    assert_eq!(bullet_xs.len(), 2, "expected two bullet renders: {bullet_xs:?}");
+    assert_eq!(alpha_xs.len(), 1, "expected alpha render");
+    assert_eq!(beta_xs.len(), 1, "expected beta render");
+    assert_eq!(continuation_xs.len(), 1, "expected continuation render");
+    assert_eq!(continuation_two_xs.len(), 1, "expected continuationtwo render");
+
+    let epsilon_pt = 0.02f32;
+    for x in &bullet_xs {
+        assert!((*x - 72.0).abs() <= epsilon_pt, "bullet x mismatch: {x}");
+    }
+    for x in [
+        alpha_xs[0],
+        beta_xs[0],
+        continuation_xs[0],
+        continuation_two_xs[0],
+    ] {
+        assert!((x - 96.0).abs() <= epsilon_pt, "item body x mismatch: {x}");
+    }
+}
+
+#[test]
+fn pdf_renderer_enumerate_number_column_alignment_invariants_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"9. nine\n10. ten")
+        .expect("writer should accept enumerate text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    assert!(
+        !pdf.windows(b"(9. nine) Tj".len()).any(|w| w == b"(9. nine) Tj"),
+        "prefix should be split from body"
+    );
+
+    let nine_number_x = tm_xs_for_segment_text_v0(&pdf, "9.");
+    let ten_number_x = tm_xs_for_segment_text_v0(&pdf, "10.");
+    let nine_body_x = tm_xs_for_segment_text_v0(&pdf, "nine");
+    let ten_body_x = tm_xs_for_segment_text_v0(&pdf, "ten");
+
+    assert_eq!(nine_number_x.len(), 1, "expected 9. number render");
+    assert_eq!(ten_number_x.len(), 1, "expected 10. number render");
+    assert_eq!(nine_body_x.len(), 1, "expected nine body render");
+    assert_eq!(ten_body_x.len(), 1, "expected ten body render");
+
+    let epsilon_pt = 0.02f32;
+    assert!(
+        nine_number_x[0] > ten_number_x[0],
+        "single-digit number should start further right: nine={:?}, ten={:?}",
+        nine_number_x,
+        ten_number_x
+    );
+    assert!(
+        (nine_body_x[0] - 96.0).abs() <= epsilon_pt,
+        "nine body x mismatch: {}",
+        nine_body_x[0]
+    );
+    assert!(
+        (ten_body_x[0] - 96.0).abs() <= epsilon_pt,
+        "ten body x mismatch: {}",
+        ten_body_x[0]
+    );
 }
 
 #[test]

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -30,6 +30,14 @@ first-line indentation, and width-sensitive wrapping are visible in the PDF prev
 \begin{enumerate}
 \item First numbered item.
 \item Second numbered item.
+\item Third numbered item.
+\item Fourth numbered item.
+\item Fifth numbered item.
+\item Sixth numbered item.
+\item Seventh numbered item.
+\item Eighth numbered item.
+\item Ninth numbered item.
+\item Tenth numbered item.
 \end{enumerate}
 
 \subsection{Quote}

--- a/scripts/wasm_typeset_minimal_v0_emit_pdf.mjs
+++ b/scripts/wasm_typeset_minimal_v0_emit_pdf.mjs
@@ -17,7 +17,7 @@ function maxTmGapPtV0(pdfBytes) {
   let maxGapPt = 0;
   for (const line of text.split('\n')) {
     const fields = line.trim().split(/\s+/).filter((field) => field.length > 0);
-    const xs = [];
+    const segments = [];
     for (let index = 0; index + 6 < fields.length; index += 1) {
       if (
         fields[index] === '1' &&
@@ -30,12 +30,35 @@ function maxTmGapPtV0(pdfBytes) {
         if (!Number.isFinite(parsedX)) {
           throw new Error(`invalid Tm x field: ${fields[index + 4]}`);
         }
-        xs.push(parsedX);
+        let textToken = '';
+        let cursor = index + 7;
+        while (cursor < fields.length) {
+          if (
+            fields[cursor] === '1' &&
+            cursor + 6 < fields.length &&
+            fields[cursor + 1] === '0' &&
+            fields[cursor + 2] === '0' &&
+            fields[cursor + 3] === '1' &&
+            fields[cursor + 6] === 'Tm'
+          ) {
+            break;
+          }
+          if (fields[cursor].startsWith('(') && fields[cursor].endsWith(')')) {
+            textToken = fields[cursor].slice(1, -1);
+          }
+          cursor += 1;
+        }
+        segments.push({ x: parsedX, text: textToken });
       }
     }
-    if (xs.length < 2) continue;
-    for (let index = 1; index < xs.length; index += 1) {
-      const gapPt = xs[index] - xs[index - 1];
+    if (segments.length < 2) continue;
+    for (let index = 1; index < segments.length; index += 1) {
+      const previous = segments[index - 1];
+      const current = segments[index];
+      if (previous.text === '-' || /^\d+\.$/.test(previous.text)) {
+        continue;
+      }
+      const gapPt = current.x - previous.x;
       if (gapPt > maxGapPt) {
         maxGapPt = gapPt;
       }


### PR DESCRIPTION
## Summary\n- align itemize bullet and body columns deterministically in PDF preview\n- right-align enumerate number column while keeping body text at a fixed indent\n- extend fixture to include 10+ enumerate items and add programmatic x-offset invariants\n\n## Proof\n- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests\n- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml pdf_renderer_itemize_bullet_and_body_x_offsets_invariants_v0\n- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml pdf_renderer_enumerate_number_column_alignment_invariants_v0\n- ./scripts/proof_wasm_typeset_minimal_v0.sh\n- ./scripts/proof_wasm_fixture_gallery_v0.sh