### PR TITLE
harden on-demand fixedpoint phase2 gates

### DIFF
--- a/scripts/ondemand_fixedpoint_v0_proof.mjs
+++ b/scripts/ondemand_fixedpoint_v0_proof.mjs
@@ -24,10 +24,33 @@ function sha256HexV0(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
 }
 
+function stableRequestPayloadShaV0(requests) {
+  return sha256HexV0(Buffer.from(JSON.stringify(requests), 'utf8'));
+}
+
 function assertV0(condition, message) {
   if (!condition) {
     throw new Error(message);
   }
+}
+
+async function readJsonFileV0(jsonPath) {
+  return JSON.parse((await readFile(jsonPath)).toString('utf8'));
+}
+
+async function countResolvedResourcesFromSummariesV0(galleryOutDir, statuses) {
+  let count = 0;
+  for (const statusEntry of statuses) {
+    const caseId = `${statusEntry?.case_id ?? ''}`;
+    if (caseId.length === 0) {
+      continue;
+    }
+    const summaryPath = path.join(galleryOutDir, caseId, 'summary.json');
+    const summary = await readJsonFileV0(summaryPath);
+    const resolvedResources = Array.isArray(summary.resolved_resources) ? summary.resolved_resources : [];
+    count += resolvedResources.length;
+  }
+  return count;
 }
 
 function endpointPathForRequestV0(request) {
@@ -116,11 +139,27 @@ function runGalleryV0(galleryOutDir, storeDir, sourceDateEpoch) {
   });
 }
 
-async function verifyPhase2ProbeStatusesV0(galleryOutDir) {
-  const reportPath = path.join(galleryOutDir, 'report.json');
-  const report = JSON.parse((await readFile(reportPath)).toString('utf8'));
-  const statuses = Array.isArray(report.statuses) ? report.statuses : [];
+function countStatusesV0(statuses) {
+  const counts = {
+    OK: 0,
+    NI: 0,
+    INVALID: 0,
+    FAIL: 0,
+    OTHER: 0,
+  };
+  for (const statusEntry of statuses) {
+    const status = statusEntry?.status;
+    if (status === 'OK' || status === 'NI' || status === 'INVALID' || status === 'FAIL') {
+      counts[status] += 1;
+    } else {
+      counts.OTHER += 1;
+    }
+  }
+  return counts;
+}
 
+async function buildProbeCaseTableV0(galleryOutDir, report) {
+  const statuses = Array.isArray(report.statuses) ? report.statuses : [];
   const probeChecks = [];
   for (const caseId of PHASE2_PROBE_CASE_IDS_V0) {
     const statusEntry = statuses.find((entry) => entry?.case_id === caseId);
@@ -140,6 +179,9 @@ async function verifyPhase2ProbeStatusesV0(galleryOutDir) {
     assertV0(resourceHints.present === true, `phase2 probe resource_hints missing for ${caseId}`);
     const hintItems = Number(resourceHints.items ?? 0);
     assertV0(hintItems > 0, `phase2 probe resource_hints must be non-empty for ${caseId}`);
+    const hintSha = `${resourceHints.artifact_sha256 ?? ''}`;
+    assertV0(/^[0-9a-f]{64}$/.test(hintSha), `phase2 probe resource_hints sha missing for ${caseId}`);
+    const resolvedResources = Array.isArray(summary.resolved_resources) ? summary.resolved_resources : [];
 
     probeChecks.push({
       case_id: caseId,
@@ -147,18 +189,14 @@ async function verifyPhase2ProbeStatusesV0(galleryOutDir) {
       actual_status: statusEntry.status,
       expected_vs_actual: statusEntry.expected_vs_actual,
       resource_hints_items: hintItems,
+      resource_hints_sha256: hintSha,
+      resolved_resources_count: resolvedResources.length,
     });
   }
   return probeChecks;
 }
 
-async function runFixedpointProofV0(outDir) {
-  const sourceDateEpochRaw = process.env.SOURCE_DATE_EPOCH ?? `${DEFAULT_SOURCE_DATE_EPOCH_V0}`;
-  const sourceDateEpoch = Number.parseInt(`${sourceDateEpochRaw}`, 10);
-  assertV0(Number.isInteger(sourceDateEpoch) && sourceDateEpoch > 0, 'SOURCE_DATE_EPOCH must be a positive integer');
-  assertV0(process.env.TZ === 'UTC', 'TZ must be UTC');
-
-  await mkdir(outDir, { recursive: true });
+async function runFixedpointPassV0(outDir, sourceDateEpoch) {
   const runRoot = await mkdtemp(path.join(outDir, 'run_'));
   const storeDir = path.join(runRoot, 'store');
   await mkdir(storeDir, { recursive: true });
@@ -168,15 +206,25 @@ async function runFixedpointProofV0(outDir) {
   let sawImprovement = false;
   let fixedpointIteration = 0;
   let fixedpointGalleryOutDir = '';
+  let fixedpointReport = null;
 
   for (let iter = 1; iter <= MAX_ITERS_V0; iter += 1) {
     const galleryOutDir = path.join(runRoot, `gallery_iter_${iter}`);
     runGalleryV0(galleryOutDir, storeDir, sourceDateEpoch);
 
     const reportPath = path.join(galleryOutDir, 'report.json');
-    const reportBytes = await readFile(reportPath);
-    const report = JSON.parse(reportBytes.toString('utf8'));
+    const report = await readJsonFileV0(reportPath);
+    const statuses = Array.isArray(report.statuses) ? report.statuses : [];
+    assertV0(statuses.length > 0, `gallery report statuses missing at iteration ${iter}`);
+    assertV0(Number.isInteger(report.case_count), `gallery report case_count missing at iteration ${iter}`);
+    assertV0(report.case_count === statuses.length, `gallery report case_count mismatch at iteration ${iter}`);
+
     const resolvedResourcesCount = Number(report.resolved_resources_count ?? 0);
+    const recomputedResolvedCount = await countResolvedResourcesFromSummariesV0(galleryOutDir, statuses);
+    assertV0(
+      resolvedResourcesCount === recomputedResolvedCount,
+      `resolved_resources_count mismatch at iteration ${iter}`,
+    );
 
     const requestListPath = path.join(runRoot, `request_list_iter_${iter}.json`);
     await buildRequestListFromHintsV0({
@@ -184,9 +232,12 @@ async function runFixedpointProofV0(outDir) {
       reportPath,
       outputPath: requestListPath,
     });
-    const requestList = JSON.parse((await readFile(requestListPath)).toString('utf8'));
+    const requestList = await readJsonFileV0(requestListPath);
     const requests = Array.isArray(requestList.requests) ? requestList.requests : [];
     const requestCount = Number(requestList.request_count ?? requests.length);
+    assertV0(requestCount === requests.length, `request_count mismatch at iteration ${iter}`);
+    const requestListSha256 = sha256HexV0(Buffer.from(JSON.stringify(requestList), 'utf8'));
+    const requestPayloadSha256 = stableRequestPayloadShaV0(requests);
 
     const resourceMap = buildStubResourceMapV0(requests);
     const stub = await startStubServerV0(resourceMap);
@@ -203,13 +254,37 @@ async function runFixedpointProofV0(outDir) {
     } finally {
       await stub.close();
     }
+    const storeSummary = await readJsonFileV0(path.join(storeDir, 'summary.json'));
+    const storeFound = Number(storeSummary.found_count ?? storeResult.foundCount);
+    const storeMissing = Number(storeSummary.missing_count ?? storeResult.missingCount);
+    assertV0(storeFound === storeResult.foundCount, `store found_count mismatch at iteration ${iter}`);
+    assertV0(storeMissing === storeResult.missingCount, `store missing_count mismatch at iteration ${iter}`);
+    assertV0(Number(storeSummary.request_count ?? requestCount) === requestCount, `store request_count mismatch at iteration ${iter}`);
+    assertV0(
+      typeof storeSummary.index_sha256 === 'string' && /^[0-9a-f]{64}$/.test(storeSummary.index_sha256),
+      `store index_sha256 missing at iteration ${iter}`,
+    );
+    assertV0(
+      typeof storeSummary.resolver_id === 'string' && storeSummary.resolver_id.length > 0,
+      `store resolver_id missing at iteration ${iter}`,
+    );
+
+    const statusCounts = countStatusesV0(statuses);
+    assertV0(statusCounts.OTHER === 0, `unsupported case status found at iteration ${iter}`);
+    const probeCases = await buildProbeCaseTableV0(galleryOutDir, report);
 
     const iteration = {
       iteration: iter,
       resolved_resources_count: resolvedResourcesCount,
-      found: storeResult.foundCount,
-      missing: storeResult.missingCount,
+      found: storeFound,
+      missing: storeMissing,
       request_count: requestCount,
+      request_list_sha256: requestListSha256,
+      request_payload_sha256: requestPayloadSha256,
+      store_index_sha256: storeSummary.index_sha256,
+      store_resolver_id: storeSummary.resolver_id,
+      status_counts: statusCounts,
+      probe_cases: probeCases,
     };
     iterations.push(iteration);
 
@@ -234,6 +309,7 @@ async function runFixedpointProofV0(outDir) {
       fixedpointReached = true;
       fixedpointIteration = iter;
       fixedpointGalleryOutDir = galleryOutDir;
+      fixedpointReport = report;
       break;
     }
     throw new Error(`fixedpoint transition must improve or stabilize at iteration ${iter}`);
@@ -242,21 +318,20 @@ async function runFixedpointProofV0(outDir) {
   assertV0(fixedpointReached, `fixedpoint not reached within ${MAX_ITERS_V0} iterations`);
   const finalIter = iterations[iterations.length - 1];
   assertV0(finalIter.missing === 0, `fixedpoint must converge with missing=0, got ${finalIter.missing}`);
+  assertV0(fixedpointReport !== null, 'fixedpoint report missing');
 
-  const phase2GalleryOutDir = path.join(runRoot, `gallery_phase2_after_fixedpoint`);
+  const phase2GalleryOutDir = path.join(runRoot, 'gallery_phase2_after_fixedpoint');
   runGalleryV0(phase2GalleryOutDir, storeDir, sourceDateEpoch);
-  const phase2ProbeChecks = await verifyPhase2ProbeStatusesV0(phase2GalleryOutDir);
-  const phase2Report = JSON.parse(
-    (await readFile(path.join(phase2GalleryOutDir, 'report.json'))).toString('utf8'),
-  );
+  const phase2Report = await readJsonFileV0(path.join(phase2GalleryOutDir, 'report.json'));
+  const phase2ProbeChecks = await buildProbeCaseTableV0(phase2GalleryOutDir, phase2Report);
+  const phase2StatusCounts = countStatusesV0(Array.isArray(phase2Report.statuses) ? phase2Report.statuses : []);
   const phase2ResolvedResources = Number(phase2Report.resolved_resources_count ?? 0);
   assertV0(
     phase2ResolvedResources === finalIter.resolved_resources_count,
     `phase2 rerun must preserve fixedpoint resolved count (${finalIter.resolved_resources_count} != ${phase2ResolvedResources})`,
   );
 
-  const summary = {
-    version: 1,
+  return {
     schema: 'ondemand_fixedpoint_summary_v0',
     source_date_epoch: sourceDateEpoch,
     store_path: storeDir,
@@ -265,19 +340,68 @@ async function runFixedpointProofV0(outDir) {
     fixedpoint_resolved_resources_count: finalIter.resolved_resources_count,
     fixedpoint_missing_count: finalIter.missing,
     phase2_probe_checks: phase2ProbeChecks,
+    phase2_status_counts: phase2StatusCounts,
     phase2_resolved_resources_count: phase2ResolvedResources,
     fixedpoint_gallery_relpath: path.relative(runRoot, fixedpointGalleryOutDir),
     phase2_gallery_relpath: path.relative(runRoot, phase2GalleryOutDir),
     final_status: 'PASS',
+  };
+}
+
+function canonicalSummaryPayloadV0(summary) {
+  const iterations = Array.isArray(summary.iterations)
+    ? summary.iterations.map((iter) => ({
+      ...iter,
+      store_resolver_id: '<store_resolver_id>',
+      request_list_sha256: '<request_list_sha256>',
+    }))
+    : [];
+  return {
+    ...summary,
+    store_path: '<store_path>',
+    iterations,
+  };
+}
+
+async function runFixedpointProofV0(outDir) {
+  const sourceDateEpochRaw = process.env.SOURCE_DATE_EPOCH ?? `${DEFAULT_SOURCE_DATE_EPOCH_V0}`;
+  const sourceDateEpoch = Number.parseInt(`${sourceDateEpochRaw}`, 10);
+  assertV0(Number.isInteger(sourceDateEpoch) && sourceDateEpoch > 0, 'SOURCE_DATE_EPOCH must be a positive integer');
+  assertV0(process.env.TZ === 'UTC', 'TZ must be UTC');
+
+  await mkdir(outDir, { recursive: true });
+  const summaryA = await runFixedpointPassV0(outDir, sourceDateEpoch);
+  const summaryB = await runFixedpointPassV0(outDir, sourceDateEpoch);
+
+  const canonicalA = canonicalSummaryPayloadV0(summaryA);
+  const canonicalB = canonicalSummaryPayloadV0(summaryB);
+  const canonicalABytes = Buffer.from(JSON.stringify(canonicalA), 'utf8');
+  const canonicalBBytes = Buffer.from(JSON.stringify(canonicalB), 'utf8');
+  const canonicalShaA = sha256HexV0(canonicalABytes);
+  const canonicalShaB = sha256HexV0(canonicalBBytes);
+  await writeFile(path.join(outDir, 'ondemand_fixedpoint_canonical_a.json'), `${JSON.stringify(canonicalA, null, 2)}\n`);
+  await writeFile(path.join(outDir, 'ondemand_fixedpoint_canonical_b.json'), `${JSON.stringify(canonicalB, null, 2)}\n`);
+  assertV0(canonicalShaA === canonicalShaB, 'ondemand fixedpoint summary must be deterministic across reruns');
+
+  const summary = {
+    version: 1,
+    ...summaryA,
+    determinism: {
+      reruns: 2,
+      canonical_summary_sha256_a: canonicalShaA,
+      canonical_summary_sha256_b: canonicalShaB,
+      canonical_summary_stable: canonicalShaA === canonicalShaB,
+    },
   };
   const summaryPath = path.join(outDir, 'ondemand_fixedpoint_summary.json');
   await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
 
   return {
     summaryPath,
-    storeDir,
-    iterations,
-    phase2ProbeChecks,
+    storeDir: summaryA.store_path,
+    iterations: summaryA.iterations,
+    phase2ProbeChecks: summaryA.phase2_probe_checks,
+    determinism: summary.determinism,
   };
 }
 
@@ -290,6 +414,9 @@ async function runCliV0() {
   console.log(`PASS: fixedpoint iterations ${result.iterations.length}`);
   console.log(`PASS: final resolved=${finalIter.resolved_resources_count} missing=${finalIter.missing}`);
   console.log(`PASS: phase2 probes ${result.phase2ProbeChecks.length} status+hint checks`);
+  console.log(
+    `PASS: deterministic summary sha256 ${result.determinism.canonical_summary_sha256_a}`,
+  );
   console.log('PASS: on-demand fixedpoint proof v0');
 }
 

--- a/scripts/ondemand_fixedpoint_v0_validate.mjs
+++ b/scripts/ondemand_fixedpoint_v0_validate.mjs
@@ -1,0 +1,200 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+
+const REQUIRED_PROBE_CASE_IDS_V0 = new Set([
+  'typeset_demo_cjk_probe_v0',
+  'typeset_demo_math_probe_v0',
+  'typeset_demo_hyperref_links_probe_v0',
+]);
+
+function sha256HexV0(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function assertV0(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function isSha256V0(value) {
+  return typeof value === 'string' && /^[0-9a-f]{64}$/.test(value);
+}
+
+function isFiniteNumberV0(value) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function validateStatusCountsV0(statusCounts, context) {
+  assertV0(statusCounts && typeof statusCounts === 'object', `${context} status_counts missing`);
+  const required = ['OK', 'NI', 'INVALID', 'FAIL', 'OTHER'];
+  for (const key of required) {
+    assertV0(Number.isInteger(statusCounts[key]) && statusCounts[key] >= 0, `${context} status_counts.${key} invalid`);
+  }
+}
+
+function hasForbiddenTimestampKeysV0(value) {
+  if (Array.isArray(value)) {
+    return value.some((entry) => hasForbiddenTimestampKeysV0(entry));
+  }
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  for (const [key, nested] of Object.entries(value)) {
+    if (key === 'source_date_epoch' || key === 'store_path') {
+      continue;
+    }
+    if (key.toLowerCase().includes('timestamp') || key.toLowerCase() === 'time') {
+      return true;
+    }
+    if (hasForbiddenTimestampKeysV0(nested)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function validateProbeChecksV0(probeChecks) {
+  assertV0(Array.isArray(probeChecks), 'phase2_probe_checks must be array');
+  const seen = new Set();
+  for (const entry of probeChecks) {
+    assertV0(entry && typeof entry === 'object', 'phase2 probe entry must be object');
+    const caseId = `${entry.case_id ?? ''}`;
+    assertV0(REQUIRED_PROBE_CASE_IDS_V0.has(caseId), `unexpected probe case_id ${caseId}`);
+    seen.add(caseId);
+    assertV0(entry.expected_vs_actual === 'MATCH', `probe expected_vs_actual mismatch for ${caseId}`);
+    assertV0(entry.actual_status === 'NI' || entry.actual_status === 'INVALID', `probe status invalid for ${caseId}`);
+    assertV0(isFiniteNumberV0(entry.resource_hints_items) && entry.resource_hints_items > 0, `probe hints must be non-empty for ${caseId}`);
+    assertV0(isSha256V0(entry.resource_hints_sha256), `probe hints sha missing for ${caseId}`);
+    assertV0(Number.isInteger(entry.resolved_resources_count) && entry.resolved_resources_count >= 0, `probe resolved count invalid for ${caseId}`);
+  }
+  for (const caseId of REQUIRED_PROBE_CASE_IDS_V0) {
+    assertV0(seen.has(caseId), `missing probe case ${caseId}`);
+  }
+}
+
+function validateIterationsV0(iterations) {
+  assertV0(Array.isArray(iterations), 'iterations must be array');
+  assertV0(iterations.length >= 2 && iterations.length <= 3, 'iterations length must be in [2,3]');
+  let sawImprovement = false;
+  for (let i = 0; i < iterations.length; i += 1) {
+    const iter = iterations[i];
+    assertV0(iter && typeof iter === 'object', `iteration ${i + 1} must be object`);
+    assertV0(iter.iteration === i + 1, `iteration index mismatch at ${i + 1}`);
+    for (const key of ['resolved_resources_count', 'found', 'missing', 'request_count']) {
+      assertV0(Number.isInteger(iter[key]) && iter[key] >= 0, `iteration ${i + 1} ${key} invalid`);
+    }
+    assertV0(isSha256V0(iter.request_list_sha256), `iteration ${i + 1} request_list_sha256 missing`);
+    assertV0(isSha256V0(iter.request_payload_sha256), `iteration ${i + 1} request_payload_sha256 missing`);
+    assertV0(isSha256V0(iter.store_index_sha256), `iteration ${i + 1} store_index_sha256 missing`);
+    assertV0(typeof iter.store_resolver_id === 'string' && iter.store_resolver_id.length > 0, `iteration ${i + 1} store_resolver_id missing`);
+    validateStatusCountsV0(iter.status_counts, `iteration ${i + 1}`);
+    validateProbeChecksV0(iter.probe_cases);
+
+    if (i === 0) {
+      continue;
+    }
+    const prev = iterations[i - 1];
+    const resolvedDelta = iter.resolved_resources_count - prev.resolved_resources_count;
+    const missingDelta = iter.missing - prev.missing;
+    assertV0(!(resolvedDelta < 0 || missingDelta > 0), `iteration ${i + 1} regression`);
+    if (resolvedDelta > 0 || missingDelta < 0) {
+      sawImprovement = true;
+    }
+    if (resolvedDelta === 0 && missingDelta === 0) {
+      assertV0(sawImprovement, `iteration ${i + 1} fixedpoint reached without prior improvement`);
+    }
+  }
+}
+
+function canonicalSummaryPayloadV0(summary) {
+  const { determinism, version, ...rest } = summary;
+  const iterations = Array.isArray(summary.iterations)
+    ? summary.iterations.map((iter) => ({
+      ...iter,
+      store_resolver_id: '<store_resolver_id>',
+      request_list_sha256: '<request_list_sha256>',
+    }))
+    : [];
+  return {
+    ...rest,
+    store_path: '<store_path>',
+    iterations,
+  };
+}
+
+async function validateSummaryV0(summaryPath) {
+  const summaryBytes = await readFile(summaryPath);
+  const summary = JSON.parse(summaryBytes.toString('utf8'));
+
+  assertV0(summary.version === 1, 'summary version must be 1');
+  assertV0(summary.schema === 'ondemand_fixedpoint_summary_v0', 'summary schema mismatch');
+  assertV0(Number.isInteger(summary.source_date_epoch) && summary.source_date_epoch > 0, 'summary source_date_epoch invalid');
+  assertV0(typeof summary.store_path === 'string' && summary.store_path.length > 0, 'summary store_path missing');
+  assertV0(summary.final_status === 'PASS', 'summary final_status must be PASS');
+  assertV0(!hasForbiddenTimestampKeysV0(summary), 'summary contains forbidden timestamp fields');
+
+  validateIterationsV0(summary.iterations);
+  const finalIter = summary.iterations[summary.iterations.length - 1];
+  assertV0(summary.fixedpoint_iteration === summary.iterations.length, 'fixedpoint_iteration mismatch');
+  assertV0(summary.fixedpoint_resolved_resources_count === finalIter.resolved_resources_count, 'fixedpoint resolved mismatch');
+  assertV0(summary.fixedpoint_missing_count === 0, 'fixedpoint missing must be 0');
+  assertV0(summary.phase2_resolved_resources_count === finalIter.resolved_resources_count, 'phase2 resolved mismatch');
+  validateStatusCountsV0(summary.phase2_status_counts, 'phase2');
+  validateProbeChecksV0(summary.phase2_probe_checks);
+
+  assertV0(
+    summary.fixedpoint_gallery_relpath === `gallery_iter_${summary.fixedpoint_iteration}`,
+    'fixedpoint_gallery_relpath mismatch',
+  );
+  assertV0(
+    summary.phase2_gallery_relpath === 'gallery_phase2_after_fixedpoint',
+    'phase2_gallery_relpath mismatch',
+  );
+
+  const determinism = summary.determinism;
+  assertV0(determinism && typeof determinism === 'object', 'determinism object missing');
+  assertV0(determinism.reruns === 2, 'determinism reruns must be 2');
+  assertV0(isSha256V0(determinism.canonical_summary_sha256_a), 'determinism sha a missing');
+  assertV0(isSha256V0(determinism.canonical_summary_sha256_b), 'determinism sha b missing');
+  assertV0(determinism.canonical_summary_stable === true, 'determinism flag must be true');
+  assertV0(
+    determinism.canonical_summary_sha256_a === determinism.canonical_summary_sha256_b,
+    'determinism sha mismatch',
+  );
+
+  const canonicalPayload = canonicalSummaryPayloadV0(summary);
+  const canonicalSha = sha256HexV0(Buffer.from(JSON.stringify(canonicalPayload), 'utf8'));
+  assertV0(canonicalSha === determinism.canonical_summary_sha256_a, 'determinism sha does not match summary payload');
+
+  return {
+    summary,
+    summarySha256: sha256HexV0(summaryBytes),
+    canonicalSha256: canonicalSha,
+  };
+}
+
+async function runCliV0() {
+  const summaryPath = path.resolve(
+    process.argv[2] ?? path.join(rootDir, 'target', 'ondemand_fixedpoint_v0', 'ondemand_fixedpoint_summary.json'),
+  );
+  const result = await validateSummaryV0(summaryPath);
+  console.log(`PASS: validated summary ${summaryPath}`);
+  console.log(`PASS: summary_sha256 ${result.summarySha256}`);
+  console.log(`PASS: canonical_summary_sha256 ${result.canonicalSha256}`);
+  console.log('PASS: on-demand fixedpoint summary validation');
+}
+
+if (import.meta.url === new URL(process.argv[1], 'file://').href) {
+  runCliV0().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`FAIL: on-demand fixedpoint summary validation: ${message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/proof_ondemand_fixedpoint_v0.sh
+++ b/scripts/proof_ondemand_fixedpoint_v0.sh
@@ -14,5 +14,7 @@ if [[ ! -s "$OUT_DIR/ondemand_fixedpoint_summary.json" ]]; then
   exit 1
 fi
 
+node "$ROOT_DIR/scripts/ondemand_fixedpoint_v0_validate.mjs" "$OUT_DIR/ondemand_fixedpoint_summary.json"
+
 echo "PASS: on-demand fixedpoint proof artifacts $OUT_DIR"
 echo "PASS: on-demand fixedpoint proof"


### PR DESCRIPTION
## Summary\n- harden fixedpoint proof with per-iteration monotonicity and no-regression checks over gallery/store loop\n- add explicit phase-2 probe gate for cjk/math/hyperref_links cases requiring NI/INVALID + non-empty resource hints\n- add deterministic summary validator for fixedpoint schema and canonical payload hash stability\n\n## Proof\n- ./scripts/proof_wasm_fixture_gallery_v0.sh | tail -n 10\n- ./scripts/proof_ondemand_resolver_v0.sh | tail -n 10\n- ./scripts/proof_ondemand_endpoint_v0.sh | tail -n 10\n- ./scripts/proof_ondemand_fixedpoint_v0.sh | tail -n 20