### PR TITLE
typeset minimal typography bundle v0

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -631,13 +631,44 @@ fn consume_heading_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8
     Some(next)
 }
 
-fn consume_list_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
-    let (env_name, mut cursor) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
-    let is_itemize = env_name.as_slice() == ITEMIZE_ENV_V0;
-    let is_enumerate = env_name.as_slice() == ENUMERATE_ENV_V0;
-    if !is_itemize && !is_enumerate {
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ListKindV0 {
+    Itemize,
+    Enumerate,
+}
+
+fn list_item_prefix_v0(kind: ListKindV0, depth: usize, enumerate_counter: usize) -> Vec<u8> {
+    let mut prefix = Vec::new();
+    for _ in 0..depth {
+        prefix.extend_from_slice(b"  ");
+    }
+    match kind {
+        ListKindV0::Itemize => prefix.extend_from_slice(b"- "),
+        ListKindV0::Enumerate => {
+            prefix.extend_from_slice(enumerate_counter.to_string().as_bytes());
+            prefix.extend_from_slice(b". ");
+        }
+    }
+    prefix
+}
+
+fn consume_list_environment_with_depth_v0(
+    tokens: &[TokenV0],
+    index: usize,
+    out: &mut Vec<u8>,
+    depth: usize,
+) -> Option<usize> {
+    if depth > 1 {
         return None;
     }
+    let (env_name, mut cursor) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
+    let kind = if env_name.as_slice() == ITEMIZE_ENV_V0 {
+        ListKindV0::Itemize
+    } else if env_name.as_slice() == ENUMERATE_ENV_V0 {
+        ListKindV0::Enumerate
+    } else {
+        return None;
+    };
 
     push_paragraph_break(out);
     let mut enumerate_counter = 1usize;
@@ -647,22 +678,24 @@ fn consume_list_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u
         match tokens.get(cursor)? {
             TokenV0::ControlSeq(name) if name.as_slice() == ITEM_CONTROL_V0 => {
                 push_newline(out);
-                if is_itemize {
-                    out.extend_from_slice(b"- ");
-                } else {
-                    out.extend_from_slice(enumerate_counter.to_string().as_bytes());
-                    out.extend_from_slice(b". ");
+                out.extend_from_slice(&list_item_prefix_v0(kind, depth, enumerate_counter));
+                if kind == ListKindV0::Enumerate {
                     enumerate_counter += 1;
                 }
                 cursor += 1;
 
                 loop {
                     match tokens.get(cursor) {
-                        Some(TokenV0::ControlSeq(name)) if name.as_slice() == ITEM_CONTROL_V0 => {
-                            break;
-                        }
+                        Some(TokenV0::ControlSeq(name)) if name.as_slice() == ITEM_CONTROL_V0 => break,
                         Some(TokenV0::ControlSeq(name)) if name.as_slice() == BEGIN_CONTROL_V0 => {
-                            return None;
+                            let (nested_env, _) =
+                                consume_env_name_command_v0(tokens, cursor, BEGIN_CONTROL_V0)?;
+                            if nested_env.as_slice() != ITEMIZE_ENV_V0
+                                && nested_env.as_slice() != ENUMERATE_ENV_V0
+                            {
+                                return None;
+                            }
+                            cursor = consume_list_environment_with_depth_v0(tokens, cursor, out, depth + 1)?;
                         }
                         Some(TokenV0::ControlSeq(name)) if name.as_slice() == END_CONTROL_V0 => {
                             let (end_env, next) =
@@ -693,6 +726,10 @@ fn consume_list_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u
             _ => return None,
         }
     }
+}
+
+fn consume_list_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+    consume_list_environment_with_depth_v0(tokens, index, out, 0)
 }
 
 fn prefix_quote_lines_v0(content: &[u8]) -> Vec<u8> {

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -155,8 +155,19 @@ fn typeset_minimal_inline_wrapper_boundaries_preserve_expected_spacing() {
 }
 
 #[test]
-fn typeset_minimal_rejects_nested_lists() {
-    let main = b"\\documentclass{article}\\begin{document}\\begin{itemize}\\item Outer\\begin{enumerate}\\item Inner\\end{enumerate}\\end{itemize}\\end{document}";
+fn typeset_minimal_accepts_single_level_nested_lists() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{itemize}\\item Outer item\\begin{enumerate}\\item Inner one\\item Inner two\\end{enumerate}\\item Outer tail\\end{itemize}\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("- Outer item\n\n  1. Inner one\n  2. Inner two\n\n- Outer tail"),
+        "body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_rejects_lists_nested_deeper_than_one_level() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{itemize}\\item Outer\\begin{enumerate}\\item Inner\\begin{itemize}\\item Too deep\\end{itemize}\\end{enumerate}\\end{itemize}\\end{document}";
     let result = compile_typeset(main);
     assert_eq!(result.status, CompileStatus::NotImplemented);
     assert!(result.main_xdv_bytes.is_empty());
@@ -169,6 +180,17 @@ fn typeset_minimal_quote_environment_prefixes_each_line() {
     let text = String::from_utf8(body).expect("body should be valid utf8");
     assert!(
         text.contains("Before.\n\n> Quoted one\n> Quoted two\n\n> New paragraph\n\nAfter."),
+        "body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_heading_list_quote_rhythm_markers_are_stable() {
+    let main = b"\\documentclass{article}\\begin{document}\\section{Heading}After heading.\\begin{itemize}\\item First item\\item Second item\\end{itemize}\\begin{quote}Quoted line one\\linebreak Quoted line two\\end{quote}After quote.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("{Heading}\n\n~ After heading.\n\n- First item\n- Second item\n\n> Quoted line one\n> Quoted line two\n\nAfter quote."),
         "body={text:?}"
     );
 }

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -177,23 +177,36 @@ enum ListPrefixKindV0 {
 struct ListPrefixV0 {
     kind: ListPrefixKindV0,
     prefix_len: usize,
-    display_prefix_len: usize,
+    display_start: usize,
+    display_len: usize,
+    leading_advance_pt: f32,
 }
 
 fn detect_list_prefix_v0(glyphs: &[GlyphPlanV0]) -> Option<ListPrefixV0> {
-    if glyphs.len() >= 2 && glyphs[0].byte == b'-' && glyphs[1].byte == b' ' {
+    let mut leading = 0usize;
+    while leading < glyphs.len() && glyphs[leading].byte == b' ' {
+        leading += 1;
+    }
+    let leading_advance_pt: f32 = glyphs[..leading]
+        .iter()
+        .map(|glyph| (glyph.advance_sp as f32) / 65_536.0)
+        .sum();
+
+    if glyphs.len() >= leading + 2 && glyphs[leading].byte == b'-' && glyphs[leading + 1].byte == b' ' {
         return Some(ListPrefixV0 {
             kind: ListPrefixKindV0::Itemize,
-            prefix_len: 2,
-            display_prefix_len: 1,
+            prefix_len: leading + 2,
+            display_start: leading,
+            display_len: 1,
+            leading_advance_pt,
         });
     }
 
-    let mut index = 0usize;
+    let mut index = leading;
     while index < glyphs.len() && glyphs[index].byte.is_ascii_digit() {
         index += 1;
     }
-    if index == 0 || index + 1 >= glyphs.len() {
+    if index == leading || index + 1 >= glyphs.len() {
         return None;
     }
     if glyphs[index].byte != b'.' || glyphs[index + 1].byte != b' ' {
@@ -202,7 +215,9 @@ fn detect_list_prefix_v0(glyphs: &[GlyphPlanV0]) -> Option<ListPrefixV0> {
     Some(ListPrefixV0 {
         kind: ListPrefixKindV0::Enumerate,
         prefix_len: index + 2,
-        display_prefix_len: index + 1,
+        display_start: leading,
+        display_len: index - leading + 1,
+        leading_advance_pt,
     })
 }
 
@@ -345,10 +360,10 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
                 active_quote_indent_pt = (FONT_SIZE_PT_V0 * 2.0).max(prefix_advance_pt);
                 active_hang_indent_pt = 0.0;
                 MARGIN_PT_V0 + active_quote_indent_pt
-            } else if list_prefix.is_some() {
-                active_hang_indent_pt = LIST_BODY_INDENT_PT_V0;
+            } else if let Some(prefix) = list_prefix {
+                active_hang_indent_pt = LIST_BODY_INDENT_PT_V0 + prefix.leading_advance_pt;
                 active_quote_indent_pt = 0.0;
-                MARGIN_PT_V0 + LIST_BODY_INDENT_PT_V0
+                MARGIN_PT_V0 + active_hang_indent_pt
             } else if noindent_prefixed {
                 active_hang_indent_pt = 0.0;
                 active_quote_indent_pt = 0.0;
@@ -363,12 +378,15 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
                 MARGIN_PT_V0
             };
             if let Some(prefix) = list_prefix {
-                let display_prefix_glyphs = &render_glyphs_base[..prefix.display_prefix_len];
+                let display_prefix_glyphs = &render_glyphs_base
+                    [prefix.display_start..prefix.display_start + prefix.display_len];
                 let display_prefix_segments = parse_styled_segments_v0(display_prefix_glyphs)?;
                 let prefix_width_pt = glyphs_advance_pt_v0(display_prefix_glyphs);
                 let prefix_x = match prefix.kind {
-                    ListPrefixKindV0::Itemize => MARGIN_PT_V0,
-                    ListPrefixKindV0::Enumerate => ENUM_NUMBER_COLUMN_RIGHT_PT_V0 - prefix_width_pt,
+                    ListPrefixKindV0::Itemize => MARGIN_PT_V0 + prefix.leading_advance_pt,
+                    ListPrefixKindV0::Enumerate => {
+                        ENUM_NUMBER_COLUMN_RIGHT_PT_V0 + prefix.leading_advance_pt - prefix_width_pt
+                    }
                 };
                 emit_styled_segments_v0(&mut out, &display_prefix_segments, prefix_x, y, font_size_pt);
             }

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -534,6 +534,63 @@ fn pdf_renderer_section_heading_spacing_invariants_v0() {
 }
 
 #[test]
+fn pdf_renderer_heading_list_quote_rhythm_invariants_v0() {
+    let demo_text = b"\nPrelude paragraph.\n\n{Heading}\n\n~ After heading paragraph.\n\n- First list item\n- Second list item\n\n> Quote line one\n> Quote line two\n\nAfter quote paragraph.";
+    let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept rhythm text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let (_, prelude_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Prelude paragraph.)").expect("prelude position");
+    let (_, heading_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Heading)").expect("heading position");
+    let (_, after_heading_y) = tm_position_for_line_containing_text_v0(&pdf, "(After heading paragraph.)")
+        .expect("after heading position");
+    let (_, list_one_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(First list item)").expect("list one");
+    let (_, list_two_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Second list item)").expect("list two");
+    let (quote_one_x, quote_one_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Quote line one)").expect("quote one");
+    let (quote_two_x, quote_two_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Quote line two)").expect("quote two");
+    let (_, after_quote_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(After quote paragraph.)")
+            .expect("after quote");
+
+    let epsilon_pt = 0.02f32;
+    assert!((prelude_y - heading_y - 28.0).abs() <= epsilon_pt);
+    assert!(
+        (heading_y - after_heading_y - 28.0).abs() <= epsilon_pt,
+        "heading->first paragraph gap mismatch: heading_y={heading_y}, after_heading_y={after_heading_y}"
+    );
+    assert!(
+        (after_heading_y - list_one_y - 28.0).abs() <= epsilon_pt,
+        "paragraph->list gap mismatch: after_heading_y={after_heading_y}, list_one_y={list_one_y}"
+    );
+    assert!(
+        (list_one_y - list_two_y - 14.0).abs() <= epsilon_pt,
+        "list line gap mismatch: list_one_y={list_one_y}, list_two_y={list_two_y}"
+    );
+    assert!(
+        (list_two_y - quote_one_y - 28.0).abs() <= epsilon_pt,
+        "list->quote gap mismatch: list_two_y={list_two_y}, quote_one_y={quote_one_y}"
+    );
+    assert!(
+        (quote_one_y - quote_two_y - 14.0).abs() <= epsilon_pt,
+        "quote line gap mismatch: quote_one_y={quote_one_y}, quote_two_y={quote_two_y}"
+    );
+    assert!(
+        (quote_two_y - after_quote_y - 28.0).abs() <= epsilon_pt,
+        "quote->paragraph gap mismatch: quote_two_y={quote_two_y}, after_quote_y={after_quote_y}"
+    );
+    assert!(quote_one_x > 72.0, "quote line should be indented");
+    assert!(
+        (quote_one_x - quote_two_x).abs() <= epsilon_pt,
+        "quote x drift mismatch"
+    );
+}
+
+#[test]
 fn pdf_renderer_applies_hanging_indent_for_list_continuation_v0() {
     let xdv = write_dvi_v2_text_page_v0(b"- item\ncontinuation").expect("writer should accept text");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
@@ -629,6 +686,106 @@ fn pdf_renderer_enumerate_number_column_alignment_invariants_v0() {
         (ten_body_x[0] - 96.0).abs() <= epsilon_pt,
         "ten body x mismatch: {}",
         ten_body_x[0]
+    );
+}
+
+#[test]
+fn pdf_renderer_enumerate_number_column_alignment_across_wraps_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"9. [NINESTART] item with enough repeated words to force wrapping and keep deterministic body indent for continuation lines before token [WRAPNINE]\n10. [TENSTART] item with enough repeated words to force wrapping and keep deterministic body indent for continuation lines before token [WRAPTEN]")
+        .expect("writer should accept long enumerate text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let nine_number_x = tm_xs_for_segment_text_v0(&pdf, "9.");
+    let ten_number_x = tm_xs_for_segment_text_v0(&pdf, "10.");
+    let nine_start_x = tm_xs_for_segment_text_v0(&pdf, "NINESTART");
+    let ten_start_x = tm_xs_for_segment_text_v0(&pdf, "TENSTART");
+    let nine_wrap_x = tm_xs_for_segment_text_v0(&pdf, "WRAPNINE");
+    let ten_wrap_x = tm_xs_for_segment_text_v0(&pdf, "WRAPTEN");
+
+    assert_eq!(nine_number_x.len(), 1, "expected 9. number render");
+    assert_eq!(ten_number_x.len(), 1, "expected 10. number render");
+    assert_eq!(nine_start_x.len(), 1, "expected NINESTART render");
+    assert_eq!(ten_start_x.len(), 1, "expected TENSTART render");
+    assert_eq!(nine_wrap_x.len(), 1, "expected WRAPNINE render");
+    assert_eq!(ten_wrap_x.len(), 1, "expected WRAPTEN render");
+
+    let epsilon_pt = 0.02f32;
+    assert!(
+        nine_number_x[0] > ten_number_x[0],
+        "single-digit number should start further right: nine={:?}, ten={:?}",
+        nine_number_x,
+        ten_number_x
+    );
+    assert!(
+        (nine_start_x[0] - 96.0).abs() <= epsilon_pt,
+        "start body x mismatch for 9.: {}",
+        nine_start_x[0]
+    );
+    assert!(
+        (ten_start_x[0] - 96.0).abs() <= epsilon_pt,
+        "start body x mismatch for 10.: {}",
+        ten_start_x[0]
+    );
+    assert!(
+        (nine_wrap_x[0] - nine_start_x[0]).abs() <= epsilon_pt,
+        "wrap body x mismatch for 9.: start={}, wrap={}",
+        nine_start_x[0],
+        nine_wrap_x[0]
+    );
+    assert!(
+        (ten_wrap_x[0] - ten_start_x[0]).abs() <= epsilon_pt,
+        "wrap body x mismatch for 10.: start={}, wrap={}",
+        ten_start_x[0],
+        ten_wrap_x[0]
+    );
+}
+
+#[test]
+fn pdf_renderer_nested_list_indentation_and_wrap_invariants_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"- [OUTERSTART] item with enough repeated words to force wrapping in the first list level before token [OUTERWRAPTOKEN]\n  - [NESTEDSTART] item with enough repeated words to force wrapping in the second list level before token [NESTEDWRAPTOKEN]")
+        .expect("writer should accept nested list text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let bullet_xs = tm_xs_for_segment_text_v0(&pdf, "-");
+    let outer_start_x = tm_xs_for_segment_text_v0(&pdf, "OUTERSTART");
+    let outer_wrap_x = tm_xs_for_segment_text_v0(&pdf, "OUTERWRAPTOKEN");
+    let nested_start_x = tm_xs_for_segment_text_v0(&pdf, "NESTEDSTART");
+    let nested_wrap_x = tm_xs_for_segment_text_v0(&pdf, "NESTEDWRAPTOKEN");
+
+    assert_eq!(bullet_xs.len(), 2, "expected two bullets: {bullet_xs:?}");
+    assert_eq!(outer_start_x.len(), 1, "expected outer start render");
+    assert_eq!(outer_wrap_x.len(), 1, "expected outer wrap render");
+    assert_eq!(nested_start_x.len(), 1, "expected nested start render");
+    assert_eq!(nested_wrap_x.len(), 1, "expected nested wrap render");
+
+    let epsilon_pt = 0.02f32;
+    assert!((bullet_xs[0] - 72.0).abs() <= epsilon_pt, "outer bullet x mismatch");
+    assert!(
+        bullet_xs[1] > bullet_xs[0],
+        "nested bullet should shift right: {bullet_xs:?}"
+    );
+    assert!(
+        (outer_start_x[0] - 96.0).abs() <= epsilon_pt,
+        "outer body x mismatch: {}",
+        outer_start_x[0]
+    );
+    assert!(
+        (outer_wrap_x[0] - outer_start_x[0]).abs() <= epsilon_pt,
+        "outer continuation x mismatch: outer={}, wrap={}",
+        outer_start_x[0],
+        outer_wrap_x[0]
+    );
+    assert!(
+        nested_start_x[0] > outer_start_x[0],
+        "nested body should shift right: outer={}, nested={}",
+        outer_start_x[0],
+        nested_start_x[0]
+    );
+    assert!(
+        (nested_wrap_x[0] - nested_start_x[0]).abs() <= epsilon_pt,
+        "nested continuation x mismatch: nested={}, wrap={}",
+        nested_start_x[0],
+        nested_wrap_x[0]
     );
 }
 

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -25,21 +25,25 @@ first-line indentation, and width-sensitive wrapping are visible in the PDF prev
 
 \subsection{Lists}
 \begin{itemize}
-\item First bullet with \emph{emphasis}.
-\item Second bullet with \textbf{bold}.
+\item First bullet with \emph{emphasis} and a deliberately long sentence to force wrapping so body alignment remains stable across continuation lines in the preview renderer.
+\item Second bullet with \textbf{bold} plus another long continuation sentence that should wrap without shifting the bullet column.
+\begin{itemize}
+\item Nested bullet item with enough words to wrap and verify one-level nested indentation remains stable in continuation lines.
+\item Another nested bullet with \emph{styled words} near punctuation,like this, to stress inline wrappers inside list content.
+\end{itemize}
 \end{itemize}
 
 \begin{enumerate}
-\item First numbered item.
-\item Second numbered item.
+\item First numbered item with a wrapping sentence to keep the body column stable.
+\item Second numbered item with enough words for continuation-line alignment checks.
 \item Third numbered item.
 \item Fourth numbered item.
 \item Fifth numbered item.
 \item Sixth numbered item.
 \item Seventh numbered item.
 \item Eighth numbered item.
-\item Ninth numbered item.
-\item Tenth numbered item.
+\item Ninth numbered item with a long tail to stress single-digit alignment.
+\item Tenth numbered item with a matching long tail to stress double-digit alignment.
 \end{enumerate}
 
 \subsection{Quote}


### PR DESCRIPTION
## Summary\n- bundle typography hardening for typeset_minimal_v0 list extraction, spacing rhythm, and renderer alignment\n- add deterministic xdv/pdf invariants for inline wrapper spacing, heading/list/quote rhythm, and list column alignment across wraps\n- extend minimal fixture with punctuation adjacency, quote stress, and wrapped list cases\n\n## Proof\n- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests\n- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml\n- ./scripts/proof_wasm_typeset_minimal_v0.sh | tail -n 6\n- ./scripts/proof_wasm_fixture_gallery_v0.sh | tail -n 10