### PR TITLE
typeset_minimal typography bundle v4: footnotes + href rendering

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -19,6 +19,9 @@ const CENTER_ENV_V0: &[u8] = b"center";
 const CENTERLINE_CONTROL_V0: &[u8] = b"centerline";
 const FLUSHRIGHT_ENV_V0: &[u8] = b"flushright";
 const RIGHTLINE_CONTROL_V0: &[u8] = b"rightline";
+const FOOTNOTE_CONTROL_V0: &[u8] = b"footnote";
+const HREF_CONTROL_V0: &[u8] = b"href";
+const FOOTNOTE_LINE_PREFIX_MARKER_V0: &[u8] = b"!f ";
 const NOINDENT_PREFIX_MARKER_V0: &[u8] = b"~ ";
 const SECTION_HEADING_PREFIX_MARKER_V0: &[u8] = b"@S ";
 const SUBSECTION_HEADING_PREFIX_MARKER_V0: &[u8] = b"@s ";
@@ -1009,6 +1012,110 @@ fn consume_meta_declaration_v0(
     Some((next, value))
 }
 
+fn maybe_emit_pending_noindent_prefix_v0(out: &mut Vec<u8>, pending_noindent: &mut bool) {
+    if !*pending_noindent {
+        return;
+    }
+    if out.is_empty()
+        || matches!(
+            out.last().copied(),
+            Some(NEWLINE_MARKER_V0 | PAGE_BREAK_MARKER_V0)
+        )
+    {
+        out.extend_from_slice(NOINDENT_PREFIX_MARKER_V0);
+        *pending_noindent = false;
+    }
+}
+
+fn is_safe_href_url_byte_v0(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric()
+        || matches!(
+            byte,
+            b':'
+                | b'/'
+                | b'?'
+                | b'#'
+                | b'['
+                | b']'
+                | b'@'
+                | b'!'
+                | b'$'
+                | b'&'
+                | b'\''
+                | b'('
+                | b')'
+                | b'*'
+                | b'+'
+                | b','
+                | b';'
+                | b'='
+                | b'%'
+                | b'.'
+                | b'_'
+                | b'-'
+                | b'~'
+        )
+}
+
+fn consume_footnote_command_v0(
+    tokens: &[TokenV0],
+    index: usize,
+    out: &mut Vec<u8>,
+    footnotes: &mut Vec<Vec<u8>>,
+) -> Option<usize> {
+    if !matches!(
+        tokens.get(index),
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == FOOTNOTE_CONTROL_V0
+    ) {
+        return None;
+    }
+    let (group_start, group_end, next) = consume_group_bounds(tokens, index + 1)?;
+    let mut footnote = Vec::<u8>::new();
+    consume_fragment_range_v0(tokens, group_start, group_end, &mut footnote, false, false)?;
+    trim_trailing_spaces(&mut footnote);
+    if footnote.is_empty() {
+        return None;
+    }
+    footnotes.push(footnote);
+    out.push(b'^');
+    out.extend_from_slice(footnotes.len().to_string().as_bytes());
+    Some(next)
+}
+
+fn consume_href_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+    if !matches!(
+        tokens.get(index),
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == HREF_CONTROL_V0
+    ) {
+        return None;
+    }
+
+    let (url_start, url_end, cursor_after_url) = consume_group_bounds(tokens, index + 1)?;
+    let mut href_url = Vec::<u8>::new();
+    for token in &tokens[url_start..url_end] {
+        match token {
+            TokenV0::Char(byte) if is_safe_href_url_byte_v0(*byte) => href_url.push(*byte),
+            _ => return None,
+        }
+    }
+    if href_url.is_empty() {
+        return None;
+    }
+
+    let (text_start, text_end, next) = consume_group_bounds(tokens, cursor_after_url)?;
+    let mut href_text = Vec::<u8>::new();
+    consume_fragment_range_v0(tokens, text_start, text_end, &mut href_text, false, false)?;
+    trim_trailing_spaces(&mut href_text);
+    if href_text.is_empty() {
+        return None;
+    }
+
+    out.push(BOLD_START_MARKER_V0);
+    out.extend_from_slice(&href_text);
+    out.push(BOLD_END_MARKER_V0);
+    Some(next)
+}
+
 fn emit_maketitle_block_v0(out: &mut Vec<u8>, meta: &TitleMetaV0) {
     let mut emitted = false;
     if let Some(title) = &meta.title {
@@ -1067,6 +1174,7 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
     }
 
     let mut body = Vec::<u8>::new();
+    let mut footnotes = Vec::<Vec<u8>>::new();
     let mut pending_noindent_after_heading = false;
     loop {
         match tokens.get(index) {
@@ -1099,21 +1207,20 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
                 pending_noindent_after_heading = false;
                 index = consume_rightline_command_v0(tokens, index, &mut body)?;
             }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == FOOTNOTE_CONTROL_V0 => {
+                maybe_emit_pending_noindent_prefix_v0(&mut body, &mut pending_noindent_after_heading);
+                index = consume_footnote_command_v0(tokens, index, &mut body, &mut footnotes)?;
+            }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == HREF_CONTROL_V0 => {
+                maybe_emit_pending_noindent_prefix_v0(&mut body, &mut pending_noindent_after_heading);
+                index = consume_href_command_v0(tokens, index, &mut body)?;
+            }
             Some(TokenV0::ControlSeq(name)) if is_heading_control_v0(name.as_slice()) => {
                 index = consume_heading_command_v0(tokens, index, &mut body)?;
                 pending_noindent_after_heading = true;
             }
             Some(_) => {
-                if pending_noindent_after_heading
-                    && (body.is_empty()
-                        || matches!(
-                            body.last().copied(),
-                            Some(NEWLINE_MARKER_V0 | PAGE_BREAK_MARKER_V0)
-                        ))
-                {
-                    body.extend_from_slice(NOINDENT_PREFIX_MARKER_V0);
-                    pending_noindent_after_heading = false;
-                }
+                maybe_emit_pending_noindent_prefix_v0(&mut body, &mut pending_noindent_after_heading);
                 index = consume_fragment_token_v0(tokens, index, &mut body, false, true)?;
             }
             None => return None,
@@ -1125,6 +1232,17 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
         .any(|token| !matches!(token, TokenV0::Space))
     {
         return None;
+    }
+
+    if !footnotes.is_empty() {
+        push_paragraph_break(&mut body);
+        for (note_index, footnote) in footnotes.iter().enumerate() {
+            body.extend_from_slice(FOOTNOTE_LINE_PREFIX_MARKER_V0);
+            body.extend_from_slice((note_index + 1).to_string().as_bytes());
+            body.push(b' ');
+            body.extend_from_slice(footnote);
+            push_newline(&mut body);
+        }
     }
 
     body = normalize_punctuation_spacing_v0(&body);

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -259,6 +259,61 @@ fn typeset_minimal_rightline_rejects_multiline_content() {
 }
 
 #[test]
+fn typeset_minimal_footnotes_and_href_emit_expected_markers() {
+    let main = b"\\documentclass{article}\\begin{document}Body text\\footnote{First note}. Visit \\href{https://example.com}{example link}.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("Body text^1. Visit {example link}."),
+        "body={text:?}"
+    );
+    assert!(text.contains("!f 1 First note"), "body={text:?}");
+}
+
+#[test]
+fn typeset_minimal_rejects_nested_footnote_content() {
+    let main = b"\\documentclass{article}\\begin{document}A\\footnote{outer \\footnote{inner}}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_href_with_unsupported_url_tokens() {
+    let main = b"\\documentclass{article}\\begin{document}\\href{\\bad}{text}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_malformed_href_missing_text_group() {
+    let main = b"\\documentclass{article}\\begin{document}\\href{https://example.com}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_keeps_multiple_footnotes_in_order() {
+    let main = b"\\documentclass{article}\\begin{document}A\\footnote{First note} B\\footnote{Second note}.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("A^1 B^2."),
+        "inline markers should be emitted in-order: body={text:?}"
+    );
+    assert!(
+        text.contains("!f 1 First note"),
+        "first footnote line missing: body={text:?}"
+    );
+    assert!(
+        text.contains("!f 2 Second note"),
+        "second footnote line missing: body={text:?}"
+    );
+}
+
+#[test]
 fn typeset_minimal_long_paragraph_wraps_to_multiple_lines() {
     let main = b"\\documentclass{article}\\begin{document}This is a long paragraph that should wrap deterministically to multiple physical lines in the minimal typeset pipeline when width-based layout is enabled and the content exceeds the configured line width for the page body area.\\end{document}";
     let result = compile_typeset(main);

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -15,6 +15,10 @@ const LIST_BODY_INDENT_PT_V0: f32 = INDENT_PT_V0;
 const ENUM_NUMBER_COLUMN_RIGHT_PT_V0: f32 = MARGIN_PT_V0 + (FONT_SIZE_PT_V0 * 1.5);
 const LEADING_PT_V0: f32 = 14.0;
 const TITLE_EXTRA_GAP_PT_V0: f32 = LEADING_PT_V0;
+const FOOTNOTE_FONT_SIZE_PT_V0: f32 = 10.0;
+const FOOTNOTE_LEADING_PT_V0: f32 = 12.0;
+const FOOTNOTE_BLOCK_GAP_PT_V0: f32 = 12.0;
+const FOOTNOTE_LINE_PREFIX_MARKER_V0: &[u8] = b"!f ";
 const NOINDENT_PREFIX_MARKER_V0: u8 = b'~';
 const SECTION_HEADING_PREFIX_MARKER_V0: &[u8] = b"@S ";
 const SUBSECTION_HEADING_PREFIX_MARKER_V0: &[u8] = b"@s ";
@@ -251,6 +255,14 @@ fn has_noindent_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
     glyphs.len() >= 2 && glyphs[0].byte == NOINDENT_PREFIX_MARKER_V0 && glyphs[1].byte == b' '
 }
 
+fn has_footnote_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() >= FOOTNOTE_LINE_PREFIX_MARKER_V0.len()
+        && glyphs[..FOOTNOTE_LINE_PREFIX_MARKER_V0.len()]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .eq(FOOTNOTE_LINE_PREFIX_MARKER_V0.iter().copied())
+}
+
 fn heading_prefix_len_v0(kind: HeadingKindV0) -> usize {
     match kind {
         HeadingKindV0::Section => SECTION_HEADING_PREFIX_MARKER_V0.len(),
@@ -333,14 +345,33 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
     out.extend_from_slice(b"BT\n");
     out.extend_from_slice(b"0 g\n");
 
-    let title_block_len = detect_title_block_len_v0(lines);
+    let footnote_block_start = lines
+        .iter()
+        .position(|line| has_footnote_line_prefix_v0(&line.glyphs))
+        .unwrap_or(lines.len());
+    let body_lines = &lines[..footnote_block_start];
+    let footnote_lines = &lines[footnote_block_start..];
+    let footnote_reserved_height_pt = if footnote_lines.is_empty() {
+        0.0
+    } else {
+        FOOTNOTE_BLOCK_GAP_PT_V0 + (footnote_lines.len() as f32 * FOOTNOTE_LEADING_PT_V0)
+    };
+    if footnote_reserved_height_pt >= (PAGE_HEIGHT_PT_V0 - (2.0 * MARGIN_PT_V0)) {
+        return None;
+    }
+    let min_body_y_pt = MARGIN_PT_V0 + footnote_reserved_height_pt;
+
+    let title_block_len = detect_title_block_len_v0(body_lines);
     let mut y = PAGE_HEIGHT_PT_V0 - MARGIN_PT_V0 - TITLE_FONT_SIZE_PT_V0;
     let mut previous_rendered_line_was_empty = false;
     let mut skip_indent_after_title_block = title_block_len > 0;
     let mut active_hang_indent_pt = 0.0f32;
     let mut active_quote_indent_pt = 0.0f32;
-    for (line_index, line) in lines.iter().enumerate() {
+    for (line_index, line) in body_lines.iter().enumerate() {
         if y < MARGIN_PT_V0 {
+            break;
+        }
+        if y < min_body_y_pt {
             break;
         }
         let quote_prefix_advance_pt = if line_index >= title_block_len {
@@ -414,7 +445,7 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
         } else {
             FONT_SIZE_PT_V0
         };
-        let next_raw_line_is_empty = lines
+        let next_raw_line_is_empty = body_lines
             .get(line_index + 1)
             .map(|next_line| next_line.glyphs.is_empty())
             .unwrap_or(false);
@@ -491,6 +522,33 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<Vec<u8>> {
         y -= LEADING_PT_V0;
         if title_block_len > 0 && line_index + 1 == title_block_len {
             y -= TITLE_EXTRA_GAP_PT_V0;
+        }
+    }
+
+    if !footnote_lines.is_empty() {
+        let mut footnote_y =
+            MARGIN_PT_V0 + footnote_reserved_height_pt - FOOTNOTE_LEADING_PT_V0;
+        for line in footnote_lines {
+            if footnote_y < MARGIN_PT_V0 {
+                return None;
+            }
+            let render_glyphs = if has_footnote_line_prefix_v0(&line.glyphs) {
+                &line.glyphs[FOOTNOTE_LINE_PREFIX_MARKER_V0.len()..]
+            } else {
+                &line.glyphs[..]
+            };
+            let segments = parse_styled_segments_v0(render_glyphs)?;
+            if !segments.is_empty() {
+                emit_styled_segments_v0(
+                    &mut out,
+                    &segments,
+                    MARGIN_PT_V0,
+                    footnote_y,
+                    FOOTNOTE_FONT_SIZE_PT_V0,
+                );
+                out.extend_from_slice(b"\n");
+            }
+            footnote_y -= FOOTNOTE_LEADING_PT_V0;
         }
     }
 

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -1671,6 +1671,96 @@ fn pdf_renderer_indents_body_paragraph_start_after_blank_line_v0() {
 }
 
 #[test]
+fn pdf_renderer_footnote_block_renders_at_page_bottom_with_small_font_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"Body marker^1 line.\n\n!f 1 Footnote text with [emph].")
+        .expect("writer should accept footnote marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    assert!(
+        pdf_text.contains("10 Tf"),
+        "footnote block should use smaller font size: {pdf_text}"
+    );
+    assert!(
+        !pdf_text.contains("!f 1"),
+        "internal footnote prefix should be hidden in pdf output: {pdf_text}"
+    );
+
+    let body_pos = tm_position_for_line_containing_text_v0(&pdf, "(Body marker^1 line.)")
+        .expect("body line position");
+    let footnote_pos =
+        tm_position_for_line_containing_text_v0(&pdf, "(1 Footnote text with ")
+            .expect("footnote line position");
+    assert!(
+        footnote_pos.1 < body_pos.1,
+        "footnote should render below body line: body_y={} footnote_y={}",
+        body_pos.1,
+        footnote_pos.1
+    );
+    assert!(
+        (72.0..=140.0).contains(&footnote_pos.1),
+        "footnote block should stay near page bottom margin: y={}",
+        footnote_pos.1
+    );
+}
+
+#[test]
+fn pdf_renderer_link_style_segments_are_emitted_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"Visit {Example link} now.")
+        .expect("writer should accept link style markers");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    assert!(
+        pdf_text.contains("/F3 12 Tf (Example link) Tj"),
+        "link segment should render in styled font: {pdf_text}"
+    );
+    assert!(
+        pdf_text.contains("/F1 12 Tf (Visit ) Tj"),
+        "leading regular segment should remain: {pdf_text}"
+    );
+    assert!(
+        pdf_text.contains("/F1 12 Tf ( now.) Tj"),
+        "trailing regular segment should remain: {pdf_text}"
+    );
+}
+
+#[test]
+fn pdf_renderer_rejects_footnote_block_overflow_v0() {
+    let mut text = Vec::<u8>::new();
+    text.extend_from_slice(b"Body line with marker^1.\n\n");
+    for index in 0..80u8 {
+        text.extend_from_slice(b"!f ");
+        text.extend_from_slice((index + 1).to_string().as_bytes());
+        text.extend_from_slice(b" Footnote overflow line.\n");
+    }
+    let xdv = write_dvi_v2_text_page_v0(&text).expect("writer should accept overflow case");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed when footnote block exceeds reserved height"
+    );
+}
+
+#[test]
+fn pdf_renderer_link_style_near_punctuation_stays_single_matrix_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"See,{Example}. Tail")
+        .expect("writer should accept styled punctuation link line");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    assert!(
+        pdf_text.contains("/F1 12 Tf (See,) Tj /F3 12 Tf (Example) Tj /F1 12 Tf (. Tail) Tj"),
+        "styled punctuation link sequence missing: {pdf_text}"
+    );
+    let tm_count = tm_count_for_line_containing_v0(&pdf, "(See,)");
+    assert_eq!(tm_count, 1, "expected single Tm for link punctuation line");
+    let max_tm_gap = max_tm_gap_pt_for_line_containing_v0(&pdf, "(See,)")
+        .expect("link punctuation line should parse");
+    assert!(
+        max_tm_gap <= 0.02,
+        "link punctuation line should not create matrix gaps: {max_tm_gap}"
+    );
+}
+
+#[test]
 fn validator_rejects_wrong_movement_amount() {
     let mut bytes = write_dvi_v2_text_page_v0(b"ABCD").expect("writer should accept ABCD");
     let right_index = bytes

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -22,6 +22,8 @@ This wrapper-punctuation adjacency line keeps boundaries tight: word\emph{mid},w
 This wrapper-stop stress keeps punctuation joins stable: word\textbf{mid}. and (\emph{mid}) and \emph{lead}, trail and lead, \emph{trail}.
 This mixed-wrapper punctuation stress keeps no giant gaps: alpha\emph{beta},gamma and alpha,\textbf{beta}gamma and (alpha\emph{beta}gamma).
 This final boundary stress line checks punctuation wrap rhythm: start,\emph{middle}. end and start \textbf{middle}, end.
+This paragraph adds a first footnote marker\footnote{First demo footnote text with \emph{inline emphasis}.} while keeping the line long enough to wrap in predictable ways for spacing checks.
+This paragraph adds a second marker\footnote{Second demo footnote text with \textbf{bold emphasis}.} and a visible link style through \href{https://example.com/minimal-demo}{CarrelTeX demo link} inside regular body flow.
 
 \subsection{Demonstration}
 This second paragraph is intentionally plain text and separated by a blank line so paragraph flow,\linebreak


### PR DESCRIPTION
## Summary\n- add typeset_minimal support for \footnote{...} markers and \href{url}{text} link-style rendering\n- render footnote block at page bottom in smaller font with fail-closed overflow behavior\n- add engine/xdv invariants and fixture stress updates for footnotes and links\n\n## Proof\n- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests\n- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml\n- ./scripts/proof_wasm_typeset_minimal_v0.sh | tail -n 6\n- ./scripts/proof_wasm_fixture_gallery_v0.sh | tail -n 10