### PR TITLE
typeset minimal v6: multipage per-page footnotes and annots

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -1,5 +1,5 @@
 use crate::{parse_dvi_v2_text_page_to_layout_v0, GlyphPlanV0, LinePlanV0, PagePlanV0, DEFAULT_LINE_ADVANCE_SP_V0};
-use std::collections::VecDeque;
+use std::collections::BTreeMap;
 
 const PDF_VERSION: &[u8] = b"%PDF-1.4\n";
 const PDF_EOF: &[u8] = b"%%EOF\n";
@@ -139,70 +139,84 @@ struct PdfLinkAnnotationV0 {
 struct PageRenderV0 {
     stream: Vec<u8>,
     annotations: Vec<PdfLinkAnnotationV0>,
-    has_footnotes: bool,
 }
 
 fn parse_styled_segments_v0(glyphs: &[GlyphPlanV0]) -> Option<Vec<PdfStyledSegmentV0>> {
     let mut style_stack = Vec::<PdfTextStyleV0>::new();
     let mut current_style = PdfTextStyleV0::Regular;
     let mut link_active = false;
+    let segments = parse_styled_segments_with_state_v0(
+        glyphs,
+        &mut style_stack,
+        &mut current_style,
+        &mut link_active,
+    )?;
+    if !style_stack.is_empty() || link_active {
+        return None;
+    }
+    Some(segments)
+}
+
+fn parse_styled_segments_with_state_v0(
+    glyphs: &[GlyphPlanV0],
+    style_stack: &mut Vec<PdfTextStyleV0>,
+    current_style: &mut PdfTextStyleV0,
+    link_active: &mut bool,
+) -> Option<Vec<PdfStyledSegmentV0>> {
     let mut segments = Vec::<PdfStyledSegmentV0>::new();
 
     for glyph in glyphs {
         let byte = glyph.byte;
         match byte {
             ITALIC_START_MARKER_V0 => {
-                style_stack.push(current_style);
-                current_style = PdfTextStyleV0::Italic;
+                style_stack.push(*current_style);
+                *current_style = PdfTextStyleV0::Italic;
             }
             ITALIC_END_MARKER_V0 => {
-                if current_style != PdfTextStyleV0::Italic {
+                if *current_style != PdfTextStyleV0::Italic {
                     return None;
                 }
-                current_style = style_stack.pop()?;
+                *current_style = style_stack.pop()?;
             }
             BOLD_START_MARKER_V0 => {
-                style_stack.push(current_style);
-                current_style = PdfTextStyleV0::Bold;
+                style_stack.push(*current_style);
+                *current_style = PdfTextStyleV0::Bold;
             }
             BOLD_END_MARKER_V0 => {
-                if current_style != PdfTextStyleV0::Bold {
+                if *current_style != PdfTextStyleV0::Bold {
                     return None;
                 }
-                current_style = style_stack.pop()?;
+                *current_style = style_stack.pop()?;
             }
             LINK_START_MARKER_V0 => {
-                if link_active {
+                if *link_active {
                     return None;
                 }
-                link_active = true;
+                *link_active = true;
             }
             LINK_END_MARKER_V0 => {
-                if !link_active {
+                if !*link_active {
                     return None;
                 }
-                link_active = false;
+                *link_active = false;
             }
             _ => {
                 let advance_pt = (glyph.advance_sp as f32) / 65_536.0;
                 if let Some(segment) = segments.last_mut() {
-                    if segment.style == current_style && segment.is_link == link_active {
+                    if segment.style == *current_style && segment.is_link == *link_active {
                         segment.glyphs.push(glyph.clone());
                         segment.advance_pt += advance_pt;
                         continue;
                     }
                 }
                 segments.push(PdfStyledSegmentV0 {
-                    style: current_style,
+                    style: *current_style,
                     glyphs: vec![glyph.clone()],
                     advance_pt,
-                    is_link: link_active,
+                    is_link: *link_active,
                 });
             }
         }
-    }
-    if !style_stack.is_empty() || link_active {
-        return None;
     }
     Some(segments)
 }
@@ -522,7 +536,51 @@ fn is_safe_link_uri_byte_v0(byte: u8) -> bool {
         )
 }
 
-fn parse_href_url_line_v0(glyphs: &[GlyphPlanV0]) -> Option<Vec<u8>> {
+fn parse_footnote_definition_line_v0(glyphs: &[GlyphPlanV0]) -> Option<(u32, Vec<GlyphPlanV0>)> {
+    if glyphs.len() < FOOTNOTE_LINE_PREFIX_MARKER_V0.len() {
+        return None;
+    }
+    if !glyphs
+        .iter()
+        .take(FOOTNOTE_LINE_PREFIX_MARKER_V0.len())
+        .map(|glyph| glyph.byte)
+        .eq(FOOTNOTE_LINE_PREFIX_MARKER_V0.iter().copied())
+    {
+        return None;
+    }
+    let marker_start = FOOTNOTE_LINE_PREFIX_MARKER_V0.len();
+    let mut cursor = marker_start;
+    let mut marker_id = 0u32;
+    let mut saw_digit = false;
+    while cursor < glyphs.len() && glyphs[cursor].byte.is_ascii_digit() {
+        marker_id = marker_id
+            .checked_mul(10)?
+            .checked_add(u32::from(glyphs[cursor].byte - b'0'))?;
+        saw_digit = true;
+        cursor += 1;
+    }
+    if !saw_digit || marker_id == 0 {
+        return None;
+    }
+    if cursor >= glyphs.len() || glyphs[cursor].byte != b' ' {
+        return None;
+    }
+    cursor += 1;
+    if cursor >= glyphs.len() {
+        return None;
+    }
+    Some((marker_id, glyphs[marker_start..].to_vec()))
+}
+
+fn has_href_url_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() >= HREF_URL_LINE_PREFIX_MARKER_V0.len()
+        && glyphs[..HREF_URL_LINE_PREFIX_MARKER_V0.len()]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .eq(HREF_URL_LINE_PREFIX_MARKER_V0.iter().copied())
+}
+
+fn parse_href_url_line_v0(glyphs: &[GlyphPlanV0]) -> Option<(u32, Vec<u8>)> {
     if glyphs.len() < HREF_URL_LINE_PREFIX_MARKER_V0.len() {
         return None;
     }
@@ -535,12 +593,16 @@ fn parse_href_url_line_v0(glyphs: &[GlyphPlanV0]) -> Option<Vec<u8>> {
         return None;
     }
     let mut cursor = HREF_URL_LINE_PREFIX_MARKER_V0.len();
+    let mut marker_id = 0u32;
     let mut saw_index_digit = false;
     while cursor < glyphs.len() && glyphs[cursor].byte.is_ascii_digit() {
+        marker_id = marker_id
+            .checked_mul(10)?
+            .checked_add(u32::from(glyphs[cursor].byte - b'0'))?;
         saw_index_digit = true;
         cursor += 1;
     }
-    if !saw_index_digit {
+    if !saw_index_digit || marker_id == 0 {
         return None;
     }
     if cursor >= glyphs.len() || glyphs[cursor].byte != b' ' {
@@ -561,7 +623,7 @@ fn parse_href_url_line_v0(glyphs: &[GlyphPlanV0]) -> Option<Vec<u8>> {
     if uri.is_empty() {
         return None;
     }
-    Some(uri)
+    Some((marker_id, uri))
 }
 
 fn collect_link_annotations_for_line_v0(
@@ -569,7 +631,10 @@ fn collect_link_annotations_for_line_v0(
     line_x_pt: f32,
     line_y_pt: f32,
     font_size_pt: f32,
-    pending_urls: &mut VecDeque<Vec<u8>>,
+    href_url_by_id: &BTreeMap<u32, Vec<u8>>,
+    next_link_id: &mut u32,
+    active_link_uri: &mut Option<Vec<u8>>,
+    link_active_at_line_end: bool,
 ) -> Option<Vec<PdfLinkAnnotationV0>> {
     let mut annotations = Vec::<PdfLinkAnnotationV0>::new();
     let mut cursor_x = line_x_pt;
@@ -582,10 +647,15 @@ fn collect_link_annotations_for_line_v0(
         if segment.is_link {
             if run_start_x.is_none() {
                 run_start_x = Some(start_x);
+                if active_link_uri.is_none() {
+                    let uri = href_url_by_id.get(next_link_id)?.clone();
+                    *next_link_id = next_link_id.checked_add(1)?;
+                    *active_link_uri = Some(uri);
+                }
             }
             run_end_x = end_x;
         } else if let Some(run_x) = run_start_x.take() {
-            let uri = pending_urls.pop_front()?;
+            let uri = active_link_uri.clone()?;
             if run_end_x <= run_x {
                 return None;
             }
@@ -599,12 +669,13 @@ fn collect_link_annotations_for_line_v0(
                 return None;
             }
             annotations.push(PdfLinkAnnotationV0 { uri, rect });
+            *active_link_uri = None;
         }
         cursor_x = end_x;
     }
 
     if let Some(run_x) = run_start_x.take() {
-        let uri = pending_urls.pop_front()?;
+        let uri = active_link_uri.clone()?;
         if run_end_x <= run_x {
             return None;
         }
@@ -618,55 +689,160 @@ fn collect_link_annotations_for_line_v0(
             return None;
         }
         annotations.push(PdfLinkAnnotationV0 { uri, rect });
+        if !link_active_at_line_end {
+            *active_link_uri = None;
+        }
+    } else if !link_active_at_line_end {
+        *active_link_uri = None;
     }
 
     Some(annotations)
 }
 
-fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<PageRenderV0> {
+fn collect_footnote_marker_ids_from_glyphs_v0(
+    glyphs: &[GlyphPlanV0],
+    marker_ids: &mut Vec<u32>,
+) -> Option<()> {
+    let mut index = 0usize;
+    while index < glyphs.len() {
+        if glyphs[index].byte != FOOTNOTE_MARKER_PREFIX_V0 {
+            index += 1;
+            continue;
+        }
+        let mut cursor = index + 1;
+        let mut marker_id = 0u32;
+        let mut saw_digit = false;
+        while cursor < glyphs.len() && glyphs[cursor].byte.is_ascii_digit() {
+            marker_id = marker_id
+                .checked_mul(10)?
+                .checked_add(u32::from(glyphs[cursor].byte - b'0'))?;
+            saw_digit = true;
+            cursor += 1;
+        }
+        if saw_digit && marker_id > 0 && !marker_ids.contains(&marker_id) {
+            marker_ids.push(marker_id);
+        }
+        index = if saw_digit { cursor } else { index + 1 };
+    }
+    Some(())
+}
+
+fn collect_page_footnote_marker_ids_v0(lines: &[LinePlanV0]) -> Option<Vec<u32>> {
+    let mut marker_ids = Vec::<u32>::new();
+    for line in lines {
+        collect_footnote_marker_ids_from_glyphs_v0(&line.glyphs, &mut marker_ids)?;
+    }
+    Some(marker_ids)
+}
+
+fn split_body_and_metadata_lines_v0(pages: &[PagePlanV0]) -> (Vec<Vec<LinePlanV0>>, Vec<LinePlanV0>) {
+    let mut body_pages = vec![Vec::<LinePlanV0>::new(); pages.len()];
+    let mut metadata_lines = Vec::<LinePlanV0>::new();
+    let mut in_metadata = false;
+    for (page_index, page) in pages.iter().enumerate() {
+        for line in &page.lines {
+            if has_footnote_line_prefix_v0(&line.glyphs) || has_href_url_line_prefix_v0(&line.glyphs) {
+                in_metadata = true;
+            }
+            if in_metadata {
+                metadata_lines.push(line.clone());
+            } else {
+                body_pages[page_index].push(line.clone());
+            }
+        }
+    }
+    while body_pages.len() > 1 {
+        let should_pop = body_pages.last().map(|lines| lines.is_empty()).unwrap_or(false);
+        if !should_pop {
+            break;
+        }
+        body_pages.pop();
+    }
+    (body_pages, metadata_lines)
+}
+
+fn parse_metadata_lines_v0(
+    metadata_lines: &[LinePlanV0],
+) -> Option<(BTreeMap<u32, Vec<Vec<GlyphPlanV0>>>, BTreeMap<u32, Vec<u8>>)> {
+    let mut footnote_defs_by_id = BTreeMap::<u32, Vec<Vec<GlyphPlanV0>>>::new();
+    let mut href_url_by_id = BTreeMap::<u32, Vec<u8>>::new();
+    let mut current_footnote_id = None::<u32>;
+    for line in metadata_lines {
+        if let Some((footnote_id, footnote_line)) = parse_footnote_definition_line_v0(&line.glyphs) {
+            if footnote_defs_by_id.contains_key(&footnote_id) {
+                return None;
+            }
+            footnote_defs_by_id.insert(footnote_id, vec![footnote_line]);
+            current_footnote_id = Some(footnote_id);
+            continue;
+        }
+        if let Some((href_id, href_url)) = parse_href_url_line_v0(&line.glyphs) {
+            if href_url_by_id.insert(href_id, href_url).is_some() {
+                return None;
+            }
+            current_footnote_id = None;
+            continue;
+        }
+        if line.glyphs.is_empty() {
+            if let Some(footnote_id) = current_footnote_id {
+                footnote_defs_by_id.get_mut(&footnote_id)?.push(Vec::new());
+            }
+            continue;
+        }
+        let footnote_id = current_footnote_id?;
+        footnote_defs_by_id.get_mut(&footnote_id)?.push(line.glyphs.clone());
+    }
+    Some((footnote_defs_by_id, href_url_by_id))
+}
+
+fn build_page_content_stream_v0(
+    lines: &[LinePlanV0],
+    footnote_defs_by_id: &BTreeMap<u32, Vec<Vec<GlyphPlanV0>>>,
+    href_url_by_id: &BTreeMap<u32, Vec<u8>>,
+    next_link_id: &mut u32,
+    allow_title_block: bool,
+) -> Option<PageRenderV0> {
     let mut out = Vec::new();
     out.extend_from_slice(b"BT\n");
     out.extend_from_slice(b"0 g\n");
 
-    let mut pending_link_urls = VecDeque::<Vec<u8>>::new();
-    let mut render_lines = Vec::<LinePlanV0>::new();
-    for line in lines {
-        if let Some(url) = parse_href_url_line_v0(&line.glyphs) {
-            pending_link_urls.push_back(url);
-            continue;
-        }
-        render_lines.push(line.clone());
+    let page_footnote_ids = collect_page_footnote_marker_ids_v0(lines)?;
+    let mut footnote_line_count = 0usize;
+    for footnote_id in &page_footnote_ids {
+        let Some(footnote_lines) = footnote_defs_by_id.get(footnote_id) else { return None; };
+        footnote_line_count = footnote_line_count.checked_add(footnote_lines.len())?;
     }
-
-    let footnote_block_start = render_lines
-        .iter()
-        .position(|line| has_footnote_line_prefix_v0(&line.glyphs))
-        .unwrap_or(render_lines.len());
-    let body_lines = &render_lines[..footnote_block_start];
-    let footnote_lines = &render_lines[footnote_block_start..];
-    let footnote_reserved_height_pt = if footnote_lines.is_empty() {
+    let footnote_reserved_height_pt = if footnote_line_count == 0 {
         0.0
     } else {
-        FOOTNOTE_BLOCK_GAP_PT_V0 + (footnote_lines.len() as f32 * FOOTNOTE_LEADING_PT_V0)
+        FOOTNOTE_BLOCK_GAP_PT_V0 + (footnote_line_count as f32 * FOOTNOTE_LEADING_PT_V0)
     };
     if footnote_reserved_height_pt >= (PAGE_HEIGHT_PT_V0 - (2.0 * MARGIN_PT_V0)) {
         return None;
     }
     let min_body_y_pt = MARGIN_PT_V0 + footnote_reserved_height_pt;
 
-    let title_block_len = detect_title_block_len_v0(body_lines);
+    let title_block_len = if allow_title_block {
+        detect_title_block_len_v0(lines)
+    } else {
+        0
+    };
     let mut y = PAGE_HEIGHT_PT_V0 - MARGIN_PT_V0 - TITLE_FONT_SIZE_PT_V0;
     let mut previous_rendered_line_was_empty = false;
     let mut skip_indent_after_title_block = title_block_len > 0;
     let mut active_hang_indent_pt = 0.0f32;
     let mut active_quote_indent_pt = 0.0f32;
     let mut annotations = Vec::<PdfLinkAnnotationV0>::new();
-    for (line_index, line) in body_lines.iter().enumerate() {
+    let mut style_stack = Vec::<PdfTextStyleV0>::new();
+    let mut current_style = PdfTextStyleV0::Regular;
+    let mut link_active = false;
+    let mut active_link_uri = None::<Vec<u8>>;
+    for (line_index, line) in lines.iter().enumerate() {
         if y < MARGIN_PT_V0 {
             break;
         }
         if y < min_body_y_pt {
-            break;
+            return None;
         }
         let quote_prefix_advance_pt = if line_index >= title_block_len {
             detect_quote_prefix_advance_pt_v0(&line.glyphs)
@@ -727,7 +903,12 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<PageRenderV0> {
             render_glyphs_base
         };
 
-        let segments = parse_styled_segments_v0(render_glyphs)?;
+        let Some(segments) = parse_styled_segments_with_state_v0(
+            render_glyphs,
+            &mut style_stack,
+            &mut current_style,
+            &mut link_active,
+        ) else { return None; };
         let render_segments = split_superscript_segments_v0(&segments);
         let line_is_empty = render_segments.is_empty();
         let in_title_block = title_block_len > 0 && line_index < title_block_len;
@@ -740,7 +921,7 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<PageRenderV0> {
         } else {
             FONT_SIZE_PT_V0
         };
-        let next_raw_line_is_empty = body_lines
+        let next_raw_line_is_empty = lines
             .get(line_index + 1)
             .map(|next_line| next_line.glyphs.is_empty())
             .unwrap_or(false);
@@ -794,7 +975,9 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<PageRenderV0> {
             if let Some(prefix) = list_prefix {
                 let display_prefix_glyphs = &render_glyphs_base
                     [prefix.display_start..prefix.display_start + prefix.display_len];
-                let display_prefix_segments = parse_styled_segments_v0(display_prefix_glyphs)?;
+                let Some(display_prefix_segments) = parse_styled_segments_v0(display_prefix_glyphs) else {
+                    return None;
+                };
                 let prefix_width_pt = glyphs_advance_pt_v0(display_prefix_glyphs);
                 let prefix_x = match prefix.kind {
                     ListPrefixKindV0::Itemize => MARGIN_PT_V0 + prefix.leading_advance_pt,
@@ -809,7 +992,10 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<PageRenderV0> {
                 line_x,
                 y,
                 font_size_pt,
-                &mut pending_link_urls,
+                href_url_by_id,
+                next_link_id,
+                &mut active_link_uri,
+                link_active,
             )?;
             annotations.append(&mut line_annotations);
             let has_superscript = render_segments.iter().any(|segment| segment.superscript);
@@ -838,71 +1024,75 @@ fn build_page_content_stream_v0(lines: &[LinePlanV0]) -> Option<PageRenderV0> {
             y -= TITLE_EXTRA_GAP_PT_V0;
         }
     }
-
-    if !footnote_lines.is_empty() {
-        let mut footnote_y =
-            MARGIN_PT_V0 + footnote_reserved_height_pt - FOOTNOTE_LEADING_PT_V0;
-        for line in footnote_lines {
-            if footnote_y < MARGIN_PT_V0 {
-                return None;
-            }
-            let render_glyphs = if has_footnote_line_prefix_v0(&line.glyphs) {
-                &line.glyphs[FOOTNOTE_LINE_PREFIX_MARKER_V0.len()..]
-            } else {
-                &line.glyphs[..]
-            };
-            let segments = parse_styled_segments_v0(render_glyphs)?;
-            if !segments.is_empty() {
-                let render_segments = split_superscript_segments_v0(&segments);
-                let has_superscript = render_segments.iter().any(|segment| segment.superscript);
-                if has_superscript {
-                    emit_render_segments_with_superscript_v0(
-                        &mut out,
-                        &render_segments,
-                        MARGIN_PT_V0,
-                        footnote_y,
-                        FOOTNOTE_FONT_SIZE_PT_V0,
-                    );
-                } else {
-                    emit_styled_segments_v0(
-                        &mut out,
-                        &segments,
-                        MARGIN_PT_V0,
-                        footnote_y,
-                        FOOTNOTE_FONT_SIZE_PT_V0,
-                    );
-                }
-                out.extend_from_slice(b"\n");
-            }
-            footnote_y -= FOOTNOTE_LEADING_PT_V0;
-        }
+    if !style_stack.is_empty() || link_active {
+        return None;
+    }
+    if active_link_uri.is_some() {
+        return None;
     }
 
-    if !pending_link_urls.is_empty() {
-        return None;
+    if footnote_line_count > 0 {
+        let mut footnote_y =
+            MARGIN_PT_V0 + footnote_reserved_height_pt - FOOTNOTE_LEADING_PT_V0;
+        for footnote_id in &page_footnote_ids {
+            for footnote_line in footnote_defs_by_id.get(footnote_id)? {
+                if footnote_y < MARGIN_PT_V0 {
+                    return None;
+                }
+                let Some(segments) = parse_styled_segments_v0(footnote_line) else { return None; };
+                if !segments.is_empty() {
+                    let render_segments = split_superscript_segments_v0(&segments);
+                    let has_superscript = render_segments.iter().any(|segment| segment.superscript);
+                    if has_superscript {
+                        emit_render_segments_with_superscript_v0(
+                            &mut out,
+                            &render_segments,
+                            MARGIN_PT_V0,
+                            footnote_y,
+                            FOOTNOTE_FONT_SIZE_PT_V0,
+                        );
+                    } else {
+                        emit_styled_segments_v0(
+                            &mut out,
+                            &segments,
+                            MARGIN_PT_V0,
+                            footnote_y,
+                            FOOTNOTE_FONT_SIZE_PT_V0,
+                        );
+                    }
+                    out.extend_from_slice(b"\n");
+                }
+                footnote_y -= FOOTNOTE_LEADING_PT_V0;
+            }
+        }
     }
 
     out.extend_from_slice(b"ET\n");
     Some(PageRenderV0 {
         stream: out,
         annotations,
-        has_footnotes: !footnote_lines.is_empty(),
     })
 }
 
 fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
-    let mut page_renders = Vec::<PageRenderV0>::with_capacity(pages.len());
-    for page in pages {
-        let Some(rendered) = build_page_content_stream_v0(&page.lines) else {
-            return Vec::new();
-        };
+    let (body_pages, metadata_lines) = split_body_and_metadata_lines_v0(pages);
+    let Some((footnote_defs_by_id, href_url_by_id)) = parse_metadata_lines_v0(&metadata_lines) else {
+        return Vec::new();
+    };
+
+    let mut next_link_id = 1u32;
+    let mut page_renders = Vec::<PageRenderV0>::with_capacity(body_pages.len());
+    for (page_index, body_lines) in body_pages.iter().enumerate() {
+        let Some(rendered) = build_page_content_stream_v0(
+            body_lines,
+            &footnote_defs_by_id,
+            &href_url_by_id,
+            &mut next_link_id,
+            page_index == 0,
+        ) else { return Vec::new(); };
         page_renders.push(rendered);
     }
-    if page_renders.len() > 1
-        && page_renders
-            .iter()
-            .any(|page| page.has_footnotes || !page.annotations.is_empty())
-    {
+    if usize::try_from(next_link_id.saturating_sub(1)).ok() != Some(href_url_by_id.len()) {
         return Vec::new();
     }
 
@@ -914,7 +1104,7 @@ fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
     // next: annotation objects (if any)
     // next: annotation action objects (if any)
     // last: Font objects (regular/italic/bold)
-    let page_count = pages.len() as u32;
+    let page_count = page_renders.len() as u32;
     let total_annotations = page_renders
         .iter()
         .map(|page| u32::try_from(page.annotations.len()).unwrap_or(0))

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -500,6 +500,112 @@ fn parse_first_link_rect_v0(pdf: &[u8]) -> Option<[f32; 4]> {
     None
 }
 
+fn count_pdf_page_objects_v0(pdf: &[u8]) -> usize {
+    String::from_utf8_lossy(pdf)
+        .matches("/Type /Page /Parent")
+        .count()
+}
+
+fn parse_pdf_object_body_v0(pdf: &[u8], id: u32) -> Option<String> {
+    let text = String::from_utf8_lossy(pdf);
+    let start_token = format!("{id} 0 obj\n");
+    let start = text.find(&start_token)? + start_token.len();
+    let end = text[start..].find("\nendobj\n")? + start;
+    Some(text[start..end].to_string())
+}
+
+fn parse_pdf_ref_ids_v0(body: &str, key: &str) -> Vec<u32> {
+    let marker = format!("{key} [");
+    let Some(start) = body.find(&marker) else {
+        return Vec::new();
+    };
+    let values_start = start + marker.len();
+    let Some(values_end_rel) = body[values_start..].find(']') else {
+        return Vec::new();
+    };
+    body[values_start..values_start + values_end_rel]
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .chunks(3)
+        .filter_map(|chunk| match chunk {
+            [id, "0", "R"] => id.parse::<u32>().ok(),
+            _ => None,
+        })
+        .collect()
+}
+
+fn parse_pdf_annotation_action_id_v0(body: &str) -> Option<u32> {
+    let marker = "/A ";
+    let start = body.find(marker)? + marker.len();
+    let fields = body[start..].split_whitespace().collect::<Vec<_>>();
+    if fields.len() < 3 || fields[1] != "0" || fields[2] != "R" {
+        return None;
+    }
+    fields[0].parse::<u32>().ok()
+}
+
+fn parse_pdf_action_uri_v0(body: &str) -> Option<String> {
+    let marker = "/URI (";
+    let start = body.find(marker)? + marker.len();
+    let end = body[start..].find(')')? + start;
+    Some(body[start..end].to_string())
+}
+
+fn parse_pdf_annotation_rect_v0(body: &str) -> Option<[f32; 4]> {
+    let marker = "/Rect [";
+    let start = body.find(marker)? + marker.len();
+    let end = body[start..].find(']')? + start;
+    let values = body[start..end]
+        .split_whitespace()
+        .filter_map(|value| value.parse::<f32>().ok())
+        .collect::<Vec<_>>();
+    if values.len() != 4 {
+        return None;
+    }
+    Some([values[0], values[1], values[2], values[3]])
+}
+
+fn tm_position_for_line_containing_text_in_body_v0(body: &str, needle: &str) -> Option<(f32, f32)> {
+    for line in body.lines() {
+        if !line.contains(needle) || !line.contains(" Tm ") {
+            continue;
+        }
+        let fields = line.split_whitespace().collect::<Vec<_>>();
+        let mut index = 0usize;
+        while index + 6 < fields.len() {
+            let is_tm = fields[index] == "1"
+                && fields[index + 1] == "0"
+                && fields[index + 2] == "0"
+                && fields[index + 3] == "1"
+                && fields[index + 6] == "Tm";
+            if !is_tm {
+                index += 1;
+                continue;
+            }
+            let x_pt = fields[index + 4].parse::<f32>().ok()?;
+            let y_pt = fields[index + 5].parse::<f32>().ok()?;
+            let mut cursor = index + 7;
+            while cursor < fields.len() {
+                if cursor + 6 < fields.len()
+                    && fields[cursor] == "1"
+                    && fields[cursor + 1] == "0"
+                    && fields[cursor + 2] == "0"
+                    && fields[cursor + 3] == "1"
+                    && fields[cursor + 6] == "Tm"
+                {
+                    break;
+                }
+                if fields[cursor].contains(needle) {
+                    return Some((x_pt, y_pt));
+                }
+                cursor += 1;
+            }
+            index += 7;
+        }
+    }
+    None
+}
+
 fn expected_center_x_pt_v0(width_sp: u32) -> f32 {
     let width_pt = (width_sp as f32) / 65_536.0;
     ((612.0 - width_pt) * 0.5).clamp(72.0, 612.0 - 72.0)
@@ -1748,7 +1854,13 @@ fn pdf_renderer_link_style_segments_are_emitted_v0() {
 #[test]
 fn pdf_renderer_rejects_footnote_block_overflow_v0() {
     let mut text = Vec::<u8>::new();
-    text.extend_from_slice(b"Body line with marker^1.\n\n");
+    text.extend_from_slice(b"Body line with markers ");
+    for index in 0..80u8 {
+        text.extend_from_slice(b"^");
+        text.extend_from_slice((index + 1).to_string().as_bytes());
+        text.push(b' ');
+    }
+    text.extend_from_slice(b"\n\n");
     for index in 0..80u8 {
         text.extend_from_slice(b"!f ");
         text.extend_from_slice((index + 1).to_string().as_bytes());
@@ -1817,6 +1929,86 @@ fn pdf_renderer_footnote_marker_uses_smaller_raised_typography_v0() {
     assert!(
         pdf_text.contains("4 Ts /F1 8 Tf (^1) Tj"),
         "footnote marker should use positive text rise for superscript effect: {pdf_text}"
+    );
+}
+
+#[test]
+fn pdf_renderer_rejects_unknown_footnote_marker_id_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"Body marker^2 line.\n\n!f 1 1 Known footnote.")
+        .expect("writer should accept marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed on unknown footnote marker id"
+    );
+}
+
+#[test]
+fn pdf_renderer_multipage_footnotes_and_annots_associate_per_page_v0() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"Page1 line with <{First link}> and marker^1.\x0cPage2 line with <{Second link}> and marker^2.\n\n!f 1 First page footnote text.\n!f 2 Second page footnote text.\n!u 1 https://example.com/page1\n!u 2 https://example.com/page2",
+    )
+    .expect("writer should accept multipage marker data");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    assert_eq!(count_pdf_page_objects_v0(&pdf), 2, "expected two page objects");
+
+    let page_one = parse_pdf_object_body_v0(&pdf, 3).expect("page 1 object");
+    let page_two = parse_pdf_object_body_v0(&pdf, 4).expect("page 2 object");
+    let page_one_annots = parse_pdf_ref_ids_v0(&page_one, "/Annots");
+    let page_two_annots = parse_pdf_ref_ids_v0(&page_two, "/Annots");
+    assert_eq!(page_one_annots.len(), 1, "page 1 should have one annotation");
+    assert_eq!(page_two_annots.len(), 1, "page 2 should have one annotation");
+    assert_ne!(
+        page_one_annots[0], page_two_annots[0],
+        "each page should reference its own annotation object"
+    );
+
+    let annotation_one = parse_pdf_object_body_v0(&pdf, page_one_annots[0]).expect("annotation one");
+    let annotation_two = parse_pdf_object_body_v0(&pdf, page_two_annots[0]).expect("annotation two");
+    let action_one = parse_pdf_annotation_action_id_v0(&annotation_one).expect("annotation one action");
+    let action_two = parse_pdf_annotation_action_id_v0(&annotation_two).expect("annotation two action");
+    let action_one_body = parse_pdf_object_body_v0(&pdf, action_one).expect("action one body");
+    let action_two_body = parse_pdf_object_body_v0(&pdf, action_two).expect("action two body");
+    assert_eq!(
+        parse_pdf_action_uri_v0(&action_one_body).as_deref(),
+        Some("https://example.com/page1"),
+        "page 1 annotation should target page 1 href"
+    );
+    assert_eq!(
+        parse_pdf_action_uri_v0(&action_two_body).as_deref(),
+        Some("https://example.com/page2"),
+        "page 2 annotation should target page 2 href"
+    );
+
+    for rect in [
+        parse_pdf_annotation_rect_v0(&annotation_one).expect("annotation one rect"),
+        parse_pdf_annotation_rect_v0(&annotation_two).expect("annotation two rect"),
+    ] {
+        assert!(rect[2] > rect[0], "annotation width must be positive: {rect:?}");
+        assert!(rect[3] > rect[1], "annotation height must be positive: {rect:?}");
+        assert!(
+            rect[0] >= 0.0 && rect[1] >= 0.0 && rect[2] <= 612.0 && rect[3] <= 792.0,
+            "annotation rect must stay within page bounds: {rect:?}"
+        );
+    }
+
+    let stream_one = parse_pdf_object_body_v0(&pdf, 5).expect("stream one body");
+    let stream_two = parse_pdf_object_body_v0(&pdf, 6).expect("stream two body");
+    let page_one_footnote_y =
+        tm_position_for_line_containing_text_in_body_v0(&stream_one, "(1")
+            .expect("page one footnote line")
+            .1;
+    let page_two_footnote_y =
+        tm_position_for_line_containing_text_in_body_v0(&stream_two, "(2")
+            .expect("page two footnote line")
+            .1;
+    assert!(
+        (72.0..=140.0).contains(&page_one_footnote_y),
+        "page 1 footnote should render near bottom: y={page_one_footnote_y}"
+    );
+    assert!(
+        (72.0..=140.0).contains(&page_two_footnote_y),
+        "page 2 footnote should render near bottom: y={page_two_footnote_y}"
     );
 }
 

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -15,19 +15,22 @@
 
 \section{Overview}
 Hello, world. This first paragraph includes \emph{emphasis} and \textbf{bold} in supported inline forms.
-This gap-stress sentence keeps a styled run in the middle: alpha beta gamma \emph{delta epsilon} zeta eta theta and \textbf{iota kappa} lambda.
-This inline boundary stress keeps wrappers tight: word\emph{mid}word and word \emph{lead} trail, \textbf{bold}!
-This punctuation stress keeps spacing stable at boundaries: edge,\emph{core}, tail and edge \textbf{core}!
-This wrapper-punctuation adjacency line keeps boundaries tight: word\emph{mid},word and word,\emph{mid}word.
-This wrapper-stop stress keeps punctuation joins stable: word\textbf{mid}. and (\emph{mid}) and \emph{lead}, trail and lead, \emph{trail}.
-This mixed-wrapper punctuation stress keeps no giant gaps: alpha\emph{beta},gamma and alpha,\textbf{beta}gamma and (alpha\emph{beta}gamma).
-This final boundary stress line checks punctuation wrap rhythm: start,\emph{middle}. end and start \textbf{middle}, end.
-This paragraph adds a first footnote marker\footnote{First demo footnote text with \emph{inline emphasis}.} while keeping the line long enough to wrap in predictable ways for spacing checks.
-This paragraph adds a second marker\footnote{Second demo footnote text with \textbf{bold emphasis}.} and a visible link style through \href{https://example.com}{CarrelTeX demo link},right beside punctuation in regular body flow.
+This paragraph adds a first footnote marker\footnote{First demo footnote text with \emph{inline emphasis}.} and a visible link style through \href{https://example.com/page1}{CarrelTeX demo link page one},right beside punctuation in regular body flow.
+
+\pagebreak
 
 \subsection{Demonstration}
+This gap-stress line keeps a styled run: alpha \emph{delta} omega and \textbf{iota} lambda.
+This inline boundary stress keeps wrappers tight: word\emph{mid}word and word \emph{lead} trail.
+This punctuation stress keeps spacing stable: edge,\emph{core}, tail and edge \textbf{core}!
+This wrapper adjacency stress keeps boundaries tight: word\emph{mid},word and word,\emph{mid}word.
+This wrapper-stop stress keeps joins stable: word\textbf{mid}. and (\emph{mid}) and \emph{lead}, trail.
+This mixed-wrapper stress keeps no giant gaps: alpha\emph{beta},gamma and alpha,\textbf{beta}gamma.
+This final boundary stress checks rhythm: start,\emph{middle}. end and start \textbf{middle}, end.
 This second paragraph is intentionally plain text and separated by a blank line so paragraph flow,\linebreak
 first-line indentation, and width-sensitive wrapping are visible in the PDF preview with words like WWWW and iiiii.
+This paragraph adds a second marker\footnote{Second demo footnote text with \textbf{bold emphasis}.} and a second visible link style through \href{https://example.com/page2}{CarrelTeX demo link page two},right beside punctuation in regular body flow.
+\pagebreak
 
 This third paragraph appears after a blank line to keep paragraph rhythm checks deterministic across heading boundaries in the PDF preview path.
 

--- a/scripts/wasm_typeset_minimal_v0_emit_pdf.mjs
+++ b/scripts/wasm_typeset_minimal_v0_emit_pdf.mjs
@@ -11,6 +11,93 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, '..');
 const MAX_SEGMENT_TM_GAP_PT_V0 = 24.0;
+const PAGE_WIDTH_PT_V0 = 612.0;
+const PAGE_HEIGHT_PT_V0 = 792.0;
+const MARGIN_PT_V0 = 72.0;
+
+function parsePdfObjectsV0(pdfBytes) {
+  const text = Buffer.from(pdfBytes).toString('utf8');
+  const objects = [];
+  const objectPattern = /(\d+)\s+0\s+obj\n([\s\S]*?)\nendobj\n/g;
+  let match;
+  while ((match = objectPattern.exec(text)) !== null) {
+    objects.push({ id: Number.parseInt(match[1], 10), body: match[2] });
+  }
+  return objects;
+}
+
+function parsePdfRefIdsV0(body, key) {
+  const marker = `${key} [`;
+  const start = body.indexOf(marker);
+  if (start < 0) return [];
+  const valuesStart = start + marker.length;
+  const valuesEnd = body.indexOf(']', valuesStart);
+  if (valuesEnd < 0) return [];
+  const fields = body.slice(valuesStart, valuesEnd).trim().split(/\s+/).filter(Boolean);
+  const ids = [];
+  for (let index = 0; index + 2 < fields.length; index += 3) {
+    if (fields[index + 1] === '0' && fields[index + 2] === 'R') {
+      const id = Number.parseInt(fields[index], 10);
+      if (Number.isFinite(id)) ids.push(id);
+    }
+  }
+  return ids;
+}
+
+function parsePdfAnnotationActionIdV0(body) {
+  const match = body.match(/\/A\s+(\d+)\s+0\s+R/);
+  if (!match) return null;
+  const id = Number.parseInt(match[1], 10);
+  return Number.isFinite(id) ? id : null;
+}
+
+function parsePdfActionUriV0(body) {
+  const match = body.match(/\/URI \(([^)]*)\)/);
+  return match ? match[1] : null;
+}
+
+function parsePdfAnnotationRectV0(body) {
+  const match = body.match(/\/Rect \[([^\]]+)\]/);
+  if (!match) return null;
+  const values = match[1]
+    .trim()
+    .split(/\s+/)
+    .map((value) => Number.parseFloat(value))
+    .filter((value) => Number.isFinite(value));
+  if (values.length !== 4) return null;
+  return values;
+}
+
+function extractPageXObjectIdsV0(objects) {
+  const pageObjects = objects.filter((obj) => obj.body.includes('/Type /Page /Parent'));
+  return pageObjects.map((obj) => obj.id);
+}
+
+function parsePageContentStreamIdV0(pageBody) {
+  const match = pageBody.match(/\/Contents\s+(\d+)\s+0\s+R/);
+  if (!match) return null;
+  const id = Number.parseInt(match[1], 10);
+  return Number.isFinite(id) ? id : null;
+}
+
+function parseTmYForNeedleV0(streamBody, needle) {
+  for (const line of streamBody.split('\n')) {
+    if (!line.includes(' Tm ') || !line.includes(needle)) continue;
+    const fields = line.trim().split(/\s+/).filter(Boolean);
+    for (let index = 0; index + 6 < fields.length; index += 1) {
+      const isTm =
+        fields[index] === '1' &&
+        fields[index + 1] === '0' &&
+        fields[index + 2] === '0' &&
+        fields[index + 3] === '1' &&
+        fields[index + 6] === 'Tm';
+      if (!isTm) continue;
+      const y = Number.parseFloat(fields[index + 5]);
+      if (Number.isFinite(y)) return y;
+    }
+  }
+  return null;
+}
 
 function maxTmGapPtV0(pdfBytes) {
   const text = Buffer.from(pdfBytes).toString('utf8');
@@ -144,6 +231,115 @@ async function run() {
   }
   summary.max_segment_tm_gap_pt = Number(maxTmGapPt.toFixed(2));
   summary.max_segment_tm_gap_threshold_pt = MAX_SEGMENT_TM_GAP_PT_V0;
+
+  const objects = parsePdfObjectsV0(pdfBytes);
+  const objectById = new Map(objects.map((obj) => [obj.id, obj.body]));
+  const pageIds = extractPageXObjectIdsV0(objects);
+  if (pageIds.length < 2) {
+    throw new Error(`expected at least 2 PDF pages, got ${pageIds.length}`);
+  }
+
+  const pageOneBody = objectById.get(pageIds[0]);
+  const pageTwoBody = objectById.get(pageIds[1]);
+  if (!pageOneBody || !pageTwoBody) {
+    throw new Error('expected page objects for first two pages');
+  }
+  const pageOneAnnotIds = parsePdfRefIdsV0(pageOneBody, '/Annots');
+  const pageTwoAnnotIds = parsePdfRefIdsV0(pageTwoBody, '/Annots');
+  if (pageOneAnnotIds.length === 0 || pageTwoAnnotIds.length === 0) {
+    throw new Error('expected non-empty /Annots for page 1 and page 2');
+  }
+
+  const pageOneUris = [];
+  for (const annotId of pageOneAnnotIds) {
+    const annotBody = objectById.get(annotId);
+    if (!annotBody || !annotBody.includes('/Subtype /Link')) {
+      throw new Error(`page 1 annotation ${annotId} missing /Subtype /Link`);
+    }
+    const actionId = parsePdfAnnotationActionIdV0(annotBody);
+    if (!actionId) throw new Error(`page 1 annotation ${annotId} missing action`);
+    const actionBody = objectById.get(actionId);
+    if (!actionBody) throw new Error(`page 1 action ${actionId} missing`);
+    const uri = parsePdfActionUriV0(actionBody);
+    if (!uri) throw new Error(`page 1 action ${actionId} missing URI`);
+    pageOneUris.push(uri);
+    const rect = parsePdfAnnotationRectV0(annotBody);
+    if (!rect) throw new Error(`page 1 annotation ${annotId} missing rect`);
+    if (
+      !(rect[2] > rect[0]) ||
+      !(rect[3] > rect[1]) ||
+      rect[0] < 0.0 ||
+      rect[1] < 0.0 ||
+      rect[2] > PAGE_WIDTH_PT_V0 ||
+      rect[3] > PAGE_HEIGHT_PT_V0
+    ) {
+      throw new Error(`page 1 annotation ${annotId} has invalid rect`);
+    }
+  }
+
+  const pageTwoUris = [];
+  for (const annotId of pageTwoAnnotIds) {
+    const annotBody = objectById.get(annotId);
+    if (!annotBody || !annotBody.includes('/Subtype /Link')) {
+      throw new Error(`page 2 annotation ${annotId} missing /Subtype /Link`);
+    }
+    const actionId = parsePdfAnnotationActionIdV0(annotBody);
+    if (!actionId) throw new Error(`page 2 annotation ${annotId} missing action`);
+    const actionBody = objectById.get(actionId);
+    if (!actionBody) throw new Error(`page 2 action ${actionId} missing`);
+    const uri = parsePdfActionUriV0(actionBody);
+    if (!uri) throw new Error(`page 2 action ${actionId} missing URI`);
+    pageTwoUris.push(uri);
+    const rect = parsePdfAnnotationRectV0(annotBody);
+    if (!rect) throw new Error(`page 2 annotation ${annotId} missing rect`);
+    if (
+      !(rect[2] > rect[0]) ||
+      !(rect[3] > rect[1]) ||
+      rect[0] < 0.0 ||
+      rect[1] < 0.0 ||
+      rect[2] > PAGE_WIDTH_PT_V0 ||
+      rect[3] > PAGE_HEIGHT_PT_V0
+    ) {
+      throw new Error(`page 2 annotation ${annotId} has invalid rect`);
+    }
+  }
+  if (!pageOneUris.every((uri) => uri === 'https://example.com/page1')) {
+    throw new Error(`expected page 1 URIs to be page1 links, got ${JSON.stringify(pageOneUris)}`);
+  }
+  if (!pageTwoUris.every((uri) => uri === 'https://example.com/page2')) {
+    throw new Error(`expected page 2 URIs to be page2 links, got ${JSON.stringify(pageTwoUris)}`);
+  }
+
+  const streamOneId = parsePageContentStreamIdV0(pageOneBody);
+  const streamTwoId = parsePageContentStreamIdV0(pageTwoBody);
+  if (!streamOneId || !streamTwoId) {
+    throw new Error('expected content streams for first two pages');
+  }
+  const streamOneBody = objectById.get(streamOneId);
+  const streamTwoBody = objectById.get(streamTwoId);
+  if (!streamOneBody || !streamTwoBody) {
+    throw new Error('missing content stream object bodies');
+  }
+  const footnoteOneY = parseTmYForNeedleV0(streamOneBody, '(1');
+  const footnoteTwoY = parseTmYForNeedleV0(streamTwoBody, '(2');
+  if (footnoteOneY == null || footnoteTwoY == null) {
+    throw new Error('expected footnote lines on both page 1 and page 2');
+  }
+  if (
+    !(footnoteOneY >= MARGIN_PT_V0 && footnoteOneY <= 140.0) ||
+    !(footnoteTwoY >= MARGIN_PT_V0 && footnoteTwoY <= 140.0)
+  ) {
+    throw new Error(
+      `expected page footnotes near bottom margin, got y1=${footnoteOneY}, y2=${footnoteTwoY}`,
+    );
+  }
+
+  summary.pdf_page_count = pageIds.length;
+  summary.page_one_annotation_count = pageOneAnnotIds.length;
+  summary.page_two_annotation_count = pageTwoAnnotIds.length;
+  summary.page_one_footnote_y_pt = Number(footnoteOneY.toFixed(2));
+  summary.page_two_footnote_y_pt = Number(footnoteTwoY.toFixed(2));
+
   await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
 
   console.log(`PASS: wasm typeset minimal emitted ${xdvPath}`);
@@ -153,6 +349,9 @@ async function run() {
   console.log(`PASS: pdf_sha256 ${summary.pdf_sha256}`);
   console.log(
     `PASS: max_segment_tm_gap_pt ${summary.max_segment_tm_gap_pt.toFixed(2)} <= ${MAX_SEGMENT_TM_GAP_PT_V0.toFixed(2)}`,
+  );
+  console.log(
+    `PASS: multipage+annots+footnotes pages=${summary.pdf_page_count} p1_annots=${summary.page_one_annotation_count} p2_annots=${summary.page_two_annotation_count}`,
   );
 }
 


### PR DESCRIPTION
## Summary
- add multipage-aware PDF rendering in crates/carreltex-xdv with per-page footnote block association by marker id
- attach href link annotations to the page where each link run is rendered, with deterministic object ordering
- add multipage invariants/tests for page count, per-page annots mapping, per-page footnote placement, and fail-closed unknown marker behavior
- update minimal typeset fixture and wasm minimal proof checks for multipage footnotes/annots invariants

## Proof
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml
- ./scripts/proof_wasm_typeset_minimal_v0.sh
- ./scripts/proof_wasm_fixture_gallery_v0.sh