### PR TITLE
typeset: typography bundle v3 rhythm and heading styles

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -20,6 +20,8 @@ const CENTERLINE_CONTROL_V0: &[u8] = b"centerline";
 const FLUSHRIGHT_ENV_V0: &[u8] = b"flushright";
 const RIGHTLINE_CONTROL_V0: &[u8] = b"rightline";
 const NOINDENT_PREFIX_MARKER_V0: &[u8] = b"~ ";
+const SECTION_HEADING_PREFIX_MARKER_V0: &[u8] = b"@S ";
+const SUBSECTION_HEADING_PREFIX_MARKER_V0: &[u8] = b"@s ";
 const ITALIC_START_MARKER_V0: u8 = b'[';
 const ITALIC_END_MARKER_V0: u8 = b']';
 const BOLD_START_MARKER_V0: u8 = b'{';
@@ -612,6 +614,20 @@ fn is_heading_control_v0(name: &[u8]) -> bool {
         || name == SUBPARAGRAPH_CONTROL_V0
 }
 
+fn heading_prefix_for_control_v0(name: &[u8]) -> Option<&'static [u8]> {
+    if name == SECTION_CONTROL_V0 {
+        Some(SECTION_HEADING_PREFIX_MARKER_V0)
+    } else if name == SUBSECTION_CONTROL_V0
+        || name == SUBSUBSECTION_CONTROL_V0
+        || name == PARAGRAPH_CONTROL_V0
+        || name == SUBPARAGRAPH_CONTROL_V0
+    {
+        Some(SUBSECTION_HEADING_PREFIX_MARKER_V0)
+    } else {
+        None
+    }
+}
+
 fn consume_heading_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
     let TokenV0::ControlSeq(name) = tokens.get(index)? else {
         return None;
@@ -619,11 +635,13 @@ fn consume_heading_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8
     if !is_heading_control_v0(name.as_slice()) {
         return None;
     }
+    let heading_prefix = heading_prefix_for_control_v0(name.as_slice())?;
     let (group_start, group_end, next) = consume_group_bounds(tokens, index + 1)?;
     let mut heading = Vec::new();
     consume_fragment_range_v0(tokens, group_start, group_end, &mut heading, false, true)?;
     trim_trailing_spaces(&mut heading);
     push_paragraph_break(out);
+    out.extend_from_slice(heading_prefix);
     out.push(BOLD_START_MARKER_V0);
     out.extend_from_slice(&heading);
     out.push(BOLD_END_MARKER_V0);

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -96,7 +96,7 @@ fn typeset_minimal_headings_emit_bold_with_paragraph_breaks() {
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
     assert!(
-        text.contains("Before.\n\n{Intro}\n\n{A [B]}\n\n~ After."),
+        text.contains("Before.\n\n@S {Intro}\n\n@s {A [B]}\n\n~ After."),
         "body={text:?}"
     );
 }
@@ -107,7 +107,7 @@ fn typeset_minimal_heading_at_start_has_no_leading_blank_lines() {
         b"\\documentclass{article}\\begin{document}\\paragraph{Lead in}Body text.\\end{document}";
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
-    assert!(text.starts_with("{Lead in}\n\n~ Body text."), "body={text:?}");
+    assert!(text.starts_with("@s {Lead in}\n\n~ Body text."), "body={text:?}");
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn typeset_minimal_first_paragraph_after_heading_uses_noindent_marker() {
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
     assert!(
-        text.contains("{Intro}\n\n~ First paragraph.\n\nSecond paragraph."),
+        text.contains("@S {Intro}\n\n~ First paragraph.\n\nSecond paragraph."),
         "body={text:?}"
     );
 }
@@ -190,7 +190,7 @@ fn typeset_minimal_heading_list_quote_rhythm_markers_are_stable() {
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
     assert!(
-        text.contains("{Heading}\n\n~ After heading.\n\n- First item\n- Second item\n\n> Quoted line one\n> Quoted line two\n\nAfter quote."),
+        text.contains("@S {Heading}\n\n~ After heading.\n\n- First item\n- Second item\n\n> Quoted line one\n> Quoted line two\n\nAfter quote."),
         "body={text:?}"
     );
 }

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -8,12 +8,16 @@ const PAGE_HEIGHT_PT_V0: f32 = 792.0;
 const MARGIN_PT_V0: f32 = 72.0;
 const FONT_SIZE_PT_V0: f32 = 12.0;
 const TITLE_FONT_SIZE_PT_V0: f32 = 18.0;
+const SECTION_HEADING_FONT_SIZE_PT_V0: f32 = 16.0;
+const SUBSECTION_HEADING_FONT_SIZE_PT_V0: f32 = 14.0;
 const INDENT_PT_V0: f32 = FONT_SIZE_PT_V0 * 2.0;
 const LIST_BODY_INDENT_PT_V0: f32 = INDENT_PT_V0;
 const ENUM_NUMBER_COLUMN_RIGHT_PT_V0: f32 = MARGIN_PT_V0 + (FONT_SIZE_PT_V0 * 1.5);
 const LEADING_PT_V0: f32 = 14.0;
 const TITLE_EXTRA_GAP_PT_V0: f32 = LEADING_PT_V0;
 const NOINDENT_PREFIX_MARKER_V0: u8 = b'~';
+const SECTION_HEADING_PREFIX_MARKER_V0: &[u8] = b"@S ";
+const SUBSECTION_HEADING_PREFIX_MARKER_V0: &[u8] = b"@s ";
 const ITALIC_START_MARKER_V0: u8 = b'[';
 const ITALIC_END_MARKER_V0: u8 = b']';
 const BOLD_START_MARKER_V0: u8 = b'{';
@@ -24,6 +28,12 @@ enum PdfTextStyleV0 {
     Regular,
     Italic,
     Bold,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum HeadingKindV0 {
+    Section,
+    Subsection,
 }
 
 fn style_font_alias_v0(style: PdfTextStyleV0) -> &'static [u8] {
@@ -241,6 +251,33 @@ fn has_noindent_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
     glyphs.len() >= 2 && glyphs[0].byte == NOINDENT_PREFIX_MARKER_V0 && glyphs[1].byte == b' '
 }
 
+fn heading_prefix_len_v0(kind: HeadingKindV0) -> usize {
+    match kind {
+        HeadingKindV0::Section => SECTION_HEADING_PREFIX_MARKER_V0.len(),
+        HeadingKindV0::Subsection => SUBSECTION_HEADING_PREFIX_MARKER_V0.len(),
+    }
+}
+
+fn detect_heading_prefix_v0(glyphs: &[GlyphPlanV0]) -> Option<HeadingKindV0> {
+    if glyphs.len() >= SECTION_HEADING_PREFIX_MARKER_V0.len()
+        && glyphs[..SECTION_HEADING_PREFIX_MARKER_V0.len()]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .eq(SECTION_HEADING_PREFIX_MARKER_V0.iter().copied())
+    {
+        return Some(HeadingKindV0::Section);
+    }
+    if glyphs.len() >= SUBSECTION_HEADING_PREFIX_MARKER_V0.len()
+        && glyphs[..SUBSECTION_HEADING_PREFIX_MARKER_V0.len()]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .eq(SUBSECTION_HEADING_PREFIX_MARKER_V0.iter().copied())
+    {
+        return Some(HeadingKindV0::Subsection);
+    }
+    None
+}
+
 fn glyphs_advance_pt_v0(glyphs: &[GlyphPlanV0]) -> f32 {
     glyphs
         .iter()
@@ -323,6 +360,16 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
             && !center_prefixed
             && !right_prefixed
             && has_noindent_prefix_v0(&line.glyphs);
+        let heading_kind = if line_index >= title_block_len
+            && quote_prefix_advance_pt.is_none()
+            && !center_prefixed
+            && !right_prefixed
+            && !noindent_prefixed
+        {
+            detect_heading_prefix_v0(&line.glyphs)
+        } else {
+            None
+        };
         let render_glyphs_base: &[GlyphPlanV0] = if quote_prefix_advance_pt.is_some() {
             &line.glyphs[2..]
         } else if center_prefixed {
@@ -331,6 +378,8 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
             &line.glyphs[2..]
         } else if noindent_prefixed {
             &line.glyphs[2..]
+        } else if let Some(kind) = heading_kind {
+            &line.glyphs[heading_prefix_len_v0(kind)..]
         } else {
             &line.glyphs
         };
@@ -339,6 +388,7 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
             && !center_prefixed
             && !right_prefixed
             && !noindent_prefixed
+            && heading_kind.is_none()
         {
             detect_list_prefix_v0(render_glyphs_base)
         } else {
@@ -357,6 +407,10 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
         let in_title_block = title_block_len > 0 && line_index < title_block_len;
         let font_size_pt = if in_title_block && line_index == 0 {
             TITLE_FONT_SIZE_PT_V0
+        } else if matches!(heading_kind, Some(HeadingKindV0::Section)) {
+            SECTION_HEADING_FONT_SIZE_PT_V0
+        } else if matches!(heading_kind, Some(HeadingKindV0::Subsection)) {
+            SUBSECTION_HEADING_FONT_SIZE_PT_V0
         } else {
             FONT_SIZE_PT_V0
         };
@@ -378,7 +432,7 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
             let line_width_pt: f32 = segments.iter().map(|segment| segment.advance_pt).sum();
             let line_x = if in_title_block {
                 centered_line_x_v0(line_width_pt)
-            } else if heading_centered {
+            } else if heading_kind.is_some() || heading_centered {
                 active_quote_indent_pt = 0.0;
                 active_hang_indent_pt = 0.0;
                 centered_line_x_v0(line_width_pt)

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -363,6 +363,28 @@ fn tm_position_for_line_containing_text_v0(pdf: &[u8], needle: &str) -> Option<(
     None
 }
 
+fn tf_sizes_for_line_containing_text_v0(pdf: &[u8], needle: &str) -> Vec<f32> {
+    let text = String::from_utf8_lossy(pdf);
+    for line in text.lines() {
+        if !line.contains(needle) {
+            continue;
+        }
+        let fields = line.split_whitespace().collect::<Vec<_>>();
+        let mut sizes = Vec::<f32>::new();
+        let mut index = 0usize;
+        while index + 1 < fields.len() {
+            if fields[index + 1] == "Tf" {
+                if let Ok(size_pt) = fields[index].parse::<f32>() {
+                    sizes.push(size_pt);
+                }
+            }
+            index += 1;
+        }
+        return sizes;
+    }
+    Vec::new()
+}
+
 fn tm_xs_for_segment_text_v0(pdf: &[u8], segment_text: &str) -> Vec<f32> {
     let target_token = format!("({segment_text})");
     let text = String::from_utf8_lossy(pdf);
@@ -412,6 +434,48 @@ fn tm_xs_for_segment_text_v0(pdf: &[u8], segment_text: &str) -> Vec<f32> {
         }
     }
     xs
+}
+
+fn tm_position_for_segment_substring_v0(pdf: &[u8], needle: &str) -> Option<(f32, f32)> {
+    let text = String::from_utf8_lossy(pdf);
+    for line in text.lines() {
+        if !line.contains(needle) || !line.contains(" Tm ") {
+            continue;
+        }
+        let fields = line.split_whitespace().collect::<Vec<_>>();
+        let mut index = 0usize;
+        while index + 6 < fields.len() {
+            let is_tm = fields[index] == "1"
+                && fields[index + 1] == "0"
+                && fields[index + 2] == "0"
+                && fields[index + 3] == "1"
+                && fields[index + 6] == "Tm";
+            if !is_tm {
+                index += 1;
+                continue;
+            }
+            let x_pt = fields[index + 4].parse::<f32>().ok()?;
+            let y_pt = fields[index + 5].parse::<f32>().ok()?;
+            let mut cursor = index + 7;
+            while cursor < fields.len() {
+                if cursor + 6 < fields.len()
+                    && fields[cursor] == "1"
+                    && fields[cursor + 1] == "0"
+                    && fields[cursor + 2] == "0"
+                    && fields[cursor + 3] == "1"
+                    && fields[cursor + 6] == "Tm"
+                {
+                    break;
+                }
+                if fields[cursor].contains(needle) {
+                    return Some((x_pt, y_pt));
+                }
+                cursor += 1;
+            }
+            index += 7;
+        }
+    }
+    None
 }
 
 fn expected_center_x_pt_v0(width_sp: u32) -> f32 {
@@ -736,6 +800,160 @@ fn pdf_renderer_title_and_heading_centering_per_line_width_v0() {
     assert!(
         (heading_alpha_x - 72.0).abs() > 0.5 && (heading_beta_x - 72.0).abs() > 0.5,
         "heading lines should not be left-margin aligned: alpha={heading_alpha_x}, beta={heading_beta_x}"
+    );
+}
+
+#[test]
+fn pdf_renderer_heading_font_hierarchy_invariants_v0() {
+    let demo_text = b"Typography Title\nAlice Bob\n2026-03-05\n\n@S {Section Heading}\n\n@s {Subsection Heading}\n\nBody paragraph text.";
+    let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept heading font demo");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let title_sizes = tf_sizes_for_line_containing_text_v0(&pdf, "(Typography Title)");
+    let section_sizes = tf_sizes_for_line_containing_text_v0(&pdf, "(Section Heading)");
+    let subsection_sizes = tf_sizes_for_line_containing_text_v0(&pdf, "(Subsection Heading)");
+    let body_sizes = tf_sizes_for_line_containing_text_v0(&pdf, "(Body paragraph text.)");
+
+    assert!(!title_sizes.is_empty(), "missing title sizes");
+    assert!(!section_sizes.is_empty(), "missing section sizes");
+    assert!(!subsection_sizes.is_empty(), "missing subsection sizes");
+    assert!(!body_sizes.is_empty(), "missing body sizes");
+
+    let title_size = title_sizes[0];
+    let section_size = section_sizes[0];
+    let subsection_size = subsection_sizes[0];
+    let body_size = body_sizes[0];
+
+    assert!((title_size - 18.0).abs() <= 0.02, "title font size mismatch: {title_size}");
+    assert!((section_size - 16.0).abs() <= 0.02, "section font size mismatch: {section_size}");
+    assert!(
+        (subsection_size - 14.0).abs() <= 0.02,
+        "subsection font size mismatch: {subsection_size}"
+    );
+    assert!((body_size - 12.0).abs() <= 0.02, "body font size mismatch: {body_size}");
+    assert!(
+        title_size > section_size && section_size > subsection_size && subsection_size > body_size,
+        "font hierarchy must be strict: title={title_size}, section={section_size}, subsection={subsection_size}, body={body_size}"
+    );
+}
+
+#[test]
+fn pdf_renderer_paragraph_rhythm_and_noindent_invariants_v0() {
+    let demo_text = b"Title\nAuthor\n2026-03-05\n\nFirst paragraph line one.\nSecond line same paragraph.\n\nSecond paragraph line.\n\n@S {Heading}\n\n~ After heading noindent line.\n\nIndented paragraph line.";
+    let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept paragraph rhythm demo");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let (first_x, first_y) = tm_position_for_line_containing_text_v0(&pdf, "(First paragraph line one.)")
+        .expect("first paragraph line one");
+    let (same_para_x, same_para_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Second line same paragraph.)")
+            .expect("same paragraph line");
+    let (second_para_x, second_para_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Second paragraph line.)")
+            .expect("second paragraph line");
+    let (heading_x, heading_y) = tm_position_for_line_containing_text_v0(&pdf, "(Heading)")
+        .expect("heading line");
+    let (after_heading_x, after_heading_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(After heading noindent line.)")
+            .expect("after heading line");
+    let (indented_x, indented_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Indented paragraph line.)")
+            .expect("indented paragraph line");
+
+    let epsilon_pt = 0.02f32;
+    assert!((first_x - 72.0).abs() <= epsilon_pt, "first paragraph x mismatch: {first_x}");
+    assert!(
+        (same_para_x - 72.0).abs() <= epsilon_pt,
+        "same paragraph line should stay non-indented: {same_para_x}"
+    );
+    assert!((second_para_x - 96.0).abs() <= epsilon_pt, "second paragraph indent mismatch: {second_para_x}");
+    assert!(
+        (after_heading_x - 72.0).abs() <= epsilon_pt,
+        "first paragraph after heading should noindent: {after_heading_x}"
+    );
+    assert!(
+        (indented_x - 96.0).abs() <= epsilon_pt,
+        "paragraph after noindent should restore indent: {indented_x}"
+    );
+    assert!(
+        (first_y - same_para_y - 14.0).abs() <= epsilon_pt,
+        "line gap mismatch inside paragraph: first_y={first_y}, same_para_y={same_para_y}"
+    );
+    assert!(
+        (same_para_y - second_para_y - 28.0).abs() <= epsilon_pt,
+        "paragraph break gap mismatch: same_para_y={same_para_y}, second_para_y={second_para_y}"
+    );
+    assert!(
+        (second_para_y - heading_y - 28.0).abs() <= epsilon_pt,
+        "paragraph->heading gap mismatch: second_para_y={second_para_y}, heading_y={heading_y}"
+    );
+    assert!(
+        (heading_y - after_heading_y - 28.0).abs() <= epsilon_pt,
+        "heading->noindent gap mismatch: heading_y={heading_y}, after_heading_y={after_heading_y}"
+    );
+    assert!(
+        (after_heading_y - indented_y - 28.0).abs() <= epsilon_pt,
+        "noindent->indented paragraph gap mismatch: after_heading_y={after_heading_y}, indented_y={indented_y}"
+    );
+    assert!((heading_x - 72.0).abs() > 0.5, "heading should be centered: {heading_x}");
+}
+
+#[test]
+fn pdf_renderer_list_rhythm_and_wrap_indent_invariants_v0() {
+    let demo_text = b"Paragraph before list.\n\n- ITEMONE lead words with deterministic wrapping content to force continuation line token WRAPONE after many repeated words in this same item.\n- ITEMTWO lead words with deterministic wrapping content to force continuation line token WRAPTWO after many repeated words in this same item.\n\nParagraph after list.";
+    let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept list rhythm demo");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let (_, before_list_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Paragraph before list.)")
+            .expect("before list paragraph");
+    let (item_one_bullet_x, item_one_y) =
+        tm_position_for_segment_substring_v0(&pdf, "(-)")
+            .expect("item one bullet position");
+    let (item_one_body_x, _) =
+        tm_position_for_segment_substring_v0(&pdf, "(ITEMONE")
+            .expect("item one body position");
+    let (item_one_wrap_x, _) =
+        tm_position_for_segment_substring_v0(&pdf, "WRAPONE")
+            .expect("item one wrap position");
+    let (item_two_bullet_x, item_two_y) =
+        tm_position_for_segment_substring_v0(&pdf, "(ITEMTWO")
+            .expect("item two body position");
+    let (item_two_wrap_x, _) =
+        tm_position_for_segment_substring_v0(&pdf, "WRAPTWO")
+            .expect("item two wrap position");
+    let (_, after_list_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Paragraph after list.)")
+            .expect("after list paragraph");
+
+    let epsilon_pt = 0.02f32;
+    assert!(
+        (28.0 - epsilon_pt..=56.0 + epsilon_pt).contains(&(before_list_y - item_one_y)),
+        "before->list top gap out of range: before_list_y={before_list_y}, item_one_y={item_one_y}"
+    );
+    assert!(
+        (item_two_y - after_list_y).abs() >= 28.0 - epsilon_pt,
+        "list->after paragraph gap must be at least one paragraph break: item_two_y={item_two_y}, after_list_y={after_list_y}"
+    );
+    assert!(
+        (item_one_bullet_x - 72.0).abs() <= epsilon_pt,
+        "item bullet column x mismatch: {item_one_bullet_x}"
+    );
+    assert!(
+        (item_one_body_x - 96.0).abs() <= epsilon_pt,
+        "item body x mismatch: {item_one_body_x}"
+    );
+    assert!(
+        (item_one_wrap_x - item_one_body_x).abs() <= epsilon_pt,
+        "item one wrap continuation should keep hanging indent: body={item_one_body_x}, wrap={item_one_wrap_x}"
+    );
+    assert!(
+        (item_two_bullet_x - 96.0).abs() <= epsilon_pt,
+        "item two body x mismatch: {item_two_bullet_x}"
+    );
+    assert!(
+        (item_two_wrap_x - item_two_bullet_x).abs() <= epsilon_pt,
+        "item two wrap continuation should keep hanging indent: body={item_two_bullet_x}, wrap={item_two_wrap_x}"
     );
 }
 

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -27,10 +27,14 @@ This final boundary stress line checks punctuation wrap rhythm: start,\emph{midd
 This second paragraph is intentionally plain text and separated by a blank line so paragraph flow,\linebreak
 first-line indentation, and width-sensitive wrapping are visible in the PDF preview with words like WWWW and iiiii.
 
+This third paragraph appears after a blank line to keep paragraph rhythm checks deterministic across heading boundaries in the PDF preview path.
+
 \subsection{Lists}
+This paragraph appears directly below the list heading so heading-to-paragraph spacing and paragraph-to-list spacing remain measurable.
+
 \begin{itemize}
-\item First bullet with \emph{emphasis} and a deliberately long sentence to force wrapping so body alignment remains stable across continuation lines in the preview renderer.
-\item Second bullet with \textbf{bold} plus another long continuation sentence that should wrap without shifting the bullet column.
+\item First bullet with \emph{emphasis} and a deliberately long sentence to force wrapping so body alignment remains stable across continuation lines in the preview renderer while keeping punctuation,wrapper boundaries near deterministic wrap points.
+\item Second bullet with \textbf{bold} plus another long continuation sentence that should wrap without shifting the bullet column and should still preserve deterministic hanging indentation between wrapped lines.
 \begin{itemize}
 \item Nested bullet item with enough words to wrap and verify one-level nested indentation remains stable in continuation lines.
 \item Another nested bullet with \emph{styled words} near punctuation,like this, to stress inline wrappers inside list content.
@@ -49,6 +53,8 @@ first-line indentation, and width-sensitive wrapping are visible in the PDF prev
 \item Ninth numbered item with a long tail to stress single-digit alignment.
 \item Tenth numbered item with a matching long tail to stress double-digit alignment.
 \end{enumerate}
+
+This paragraph follows the lists and should restore the normal paragraph indentation and vertical spacing after list bottom separation.
 
 \subsection{Quote}
 \begin{quote}


### PR DESCRIPTION
## Summary\n- add heading markers in typeset_minimal extraction for section/subsection hierarchy\n- render heading tiers with distinct sizes and centered alignment in PDF preview\n- add deterministic rhythm/spacing/list invariants and fixture stress coverage\n\n## Proof\n- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests\n- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml\n- ./scripts/proof_wasm_typeset_minimal_v0.sh\n- ./scripts/proof_wasm_fixture_gallery_v0.sh