### PR TITLE
gallery: integrate per-case ondemand fixedpoint v1

### DIFF
--- a/scripts/ondemand_fixedpoint_v0_proof.mjs
+++ b/scripts/ondemand_fixedpoint_v0_proof.mjs
@@ -148,12 +148,13 @@ function countStatusesV0(statuses) {
     OK: 0,
     NI: 0,
     INVALID: 0,
+    MISMATCH: 0,
     FAIL: 0,
     OTHER: 0,
   };
   for (const statusEntry of statuses) {
     const status = statusEntry?.status;
-    if (status === 'OK' || status === 'NI' || status === 'INVALID' || status === 'FAIL') {
+    if (status === 'OK' || status === 'NI' || status === 'INVALID' || status === 'MISMATCH' || status === 'FAIL') {
       counts[status] += 1;
     } else {
       counts.OTHER += 1;

--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_DIR="${1:-$ROOT_DIR/target/wasm_fixture_gallery_v0}"
+ONDEMAND_OUT_DIR="${OUT_DIR}_ondemand_v1"
 STORE_DIR="${OUT_DIR}_store"
 HINT_STORE_DIR_A="${OUT_DIR}_store_from_hints_a"
 HINT_STORE_DIR_B="${OUT_DIR}_store_from_hints_b"
@@ -23,10 +24,11 @@ export TZ=UTC
 
 "$ROOT_DIR/scripts/wasm_smoke_build.sh"
 
-rm -rf "$OUT_DIR" "$STORE_DIR" "$HINT_STORE_DIR_A" "$HINT_STORE_DIR_B" "$FIXTURE_SOURCE_DIR" "$BASELINE_ROOT"
+rm -rf "$OUT_DIR" "$ONDEMAND_OUT_DIR" "$STORE_DIR" "$HINT_STORE_DIR_A" "$HINT_STORE_DIR_B" "$FIXTURE_SOURCE_DIR" "$BASELINE_ROOT"
 mkdir -p \
   "$OUT_DIR" \
   "$FIXTURE_SOURCE_DIR/xetex/tex" \
+  "$FIXTURE_SOURCE_DIR/xetex/tex/ondemand" \
   "$FIXTURE_SOURCE_DIR/xetex/tex/sections" \
   "$FIXTURE_SOURCE_DIR/xetex/tex/chapters" \
   "$FIXTURE_SOURCE_DIR/xetex/tex/appendices" \
@@ -41,6 +43,8 @@ mkdir -p \
   "$BASELINE_PACKS_ROOT"
 
 printf 'fixture-bytes-for-typeset-minimal-v0\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/typeset_demo_minimal_v0"
+printf 'fixture-bytes-for-ondemand-input-probe-main\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/typeset_demo_ondemand_input_probe_v0"
+printf 'fixture-bytes-for-ondemand-include-probe-main\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/typeset_demo_ondemand_include_probe_v0"
 printf 'fixture-bytes-for-chapter-intro\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapter_intro.tex"
 printf 'fixture-bytes-for-chapter-appendix\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapter_appendix.tex"
 printf 'fixture-bytes-for-chapters-intro\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapters__intro.tex"
@@ -49,6 +53,10 @@ printf 'fixture-bytes-for-sections-intro-nested\n' > "$FIXTURE_SOURCE_DIR/xetex/
 printf 'fixture-bytes-for-chapters-ch1-nested\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapters/ch1.tex"
 printf 'fixture-bytes-for-sections-intro-normalized\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/sections__intro.tex"
 printf 'fixture-bytes-for-chapters-ch1-normalized\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapters__ch1.tex"
+printf 'fixture-bytes-for-ondemand-extra-section-nested\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/ondemand/extra_section.tex"
+printf 'fixture-bytes-for-ondemand-chapter-one-nested\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/ondemand/chapter_one.tex"
+printf 'fixture-bytes-for-ondemand-extra-section-normalized\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/ondemand__extra_section.tex"
+printf 'fixture-bytes-for-ondemand-chapter-one-normalized\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/ondemand__chapter_one.tex"
 printf 'fixture-bytes-for-appendices-apx-a-nested\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/appendices/apx_a.tex"
 printf 'fixture-bytes-for-appendices-apx-b-nested\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/appendices/apx_b.tex"
 printf 'fixture-bytes-for-appendices-apx-a-normalized\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/appendices__apx_a.tex"
@@ -85,6 +93,7 @@ printf 'fixture-bytes-for-memoir-cls\n' > "$FIXTURE_SOURCE_DIR/xetex/cls/memoir.
 printf 'fixture-bytes-for-classoptsdemo-cls\n' > "$FIXTURE_SOURCE_DIR/xetex/cls/classoptsdemo.cls"
 printf 'fixture-bytes-for-classoptsmulti-cls\n' > "$FIXTURE_SOURCE_DIR/xetex/cls/classoptsmulti.cls"
 printf 'fixture-bytes-for-memoirplus-cls\n' > "$FIXTURE_SOURCE_DIR/xetex/cls/memoirplus.cls"
+printf 'fixture-bytes-for-article-cls\n' > "$FIXTURE_SOURCE_DIR/xetex/cls/article.cls"
 printf 'fixture-bytes-for-found-sans\n' > "$FIXTURE_SOURCE_DIR/fontconfig/public/FoundSans"
 
 cat > "$REQUEST_LIST" <<'JSON'
@@ -298,6 +307,20 @@ const includeProbeRequest = listA.requests.find(
 );
 if (!includeProbeRequest) {
   console.error('FAIL: request list must include include probe hint request for chapters__ch1.tex');
+  process.exit(1);
+}
+const ondemandInputProbeRequest = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'tex' && request.name === 'ondemand__extra_section.tex' && request.variant === 'typeset',
+);
+if (!ondemandInputProbeRequest) {
+  console.error('FAIL: request list must include on-demand input hint request for ondemand__extra_section.tex');
+  process.exit(1);
+}
+const ondemandIncludeProbeRequest = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'tex' && request.name === 'ondemand__chapter_one.tex' && request.variant === 'typeset',
+);
+if (!ondemandIncludeProbeRequest) {
+  console.error('FAIL: request list must include on-demand include hint request for ondemand__chapter_one.tex');
   process.exit(1);
 }
 const includeOnlyProbeRequestA = listA.requests.find(
@@ -1525,6 +1548,181 @@ console.log(`PASS: pkgopt_v0 sha stable ${pkgoptShaSecond}`);
 console.log(`PASS: graphics_v0 sha stable ${graphicsShaSecond}`);
 console.log('PASS: report typed_artifact_sha256 map present and stable');
 console.log('PASS: report top-level case_artifact_sha256 present');
+NODE
+
+node - "$ROOT_DIR" "$ONDEMAND_OUT_DIR" "$STORE_DIR" "$FIXTURE_SOURCE_DIR" <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+const { spawn } = require('node:child_process');
+
+const rootDir = process.argv[2];
+const ondemandOutDir = process.argv[3];
+const storeDir = process.argv[4];
+const fixtureSourceDir = process.argv[5];
+const sourceDateEpoch = process.env.SOURCE_DATE_EPOCH ?? '1700000000';
+
+const assert = (condition, message) => {
+  if (!condition) {
+    console.error(`FAIL: ${message}`);
+    process.exit(1);
+  }
+};
+
+const makeStableId = (prefix, parts) => {
+  const token = parts.join('_').replace(/[^A-Za-z0-9_:-]/g, '_');
+  return `${prefix}_${token}`.slice(0, 120);
+};
+
+const mapEndpointPathToFixturePath = (pathname) => {
+  const parts = pathname.split('/').filter(Boolean);
+  if (parts.length === 0) {
+    return null;
+  }
+  if (parts[0] === 'xetex' && parts.length === 3) {
+    return {
+      filePath: path.join(fixtureSourceDir, 'xetex', parts[1], parts[2]),
+      stableId: makeStableId('fileid', parts),
+      headerName: 'fileid',
+    };
+  }
+  if (parts[0] === 'fontconfig' && parts.length === 3) {
+    return {
+      filePath: path.join(fixtureSourceDir, 'fontconfig', parts[1], parts[2]),
+      stableId: makeStableId('fontid', parts),
+      headerName: 'fontid',
+    };
+  }
+  return null;
+};
+
+const server = http.createServer((req, res) => {
+  const pathname = new URL(req.url ?? '/', 'http://127.0.0.1').pathname;
+  const mapped = mapEndpointPathToFixturePath(pathname);
+  if (!mapped || !fs.existsSync(mapped.filePath)) {
+    res.statusCode = 404;
+    res.end('not found');
+    return;
+  }
+  const bytes = fs.readFileSync(mapped.filePath);
+  if (!bytes.length) {
+    res.statusCode = 404;
+    res.end('not found');
+    return;
+  }
+  res.statusCode = 200;
+  res.setHeader('content-type', 'application/octet-stream');
+  res.setHeader(mapped.headerName, mapped.stableId);
+  res.end(bytes);
+});
+
+const runNodeProcess = (args, env) =>
+  new Promise((resolve) => {
+    const child = spawn('node', args, {
+      cwd: rootDir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString('utf8');
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString('utf8');
+    });
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+
+server.listen(0, '127.0.0.1', async () => {
+  const address = server.address();
+  if (!address || typeof address !== 'object') {
+    console.error('FAIL: could not bind ondemand fixture endpoint');
+    process.exit(1);
+  }
+  const endpoint = `http://127.0.0.1:${address.port}`;
+  try {
+    const baselineOutDir = `${ondemandOutDir}_baseline`;
+    fs.rmSync(baselineOutDir, { recursive: true, force: true });
+    fs.rmSync(ondemandOutDir, { recursive: true, force: true });
+
+    const baselineRun = await runNodeProcess(
+      [path.join(rootDir, 'scripts', 'wasm_fixture_gallery_v0.mjs'), baselineOutDir],
+      {
+        ...process.env,
+        SOURCE_DATE_EPOCH: sourceDateEpoch,
+        TZ: 'UTC',
+        TEXLIVE_RESOLVER_BACKEND_V0: 'offline_store_v0',
+        TEXLIVE_STORE_DIR_V0: storeDir,
+      },
+    );
+    if (baselineRun.code !== 0) {
+      process.stderr.write(baselineRun.stdout ?? '');
+      process.stderr.write(baselineRun.stderr ?? '');
+      console.error('FAIL: baseline gallery run for ondemand integration failed');
+      process.exit(1);
+    }
+
+    const ondemandRun = await runNodeProcess(
+      [path.join(rootDir, 'scripts', 'wasm_fixture_gallery_v0.mjs'), ondemandOutDir],
+      {
+        ...process.env,
+        SOURCE_DATE_EPOCH: sourceDateEpoch,
+        TZ: 'UTC',
+        TEXLIVE_RESOLVER_BACKEND_V0: 'offline_store_v0',
+        TEXLIVE_STORE_DIR_V0: storeDir,
+        TEXLIVE_ENDPOINT: endpoint,
+        WASM_GALLERY_ENABLE_ONDEMAND_V1: '1',
+        WASM_GALLERY_ONDEMAND_MAX_ITERS_V1: '3',
+      },
+    );
+    if (ondemandRun.code !== 0) {
+      process.stderr.write(ondemandRun.stdout ?? '');
+      process.stderr.write(ondemandRun.stderr ?? '');
+      console.error('FAIL: ondemand-enabled fixture gallery run failed');
+      process.exit(1);
+    }
+
+    const baselineReport = JSON.parse(fs.readFileSync(path.join(baselineOutDir, 'report.json'), 'utf8'));
+    const ondemandReport = JSON.parse(fs.readFileSync(path.join(ondemandOutDir, 'report.json'), 'utf8'));
+    assert(Array.isArray(ondemandReport.statuses), 'ondemand report statuses missing');
+    assert(
+      typeof ondemandReport.resolved_resources_count === 'number',
+      'ondemand report missing resolved_resources_count',
+    );
+    assert(
+      ondemandReport.resolved_resources_count > baselineReport.resolved_resources_count,
+      'ondemand run must increase resolved_resources_count',
+    );
+    const requiredCases = [
+      'typeset_demo_ondemand_input_probe_v0',
+      'typeset_demo_ondemand_include_probe_v0',
+    ];
+    for (const caseId of requiredCases) {
+      const status = ondemandReport.statuses.find((entry) => entry.case_id === caseId);
+      assert(status, `ondemand report missing status for ${caseId}`);
+      assert(typeof status.config_hash === 'string' && status.config_hash.length > 0, `${caseId} missing config_hash`);
+      assert(status.input_sha256 && typeof status.input_sha256.main_tex === 'string', `${caseId} missing input sha`);
+      assert(Number.isInteger(status.missing_before), `${caseId} missing_before not integer`);
+      assert(Number.isInteger(status.missing_after), `${caseId} missing_after not integer`);
+      assert(Number.isInteger(status.resolved_resources_count), `${caseId} resolved_resources_count not integer`);
+      assert(status.missing_before > 0, `${caseId} missing_before must be > 0`);
+      assert(status.missing_after < status.missing_before, `${caseId} missing_after must decrease`);
+      assert(status.ondemand_v1?.attempted === true, `${caseId} ondemand attempt flag missing`);
+      assert(
+        status.status === 'NI' || status.status === 'INVALID' || status.status === 'MISMATCH',
+        `${caseId} status must remain fail-closed`,
+      );
+    }
+
+    console.log(`PASS: ondemand run resolved_resources_count ${baselineReport.resolved_resources_count} -> ${ondemandReport.resolved_resources_count}`);
+    console.log('PASS: ondemand per-case missing_before/missing_after fields and retries verified');
+  } finally {
+    server.close();
+  }
+});
 NODE
 
 echo "PASS: wasm fixture gallery artifacts $OUT_DIR"

--- a/scripts/texlive_smoke/fixtures/typeset_demo_ondemand_include_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_ondemand_include_probe_v0.tex
@@ -1,0 +1,11 @@
+\documentclass{article}
+
+\title{CarrelTeX On-Demand Include Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+\include{ondemand/chapter_one}
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_ondemand_input_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_ondemand_input_probe_v0.tex
@@ -1,0 +1,11 @@
+\documentclass{article}
+
+\title{CarrelTeX On-Demand Input Probe}
+\author{Fixture Bot}
+\date{2026-03-05}
+
+\begin{document}
+\maketitle
+
+\input{ondemand/extra_section}
+\end{document}

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -8,6 +8,7 @@ import { createCtx } from './wasm_smoke_js/ctx.mjs';
 import { createMemHelpers } from './wasm_smoke_js/mem.mjs';
 import { createAssertHelpers } from './wasm_smoke_js/assert.mjs';
 import { createOnDemandResolverV0 } from './wasm_smoke_js/ondemand_resolver_v0.mjs';
+import { generateTexliveStoreV0 } from './texlive_store_gen_v0.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -19,7 +20,9 @@ const STATUS_OK_V0 = 'OK';
 const STATUS_NI_V0 = 'NI';
 const STATUS_INVALID_V0 = 'INVALID';
 const STATUS_FAIL_V0 = 'FAIL';
+const STATUS_MISMATCH_V0 = 'MISMATCH';
 const EXPECTED_STATUS_VALUES_V0 = new Set([STATUS_OK_V0, STATUS_NI_V0, STATUS_INVALID_V0, STATUS_FAIL_V0]);
+const DEFAULT_ONDEMAND_FIXEDPOINT_MAX_ITERS_V1 = 3;
 const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'bib', 'hyperref', 'pkgopt', 'graphics'];
 const TYPED_ARTIFACTS_VERSION_V0 = 1;
 const MAX_TOC_ENTRIES_V0 = 256;
@@ -119,6 +122,14 @@ function expectedVsActualV0(expectedStatus, actualStatus) {
   return expectedStatus === actualStatus ? 'MATCH' : 'MISMATCH';
 }
 
+function parseBoolEnvV0(value) {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  const normalized = `${value}`.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
 async function loadGalleryManifestV0() {
   const manifestPath = path.join(rootDir, 'scripts', 'wasm_fixture_gallery_v0_manifest.json');
   const bytes = await readFile(manifestPath);
@@ -158,6 +169,7 @@ async function loadGalleryManifestV0() {
       tags,
       expected_status: expectedStatus,
       purpose: purpose.trim(),
+      ondemand_opt_in: raw?.ondemand_opt_in === true,
     });
   }
   return {
@@ -284,6 +296,16 @@ async function loadFixtureCasesV0() {
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_include_probe_v0.tex',
     },
     {
+      id: 'typeset_demo_ondemand_input_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_ondemand_input_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_ondemand_include_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_ondemand_include_probe_v0.tex',
+    },
+    {
       id: 'typeset_demo_includeonly_probe_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_includeonly_probe_v0.tex',
@@ -403,6 +425,7 @@ async function loadFixtureCasesV0() {
       tags: metadata.tags,
       expected_status: metadata.expected_status,
       purpose: metadata.purpose,
+      ondemand_opt_in: metadata.ondemand_opt_in,
     };
   });
 
@@ -438,6 +461,7 @@ function buildConfigHashV0(cases, sourceDateEpoch, resolverId) {
       fixture: item.fixtureRelPath,
       tags: item.tags,
       expected_status: item.expected_status,
+      ondemand_opt_in: item.ondemand_opt_in === true,
     })),
   };
   return sha256HexV0(Buffer.from(JSON.stringify(config)));
@@ -1964,6 +1988,104 @@ async function computeBaselineMatchV0(caseId, artifactSha256, baselineDir) {
   return 'MISMATCH';
 }
 
+function buildResolverOutcomeEntryV0(request, resolution) {
+  return {
+    kind: request.kind,
+    format: request.format,
+    name: request.name,
+    variant: request.variant,
+    hint_type: request.hint_type ?? null,
+    stable_id: resolution.stable_id,
+    sha256: resolution.sha256,
+    cache_hit: resolution.cache_hit,
+  };
+}
+
+function buildResolverMissingEntryV0(request, resolution) {
+  return {
+    kind: request.kind,
+    format: request.format,
+    name: request.name,
+    variant: request.variant,
+    hint_type: request.hint_type ?? null,
+    cache_hit: resolution.cache_hit,
+  };
+}
+
+async function resolveRequestsWithResolverV0(resolver, requests) {
+  const resolvedResources = [];
+  const missingResources = [];
+  for (const request of requests) {
+    const resolution = await resolver.resolve({
+      kind: request.kind,
+      format: request.format,
+      name: request.name,
+      variant: request.variant,
+      resolver_id: resolver.resolverId,
+    });
+    if (resolution.tag === 'Found') {
+      resolvedResources.push(buildResolverOutcomeEntryV0(request, resolution));
+      continue;
+    }
+    missingResources.push(buildResolverMissingEntryV0(request, resolution));
+  }
+  return {
+    resolvedResources,
+    missingResources,
+  };
+}
+
+function normalizeStoreRequestFromEntryV0(entry) {
+  const kind = typeof entry?.kind === 'string' ? entry.kind : '';
+  const format = typeof entry?.format === 'string' ? entry.format : '';
+  const name = typeof entry?.name === 'string' ? entry.name : '';
+  const variant = typeof entry?.variant === 'string' ? entry.variant : '';
+  const safeVariant = variant === '' || isSafeResolverTokenV0(variant);
+  if (!isSafeResolverTokenV0(kind) || !isSafeResolverTokenV0(format) || !isSafeResolverTokenV0(name) || !safeVariant) {
+    return null;
+  }
+  return { kind, format, name, variant };
+}
+
+async function loadStoreRequestsV0(storeDir) {
+  const indexPath = path.join(storeDir, 'index.json');
+  const indexBytes = await readFile(indexPath).catch(() => null);
+  if (!indexBytes) {
+    return [];
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(indexBytes.toString('utf8'));
+  } catch {
+    return [];
+  }
+  const entries = Array.isArray(parsed?.entries) ? parsed.entries : [];
+  const requestsByKey = new Map();
+  for (const entry of entries) {
+    const normalized = normalizeStoreRequestFromEntryV0(entry);
+    if (!normalized) {
+      continue;
+    }
+    requestsByKey.set(resolverRequestKeyV0(normalized), normalized);
+  }
+  return [...requestsByKey.values()].sort((left, right) => resolverRequestKeyV0(left).localeCompare(resolverRequestKeyV0(right)));
+}
+
+function mergeStoreRequestsV0(existingRequests, missingRequests) {
+  const requestsByKey = new Map();
+  for (const request of existingRequests) {
+    requestsByKey.set(resolverRequestKeyV0(request), request);
+  }
+  for (const request of missingRequests) {
+    const normalized = normalizeStoreRequestFromEntryV0(request);
+    if (!normalized) {
+      continue;
+    }
+    requestsByKey.set(resolverRequestKeyV0(normalized), normalized);
+  }
+  return [...requestsByKey.values()].sort((left, right) => resolverRequestKeyV0(left).localeCompare(resolverRequestKeyV0(right)));
+}
+
 async function runCaseV0(
   ctx,
   mem,
@@ -2075,25 +2197,15 @@ async function runCaseV0(
     errorMessage = errorMessage || 'expected non-empty main.pdf for OK case';
   }
 
-  const resolvedResources = [];
-  const resolution = await resolver.resolve({
+  const resolverRequestsByKey = new Map();
+  const rootResolverRequest = {
     kind: 'texmf',
     format: 'tex',
     name: caseSpec.id,
     variant: caseSpec.mode,
-    resolver_id: resolver.resolverId,
-  });
-  if (resolution.tag === 'Found') {
-    resolvedResources.push({
-      kind: 'texmf',
-      format: 'tex',
-      name: caseSpec.id,
-      variant: caseSpec.mode,
-      stable_id: resolution.stable_id,
-      sha256: resolution.sha256,
-      cache_hit: resolution.cache_hit,
-    });
-  }
+    hint_type: 'entrypoint',
+  };
+  resolverRequestsByKey.set(resolverRequestKeyV0(rootResolverRequest), rootResolverRequest);
 
   const summary = {
     case_id: caseSpec.id,
@@ -2119,8 +2231,14 @@ async function runCaseV0(
       main_xdv: sha256HexV0(xdvBytes),
       main_pdf: sha256HexV0(pdfBytes),
     },
+    input_sha256: {
+      main_tex: sha256HexV0(fixtureBytes),
+    },
     resolver_id: resolver.resolverId,
-    resolved_resources: resolvedResources,
+    resolved_resources: [],
+    missing_resources: [],
+    resolved_resources_count: 0,
+    missing_resources_count: 0,
     typed_artifacts_version: TYPED_ARTIFACTS_VERSION_V0,
     typed_artifacts: buildTypedArtifactsPlaceholderV0(),
   };
@@ -2140,26 +2258,17 @@ async function runCaseV0(
     summary.resource_hints_v0,
   );
   for (const request of typedArtifactRequests) {
-    const resolutionFromHint = await resolver.resolve({
-      kind: request.kind,
-      format: request.format,
-      name: request.name,
-      variant: request.variant,
-      resolver_id: resolver.resolverId,
-    });
-    if (resolutionFromHint.tag !== 'Found') {
-      continue;
-    }
-    resolvedResources.push({
-      kind: request.kind,
-      format: request.format,
-      name: request.name,
-      variant: request.variant,
-      stable_id: resolutionFromHint.stable_id,
-      sha256: resolutionFromHint.sha256,
-      cache_hit: resolutionFromHint.cache_hit,
-    });
+    resolverRequestsByKey.set(resolverRequestKeyV0(request), request);
   }
+  const resolverRequests = [...resolverRequestsByKey.values()].sort(
+    (left, right) => resolverRequestKeyV0(left).localeCompare(resolverRequestKeyV0(right)),
+  );
+  const resolverOutcomes = await resolveRequestsWithResolverV0(resolver, resolverRequests);
+  summary.resolved_resources = resolverOutcomes.resolvedResources;
+  summary.missing_resources = resolverOutcomes.missingResources;
+  summary.resolved_resources_count = resolverOutcomes.resolvedResources.length;
+  summary.missing_resources_count = resolverOutcomes.missingResources.length;
+  summary.expected_vs_actual = expectedVsActualV0(caseSpec.expected_status, summary.status);
   summary.baseline_match = await computeBaselineMatchV0(caseSpec.id, summary.artifact_sha256, baselineDir);
   if (errorMessage) {
     summary.error = errorMessage;
@@ -2179,6 +2288,17 @@ async function run() {
   const baselineDir = process.env.TEXLIVE_BASELINE_DIR
     ? path.resolve(process.env.TEXLIVE_BASELINE_DIR)
     : '';
+  const onDemandEnabled = parseBoolEnvV0(
+    process.env.WASM_GALLERY_ENABLE_ONDEMAND_V1 ?? process.env.WASM_GALLERY_ONDEMAND_ENABLE_V1,
+  );
+  const onDemandMaxItersRaw = process.env.WASM_GALLERY_ONDEMAND_MAX_ITERS_V1 ?? `${DEFAULT_ONDEMAND_FIXEDPOINT_MAX_ITERS_V1}`;
+  const onDemandMaxIters = Number.parseInt(onDemandMaxItersRaw, 10);
+  if (!Number.isInteger(onDemandMaxIters) || onDemandMaxIters <= 0 || onDemandMaxIters > 5) {
+    throw new Error(`WASM_GALLERY_ONDEMAND_MAX_ITERS_V1 must be an integer in [1,5], got: ${onDemandMaxItersRaw}`);
+  }
+  const onDemandEndpoint = typeof process.env.TEXLIVE_ENDPOINT === 'string'
+    ? process.env.TEXLIVE_ENDPOINT.trim()
+    : '';
   const sourceDateEpochRaw = process.env.SOURCE_DATE_EPOCH ?? `${DEFAULT_SOURCE_DATE_EPOCH_V0}`;
   const sourceDateEpoch = Number.parseInt(sourceDateEpochRaw, 10);
   if (!Number.isInteger(sourceDateEpoch) || sourceDateEpoch <= 0) {
@@ -2194,13 +2314,21 @@ async function run() {
     encoding: 'utf8',
   }).trim();
   const { cases, manifestPath } = await loadFixtureCasesV0();
+  const resolverBackend = process.env.TEXLIVE_RESOLVER_BACKEND_V0;
   const resolver = await createOnDemandResolverV0({
     backend: process.env.TEXLIVE_RESOLVER_BACKEND_V0,
-    endpoint: process.env.TEXLIVE_ENDPOINT,
+    endpoint: onDemandEndpoint,
     rootDir,
     storeDir,
   });
   const configHash = buildConfigHashV0(cases, sourceDateEpoch, resolver.resolverId);
+  const buildCaseResolver = () =>
+    createOnDemandResolverV0({
+      backend: resolverBackend,
+      endpoint: onDemandEndpoint,
+      rootDir,
+      storeDir,
+    });
 
   await rm(outDir, { recursive: true, force: true });
   await mkdir(outDir, { recursive: true });
@@ -2210,20 +2338,99 @@ async function run() {
   const helpers = createAssertHelpers(ctx, mem);
   const summaries = [];
   for (const caseSpec of cases) {
-    summaries.push(
-      await runCaseV0(
-        ctx,
-        mem,
-        helpers,
-        outDir,
-        caseSpec,
-        sourceDateEpoch,
-        engineRev,
-        configHash,
-        resolver,
-        baselineDir,
-      ),
+    const initialSummary = await runCaseV0(
+      ctx,
+      mem,
+      helpers,
+      outDir,
+      caseSpec,
+      sourceDateEpoch,
+      engineRev,
+      configHash,
+      await buildCaseResolver(),
+      baselineDir,
     );
+    let finalSummary = initialSummary;
+    const missingBefore = Number(initialSummary.missing_resources_count ?? 0);
+    const resolvedBefore = Number(initialSummary.resolved_resources_count ?? 0);
+    const onDemandTriggered = onDemandEnabled && caseSpec.ondemand_opt_in === true && missingBefore > 0;
+    const onDemandAttempted = onDemandTriggered && onDemandEndpoint.length > 0;
+    let onDemandIterations = 0;
+    let onDemandStoreFound = 0;
+    let onDemandStoreMissing = missingBefore;
+    if (onDemandAttempted) {
+      for (let iter = 1; iter <= onDemandMaxIters; iter += 1) {
+        const missingRequests = Array.isArray(finalSummary.missing_resources) ? finalSummary.missing_resources : [];
+        if (missingRequests.length === 0) {
+          break;
+        }
+        const existingStoreRequests = await loadStoreRequestsV0(storeDir);
+        const mergedRequests = mergeStoreRequestsV0(existingStoreRequests, missingRequests);
+        if (mergedRequests.length === 0) {
+          break;
+        }
+        const caseOutDir = path.join(outDir, caseSpec.id);
+        const requestListPath = path.join(caseOutDir, `ondemand_requests_iter_${iter}.json`);
+        await writeFile(
+          requestListPath,
+          `${JSON.stringify({ version: 1, requests: mergedRequests }, null, 2)}\n`,
+        );
+        const storeResult = await generateTexliveStoreV0({
+          rootDir,
+          requestListPath,
+          storeDir,
+          backend: 'endpoint_v0',
+          endpoint: onDemandEndpoint,
+          sourceDateEpoch,
+        });
+        onDemandIterations = iter;
+        onDemandStoreFound = Number(storeResult.foundCount ?? 0);
+        onDemandStoreMissing = Number(storeResult.missingCount ?? 0);
+        const rerunSummary = await runCaseV0(
+          ctx,
+          mem,
+          helpers,
+          outDir,
+          caseSpec,
+          sourceDateEpoch,
+          engineRev,
+          configHash,
+          await buildCaseResolver(),
+          baselineDir,
+        );
+        const improved = rerunSummary.resolved_resources_count > finalSummary.resolved_resources_count
+          || rerunSummary.missing_resources_count < finalSummary.missing_resources_count;
+        finalSummary = rerunSummary;
+        if (!improved || rerunSummary.missing_resources_count === 0) {
+          break;
+        }
+      }
+    }
+    finalSummary.missing_before = missingBefore;
+    finalSummary.missing_after = Number(finalSummary.missing_resources_count ?? 0);
+    finalSummary.resolved_resources_before = resolvedBefore;
+    finalSummary.resolved_resources_after = Number(finalSummary.resolved_resources_count ?? 0);
+    finalSummary.status_for_report = finalSummary.expected_vs_actual === 'MATCH'
+      ? finalSummary.status
+      : STATUS_MISMATCH_V0;
+    finalSummary.ondemand_v1 = {
+      enabled: onDemandEnabled,
+      case_opt_in: caseSpec.ondemand_opt_in === true,
+      triggered: onDemandTriggered,
+      attempted: onDemandAttempted,
+      endpoint_present: onDemandEndpoint.length > 0,
+      max_iters: onDemandMaxIters,
+      iterations: onDemandIterations,
+      store_found: onDemandStoreFound,
+      store_missing: onDemandStoreMissing,
+      missing_before: missingBefore,
+      missing_after: finalSummary.missing_after,
+      resolved_before: resolvedBefore,
+      resolved_after: finalSummary.resolved_resources_after,
+    };
+    const caseOutDir = path.join(outDir, caseSpec.id);
+    await writeFile(path.join(caseOutDir, 'summary.json'), `${JSON.stringify(finalSummary, null, 2)}\n`);
+    summaries.push(finalSummary);
   }
 
   const report = {
@@ -2234,8 +2441,21 @@ async function run() {
     baseline_dir: baselineDir || null,
     manifest_path: manifestPath,
     config_hash: configHash,
+    ondemand_v1: {
+      enabled: onDemandEnabled,
+      endpoint_present: onDemandEndpoint.length > 0,
+      max_iters: onDemandMaxIters,
+    },
     typed_artifacts_version: TYPED_ARTIFACTS_VERSION_V0,
     case_count: summaries.length,
+    missing_before_total: summaries.reduce(
+      (sum, summary) => sum + Number(summary.missing_before ?? summary.missing_resources_count ?? 0),
+      0,
+    ),
+    missing_after_total: summaries.reduce(
+      (sum, summary) => sum + Number(summary.missing_after ?? summary.missing_resources_count ?? 0),
+      0,
+    ),
     resolved_resources_count: summaries.reduce(
       (sum, summary) => sum + (Array.isArray(summary.resolved_resources) ? summary.resolved_resources.length : 0),
       0,
@@ -2246,6 +2466,7 @@ async function run() {
         {
           main_xdv: summary.artifact_sha256.main_xdv,
           main_pdf: summary.artifact_sha256.main_pdf,
+          main_tex: summary.input_sha256?.main_tex ?? null,
           typed_artifacts: Object.fromEntries(
             TYPED_ARTIFACT_KEYS_V0.map((key) => [
               key,
@@ -2277,11 +2498,17 @@ async function run() {
       tags: summary.tags,
       expected_status: summary.expected_status,
       expected_vs_actual: summary.expected_vs_actual,
+      config_hash: summary.config_hash,
+      input_sha256: summary.input_sha256,
       baseline_match: summary.baseline_match,
+      resolved_resources_count: summary.resolved_resources_count,
+      missing_before: Number(summary.missing_before ?? summary.missing_resources_count ?? 0),
+      missing_after: Number(summary.missing_after ?? summary.missing_resources_count ?? 0),
+      ondemand_v1: summary.ondemand_v1,
       typed_artifacts_presence: Object.fromEntries(
         TYPED_ARTIFACT_KEYS_V0.map((key) => [key, summary.typed_artifacts?.[key]?.present === true]),
       ),
-      status: summary.status,
+      status: summary.status_for_report ?? summary.status,
       artifact_sha256: summary.artifact_sha256,
     })),
   };

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -146,6 +146,20 @@
       "purpose": "Probes include resource-hint extraction and deterministic .tex request mapping."
     },
     {
+      "id": "typeset_demo_ondemand_input_probe_v0",
+      "tags": ["typeset", "ondemand", "input", "probe", "ni"],
+      "expected_status": "NI",
+      "ondemand_opt_in": true,
+      "purpose": "Probes opt-in on-demand closure by requiring a nested input resource that starts missing in baseline store."
+    },
+    {
+      "id": "typeset_demo_ondemand_include_probe_v0",
+      "tags": ["typeset", "ondemand", "include", "probe", "ni"],
+      "expected_status": "NI",
+      "ondemand_opt_in": true,
+      "purpose": "Probes opt-in on-demand closure by requiring a nested include resource that starts missing in baseline store."
+    },
+    {
       "id": "typeset_demo_includeonly_probe_v0",
       "tags": ["typeset", "includeonly", "probe", "ni"],
       "expected_status": "NI",


### PR DESCRIPTION
## Summary\n- add optional per-case on-demand fixedpoint rerun flow in wasm fixture gallery\n- add on-demand opt-in probe fixtures and manifest metadata\n- extend report/status fields with missing before/after and ondemand attempt details\n\n## Proof\n- ./scripts/proof_wasm_fixture_gallery_v0.sh\n- ./scripts/proof_ondemand_fixedpoint_v0.sh