### PR TITLE
typeset_minimal table v0 + figure stub v0

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -19,10 +19,17 @@ const CENTER_ENV_V0: &[u8] = b"center";
 const CENTERLINE_CONTROL_V0: &[u8] = b"centerline";
 const FLUSHRIGHT_ENV_V0: &[u8] = b"flushright";
 const RIGHTLINE_CONTROL_V0: &[u8] = b"rightline";
+const TABULAR_ENV_V0: &[u8] = b"tabular";
+const FIGURE_ENV_V0: &[u8] = b"figure";
+const CAPTION_CONTROL_V0: &[u8] = b"caption";
+const INCLUDEGRAPHICS_CONTROL_V0: &[u8] = b"includegraphics";
 const FOOTNOTE_CONTROL_V0: &[u8] = b"footnote";
 const HREF_CONTROL_V0: &[u8] = b"href";
 const FOOTNOTE_LINE_PREFIX_MARKER_V0: &[u8] = b"!f ";
 const HREF_URL_LINE_PREFIX_MARKER_V0: &[u8] = b"!u ";
+const TABLE_ROW_PREFIX_MARKER_V0: &[u8] = b"!t ";
+const FIGURE_BOX_PREFIX_MARKER_V0: &[u8] = b"!gbox";
+const FIGURE_CAPTION_PREFIX_MARKER_V0: &[u8] = b"!gcap ";
 const LINK_START_MARKER_V0: u8 = b'<';
 const LINK_END_MARKER_V0: u8 = b'>';
 const NOINDENT_PREFIX_MARKER_V0: &[u8] = b"~ ";
@@ -660,6 +667,181 @@ fn consume_heading_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8
     Some(next)
 }
 
+fn is_hard_line_break_control_v0(name: &[u8]) -> bool {
+    name.is_empty()
+        || name == HARD_LINE_BREAK_CONTROL_V0
+        || name == NEWLINE_ALIAS_CONTROL_V0
+        || name == LINEBREAK_ALIAS_CONTROL_V0
+        || name == CARRELNEWLINE_MARKER_CONTROL_V0
+}
+
+fn parse_char_space_group_trimmed_v0(
+    tokens: &[TokenV0],
+    group_start: usize,
+    group_end: usize,
+) -> Option<Vec<u8>> {
+    let mut out = Vec::<u8>::new();
+    for token in &tokens[group_start..group_end] {
+        match token {
+            TokenV0::Char(byte) => out.push(*byte),
+            TokenV0::Space => out.push(b' '),
+            _ => return None,
+        }
+    }
+    while matches!(out.first(), Some(b' ')) {
+        out.remove(0);
+    }
+    while matches!(out.last(), Some(b' ')) {
+        out.pop();
+    }
+    Some(out)
+}
+
+fn consume_tabular_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+    let (env_name, mut cursor) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
+    if env_name.as_slice() != TABULAR_ENV_V0 {
+        return None;
+    }
+
+    let (align_start, align_end, next_after_align) = consume_group_bounds(tokens, cursor)?;
+    let align_spec = parse_char_space_group_trimmed_v0(tokens, align_start, align_end)?;
+    if align_spec.as_slice() != b"lcr" {
+        return None;
+    }
+    cursor = next_after_align;
+
+    let mut rows = Vec::<Vec<Vec<u8>>>::new();
+    loop {
+        cursor = skip_spaces(tokens, cursor);
+        if matches!(
+            tokens.get(cursor),
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == END_CONTROL_V0
+        ) {
+            let (end_env, next) = consume_env_name_command_v0(tokens, cursor, END_CONTROL_V0)?;
+            if end_env.as_slice() != TABULAR_ENV_V0 || rows.is_empty() {
+                return None;
+            }
+            push_paragraph_break(out);
+            for row in &rows {
+                out.extend_from_slice(TABLE_ROW_PREFIX_MARKER_V0);
+                for (cell_index, cell) in row.iter().enumerate() {
+                    if cell_index > 0 {
+                        out.extend_from_slice(b"||");
+                    }
+                    out.extend_from_slice(cell);
+                }
+                push_newline(out);
+            }
+            push_paragraph_break(out);
+            return Some(next);
+        }
+
+        let mut row = Vec::<Vec<u8>>::new();
+        let mut cell = Vec::<u8>::new();
+        loop {
+            match tokens.get(cursor) {
+                Some(TokenV0::Char(b'&')) => {
+                    trim_trailing_spaces(&mut cell);
+                    if cell.windows(2).any(|window| window == b"||") {
+                        return None;
+                    }
+                    row.push(core::mem::take(&mut cell));
+                    cursor += 1;
+                }
+                Some(TokenV0::ControlSeq(name)) if is_hard_line_break_control_v0(name.as_slice()) => {
+                    trim_trailing_spaces(&mut cell);
+                    if cell.windows(2).any(|window| window == b"||") {
+                        return None;
+                    }
+                    row.push(core::mem::take(&mut cell));
+                    cursor += 1;
+                    break;
+                }
+                Some(TokenV0::ControlSeq(name)) if name.as_slice() == END_CONTROL_V0 => {
+                    return None;
+                }
+                Some(TokenV0::ControlSeq(name)) if name.as_slice() == BEGIN_CONTROL_V0 => {
+                    return None;
+                }
+                Some(_) => {
+                    cursor = consume_fragment_token_v0(tokens, cursor, &mut cell, false, false)?;
+                }
+                None => return None,
+            }
+        }
+        if row.len() != 3 {
+            return None;
+        }
+        rows.push(row);
+    }
+}
+
+fn consume_figure_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+    let (env_name, mut cursor) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
+    if env_name.as_slice() != FIGURE_ENV_V0 {
+        return None;
+    }
+
+    let mut caption: Option<Vec<u8>> = None;
+    loop {
+        cursor = skip_spaces(tokens, cursor);
+        match tokens.get(cursor) {
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == END_CONTROL_V0 => {
+                let (end_env, next) = consume_env_name_command_v0(tokens, cursor, END_CONTROL_V0)?;
+                if end_env.as_slice() != FIGURE_ENV_V0 {
+                    return None;
+                }
+                let mut figure_caption = caption?;
+                trim_trailing_spaces(&mut figure_caption);
+                if figure_caption.is_empty() {
+                    return None;
+                }
+                push_paragraph_break(out);
+                out.extend_from_slice(FIGURE_BOX_PREFIX_MARKER_V0);
+                push_newline(out);
+                out.extend_from_slice(FIGURE_CAPTION_PREFIX_MARKER_V0);
+                out.extend_from_slice(&figure_caption);
+                push_newline(out);
+                push_paragraph_break(out);
+                return Some(next);
+            }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == BEGIN_CONTROL_V0 => {
+                return None;
+            }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == CAPTION_CONTROL_V0 => {
+                if caption.is_some() {
+                    return None;
+                }
+                let (group_start, group_end, next) = consume_group_bounds(tokens, cursor + 1)?;
+                let mut value = Vec::<u8>::new();
+                consume_fragment_range_v0(tokens, group_start, group_end, &mut value, false, false)?;
+                trim_trailing_spaces(&mut value);
+                if value.is_empty() {
+                    return None;
+                }
+                caption = Some(value);
+                cursor = next;
+            }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == INCLUDEGRAPHICS_CONTROL_V0 => {
+                return None;
+            }
+            Some(TokenV0::ControlSeq(name))
+                if name.as_slice() == b"protect" || name.as_slice() == b"relax" =>
+            {
+                cursor += 1;
+            }
+            Some(TokenV0::Char(byte)) if *byte == NEWLINE_MARKER_V0 => {
+                cursor += 1;
+            }
+            Some(TokenV0::Space) => {
+                cursor += 1;
+            }
+            Some(_) => return None,
+            None => return None,
+        }
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ListKindV0 {
     Itemize,
@@ -990,6 +1172,12 @@ fn consume_body_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u
     }
     if env_name.as_slice() == FLUSHRIGHT_ENV_V0 {
         return consume_flushright_environment_v0(tokens, index, out);
+    }
+    if env_name.as_slice() == TABULAR_ENV_V0 {
+        return consume_tabular_environment_v0(tokens, index, out);
+    }
+    if env_name.as_slice() == FIGURE_ENV_V0 {
+        return consume_figure_environment_v0(tokens, index, out);
     }
     None
 }

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -259,6 +259,60 @@ fn typeset_minimal_rightline_rejects_multiline_content() {
 }
 
 #[test]
+fn typeset_minimal_tabular_emits_deterministic_row_markers() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{tabular}{lcr}Left & Center & Right\\\\L2 & C2 & R2\\\\\\end{tabular}\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("!t Left||Center||Right\n!t L2||C2||R2"),
+        "body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_rejects_tabular_unsupported_alignment() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{tabular}{ll}A & B\\\\\\end{tabular}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_tabular_missing_row_terminator() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{tabular}{lcr}A & B & C\\end{tabular}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_figure_stub_emits_placeholder_and_caption_markers() {
+    let main = b"\\documentclass{article}\\begin{document}Before.\\begin{figure}\\caption{Demo figure caption with \\emph{emphasis}.}\\end{figure}After.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("Before.\n\n!gbox\n!gcap Demo figure caption with [emphasis].\n\nAfter."),
+        "body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_rejects_figure_with_includegraphics() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{figure}\\includegraphics{demo.png}\\caption{Nope}\\end{figure}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_figure_without_caption() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{figure}\\end{figure}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
 fn typeset_minimal_footnotes_and_href_emit_expected_markers() {
     let main = b"\\documentclass{article}\\begin{document}Body text\\footnote{First note}. Visit \\href{https://example.com}{example link}.\\end{document}";
     let body = extract_typeset_body(main);

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -27,6 +27,13 @@ const LINK_END_MARKER_V0: u8 = b'>';
 const FOOTNOTE_MARKER_PREFIX_V0: u8 = b'^';
 const FOOTNOTE_MARKER_FONT_SIZE_PT_V0: f32 = 8.0;
 const FOOTNOTE_MARKER_RISE_PT_V0: f32 = 4.0;
+const TABLE_ROW_PREFIX_MARKER_V0: &[u8] = b"!t ";
+const FIGURE_BOX_PREFIX_MARKER_V0: &[u8] = b"!gbox";
+const FIGURE_CAPTION_PREFIX_MARKER_V0: &[u8] = b"!gcap ";
+const TABLE_COLUMN_COUNT_V0: usize = 3;
+const TABLE_CELL_PADDING_PT_V0: f32 = 6.0;
+const FIGURE_PLACEHOLDER_LINE_V0: &[u8] = b"[ Figure placeholder ]";
+const FIGURE_CAPTION_FONT_SIZE_PT_V0: f32 = 11.0;
 const SECTION_HEADING_PREFIX_MARKER_V0: &[u8] = b"@S ";
 const SUBSECTION_HEADING_PREFIX_MARKER_V0: &[u8] = b"@s ";
 const ITALIC_START_MARKER_V0: u8 = b'[';
@@ -415,6 +422,221 @@ fn detect_heading_prefix_v0(glyphs: &[GlyphPlanV0]) -> Option<HeadingKindV0> {
         return Some(HeadingKindV0::Subsection);
     }
     None
+}
+
+fn has_table_row_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() >= TABLE_ROW_PREFIX_MARKER_V0.len()
+        && glyphs[..TABLE_ROW_PREFIX_MARKER_V0.len()]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .eq(TABLE_ROW_PREFIX_MARKER_V0.iter().copied())
+}
+
+fn has_figure_box_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() == FIGURE_BOX_PREFIX_MARKER_V0.len()
+        && glyphs
+            .iter()
+            .map(|glyph| glyph.byte)
+            .eq(FIGURE_BOX_PREFIX_MARKER_V0.iter().copied())
+}
+
+fn has_figure_caption_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() >= FIGURE_CAPTION_PREFIX_MARKER_V0.len()
+        && glyphs[..FIGURE_CAPTION_PREFIX_MARKER_V0.len()]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .eq(FIGURE_CAPTION_PREFIX_MARKER_V0.iter().copied())
+}
+
+fn trim_space_glyph_edges_v0(glyphs: &[GlyphPlanV0]) -> Vec<GlyphPlanV0> {
+    let mut start = 0usize;
+    let mut end = glyphs.len();
+    while start < end && glyphs[start].byte == b' ' {
+        start += 1;
+    }
+    while start < end && glyphs[end - 1].byte == b' ' {
+        end -= 1;
+    }
+    glyphs[start..end].to_vec()
+}
+
+fn parse_table_row_cells_v0(glyphs: &[GlyphPlanV0]) -> Option<Vec<Vec<GlyphPlanV0>>> {
+    if !has_table_row_prefix_v0(glyphs) {
+        return None;
+    }
+    let mut cells = Vec::<Vec<GlyphPlanV0>>::new();
+    let mut current = Vec::<GlyphPlanV0>::new();
+    let mut index = TABLE_ROW_PREFIX_MARKER_V0.len();
+    while index < glyphs.len() {
+        if index + 1 < glyphs.len() && glyphs[index].byte == b'|' && glyphs[index + 1].byte == b'|' {
+            cells.push(trim_space_glyph_edges_v0(&current));
+            current.clear();
+            index += 2;
+            continue;
+        }
+        current.push(glyphs[index].clone());
+        index += 1;
+    }
+    cells.push(trim_space_glyph_edges_v0(&current));
+    if cells.len() != TABLE_COLUMN_COUNT_V0 {
+        return None;
+    }
+    Some(cells)
+}
+
+fn parse_figure_caption_line_v0(glyphs: &[GlyphPlanV0]) -> Option<Vec<GlyphPlanV0>> {
+    if !has_figure_caption_prefix_v0(glyphs) {
+        return None;
+    }
+    let caption = trim_space_glyph_edges_v0(&glyphs[FIGURE_CAPTION_PREFIX_MARKER_V0.len()..]);
+    if caption.is_empty() {
+        return None;
+    }
+    Some(caption)
+}
+
+fn placeholder_segments_v0() -> Vec<PdfStyledSegmentV0> {
+    let glyphs: Vec<GlyphPlanV0> = FIGURE_PLACEHOLDER_LINE_V0
+        .iter()
+        .copied()
+        .map(|byte| GlyphPlanV0 {
+            byte,
+            advance_sp: 65_536,
+        })
+        .collect();
+    vec![PdfStyledSegmentV0 {
+        style: PdfTextStyleV0::Regular,
+        glyphs: glyphs.clone(),
+        advance_pt: glyphs
+            .iter()
+            .map(|glyph| (glyph.advance_sp as f32) / 65_536.0)
+            .sum(),
+        is_link: false,
+    }]
+}
+
+fn emit_table_block_v0(
+    out: &mut Vec<u8>,
+    rows: &[LinePlanV0],
+    y: &mut f32,
+    min_body_y_pt: f32,
+) -> Option<()> {
+    if rows.is_empty() {
+        return None;
+    }
+    let mut parsed_rows = Vec::<Vec<Vec<PdfRenderSegmentV0>>>::new();
+    let mut col_max_width_pt = [0.0f32; TABLE_COLUMN_COUNT_V0];
+
+    for row in rows {
+        let cells = parse_table_row_cells_v0(&row.glyphs)?;
+        let mut parsed_cells = Vec::<Vec<PdfRenderSegmentV0>>::new();
+        for (col_index, cell_glyphs) in cells.iter().enumerate() {
+            let segments = parse_styled_segments_v0(cell_glyphs)?;
+            let render_segments = split_superscript_segments_v0(&segments);
+            if render_segments.iter().any(|segment| segment.superscript || segment.is_link) {
+                return None;
+            }
+            let width_pt = render_segments.iter().map(|segment| segment.advance_pt).sum::<f32>();
+            col_max_width_pt[col_index] = col_max_width_pt[col_index].max(width_pt);
+            parsed_cells.push(render_segments);
+        }
+        parsed_rows.push(parsed_cells);
+    }
+
+    let table_width_pt = col_max_width_pt
+        .iter()
+        .copied()
+        .fold(0.0f32, |acc, width_pt| acc + width_pt + (TABLE_CELL_PADDING_PT_V0 * 2.0));
+    let max_content_width_pt = PAGE_WIDTH_PT_V0 - (2.0 * MARGIN_PT_V0);
+    if table_width_pt > max_content_width_pt {
+        return None;
+    }
+
+    for row in &parsed_rows {
+        if *y < min_body_y_pt {
+            return None;
+        }
+        let mut col_left_x = MARGIN_PT_V0;
+        for col_index in 0..TABLE_COLUMN_COUNT_V0 {
+            let cell_width_pt = row[col_index]
+                .iter()
+                .map(|segment| segment.advance_pt)
+                .sum::<f32>();
+            let col_content_width_pt = col_max_width_pt[col_index];
+            let align_offset_pt = match col_index {
+                0 => 0.0,
+                1 => (col_content_width_pt - cell_width_pt) * 0.5,
+                _ => col_content_width_pt - cell_width_pt,
+            };
+            let x_pt = col_left_x + TABLE_CELL_PADDING_PT_V0 + align_offset_pt.max(0.0);
+            emit_render_segments_with_superscript_v0(
+                out,
+                &row[col_index],
+                x_pt,
+                *y,
+                FONT_SIZE_PT_V0,
+            );
+            col_left_x += col_content_width_pt + (TABLE_CELL_PADDING_PT_V0 * 2.0);
+        }
+        out.extend_from_slice(b"\n");
+        *y -= LEADING_PT_V0;
+    }
+    Some(())
+}
+
+fn emit_figure_block_v0(
+    out: &mut Vec<u8>,
+    caption_glyphs: &[GlyphPlanV0],
+    y: &mut f32,
+    min_body_y_pt: f32,
+) -> Option<()> {
+    if *y < min_body_y_pt {
+        return None;
+    }
+
+    let placeholder_segments = placeholder_segments_v0();
+    let placeholder_render_segments = split_superscript_segments_v0(&placeholder_segments);
+    let placeholder_width_pt = placeholder_render_segments
+        .iter()
+        .map(|segment| segment.advance_pt)
+        .sum::<f32>();
+    let placeholder_x_pt = centered_line_x_v0(placeholder_width_pt);
+    emit_render_segments_with_superscript_v0(
+        out,
+        &placeholder_render_segments,
+        placeholder_x_pt,
+        *y,
+        FONT_SIZE_PT_V0,
+    );
+    out.extend_from_slice(b"\n");
+    *y -= LEADING_PT_V0;
+
+    if *y < min_body_y_pt {
+        return None;
+    }
+    let caption_segments = parse_styled_segments_v0(caption_glyphs)?;
+    let caption_render_segments = split_superscript_segments_v0(&caption_segments);
+    if caption_render_segments
+        .iter()
+        .any(|segment| segment.superscript || segment.is_link)
+    {
+        return None;
+    }
+    let caption_width_pt = caption_render_segments
+        .iter()
+        .map(|segment| segment.advance_pt)
+        .sum::<f32>();
+    let caption_x_pt = centered_line_x_v0(caption_width_pt);
+    emit_render_segments_with_superscript_v0(
+        out,
+        &caption_render_segments,
+        caption_x_pt,
+        *y,
+        FIGURE_CAPTION_FONT_SIZE_PT_V0,
+    );
+    out.extend_from_slice(b"\n");
+    *y -= LEADING_PT_V0;
+    Some(())
 }
 
 fn glyphs_advance_pt_v0(glyphs: &[GlyphPlanV0]) -> f32 {
@@ -837,11 +1059,40 @@ fn build_page_content_stream_v0(
     let mut current_style = PdfTextStyleV0::Regular;
     let mut link_active = false;
     let mut active_link_uri = None::<Vec<u8>>;
-    for (line_index, line) in lines.iter().enumerate() {
+    let mut line_index = 0usize;
+    while line_index < lines.len() {
+        let line = &lines[line_index];
         if y < MARGIN_PT_V0 {
             break;
         }
         if y < min_body_y_pt {
+            return None;
+        }
+        if line_index >= title_block_len && has_table_row_prefix_v0(&line.glyphs) {
+            let mut table_end = line_index;
+            while table_end < lines.len() && has_table_row_prefix_v0(&lines[table_end].glyphs) {
+                table_end += 1;
+            }
+            emit_table_block_v0(&mut out, &lines[line_index..table_end], &mut y, min_body_y_pt)?;
+            previous_rendered_line_was_empty = false;
+            skip_indent_after_title_block = false;
+            active_hang_indent_pt = 0.0;
+            active_quote_indent_pt = 0.0;
+            line_index = table_end;
+            continue;
+        }
+        if line_index >= title_block_len && has_figure_box_prefix_v0(&line.glyphs) {
+            let caption_line = lines.get(line_index + 1)?;
+            let caption_glyphs = parse_figure_caption_line_v0(&caption_line.glyphs)?;
+            emit_figure_block_v0(&mut out, &caption_glyphs, &mut y, min_body_y_pt)?;
+            previous_rendered_line_was_empty = false;
+            skip_indent_after_title_block = false;
+            active_hang_indent_pt = 0.0;
+            active_quote_indent_pt = 0.0;
+            line_index += 2;
+            continue;
+        }
+        if line_index >= title_block_len && has_figure_caption_prefix_v0(&line.glyphs) {
             return None;
         }
         let quote_prefix_advance_pt = if line_index >= title_block_len {
@@ -1023,6 +1274,7 @@ fn build_page_content_stream_v0(
         if title_block_len > 0 && line_index + 1 == title_block_len {
             y -= TITLE_EXTRA_GAP_PT_V0;
         }
+        line_index += 1;
     }
     if !style_stack.is_empty() || link_active {
         return None;

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -2013,6 +2013,117 @@ fn pdf_renderer_multipage_footnotes_and_annots_associate_per_page_v0() {
 }
 
 #[test]
+fn pdf_renderer_table_rows_use_stable_column_x_offsets_v0() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"Before.\n\n!t Alpha||Beta||Gamma\n!t Delta||Epsilon||Zeta\n\nAfter.",
+    )
+    .expect("writer should accept table marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    assert!(
+        !pdf_text.contains("!t Alpha||Beta||Gamma"),
+        "table marker should be hidden in pdf output: {pdf_text}"
+    );
+
+    let epsilon_pt = 0.05f32;
+    let alpha_x = *tm_xs_for_segment_text_v0(&pdf, "Alpha")
+        .first()
+        .expect("alpha x");
+    let delta_x = *tm_xs_for_segment_text_v0(&pdf, "Delta")
+        .first()
+        .expect("delta x");
+    let beta_x = *tm_xs_for_segment_text_v0(&pdf, "Beta")
+        .first()
+        .expect("beta x");
+    let epsilon_x = *tm_xs_for_segment_text_v0(&pdf, "Epsilon")
+        .first()
+        .expect("epsilon x");
+    let gamma_x = *tm_xs_for_segment_text_v0(&pdf, "Gamma")
+        .first()
+        .expect("gamma x");
+    let zeta_x = *tm_xs_for_segment_text_v0(&pdf, "Zeta")
+        .first()
+        .expect("zeta x");
+
+    assert!(
+        (alpha_x - delta_x).abs() <= epsilon_pt,
+        "column 1 x drift: {alpha_x} vs {delta_x}"
+    );
+    assert!(
+        (beta_x - epsilon_x).abs() <= 2.0,
+        "column 2 x drift too large: {beta_x} vs {epsilon_x}"
+    );
+    assert!(
+        (gamma_x - zeta_x).abs() <= 3.0,
+        "column 3 x drift too large: {gamma_x} vs {zeta_x}"
+    );
+    assert!(alpha_x < beta_x && beta_x < gamma_x, "column order mismatch");
+}
+
+#[test]
+fn pdf_renderer_rejects_table_width_overflow_v0() {
+    let mut row = Vec::<u8>::new();
+    row.extend_from_slice(b"!t ");
+    row.extend_from_slice("W".repeat(400).as_bytes());
+    row.extend_from_slice(b"||Center||Right");
+    let xdv = write_dvi_v2_text_page_with_layout_and_wrap_v0(&row, 65_536, 786_432, 5_000)
+        .expect("writer should accept table marker line");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
+    assert!(pdf.is_none(), "renderer should fail-closed for table overflow");
+}
+
+#[test]
+fn pdf_renderer_figure_block_spacing_invariants_v0() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"Before paragraph.\n\n!gbox\n!gcap Figure caption text.\n\nAfter paragraph.",
+    )
+    .expect("writer should accept figure marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    assert!(
+        !pdf_text.contains("!gbox"),
+        "figure marker should be hidden in pdf output: {pdf_text}"
+    );
+    assert!(
+        pdf_text.contains("([ Figure placeholder ]) Tj"),
+        "placeholder text should render: {pdf_text}"
+    );
+    assert!(
+        pdf_text.contains("(Figure caption text.) Tj"),
+        "caption text should render: {pdf_text}"
+    );
+
+    let epsilon_pt = 0.05f32;
+    let left_margin_pt = 72.0f32;
+    let left_margin_epsilon = 0.5f32;
+    let (before_x, before_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Before paragraph.)").expect("before");
+    let (placeholder_x, placeholder_y) = tm_position_for_line_containing_text_v0(
+        &pdf,
+        "([ Figure placeholder ])",
+    )
+    .expect("placeholder");
+    let (caption_x, caption_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Figure caption text.)").expect("caption");
+    let (after_x, after_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(After paragraph.)").expect("after");
+
+    assert!(
+        placeholder_x > left_margin_pt + left_margin_epsilon,
+        "placeholder should be visually offset from body margin"
+    );
+    assert!(
+        caption_x > left_margin_pt + left_margin_epsilon,
+        "caption should be visually offset from body margin"
+    );
+    assert!(before_x >= left_margin_pt - epsilon_pt, "before paragraph should stay in body column");
+    assert!(after_x >= left_margin_pt - epsilon_pt, "after paragraph should stay in body column");
+    assert!(before_y > placeholder_y, "placeholder should render below body");
+    assert!(placeholder_y > caption_y, "caption should render below placeholder");
+    assert!(caption_y > after_y, "after paragraph should render below caption");
+}
+
+#[test]
 fn validator_rejects_wrong_movement_amount() {
     let mut bytes = write_dvi_v2_text_page_v0(b"ABCD").expect("writer should accept ABCD");
     let right_index = bytes

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -68,6 +68,22 @@ This quoted paragraph is intentionally long so width-based wrapping produces con
 This is a second quoted paragraph to confirm paragraph breaks are preserved inside the quote environment and quote indentation remains stable.
 \end{quote}
 
+\subsection{Table}
+The table block below is a deterministic subset of tabular rendering and should keep three fixed columns with stable alignment in the PDF preview.
+
+\begin{tabular}{lcr}
+Label & Value & Notes\\
+Alpha & 12.50 & Stable\\
+Beta & 9.00 & Check\\
+\end{tabular}
+
+\subsection{Figure}
+The figure block below is a deterministic placeholder stub with caption spacing invariants.
+
+\begin{figure}
+\caption{Deterministic placeholder figure caption for layout validation.}
+\end{figure}
+
 \subsection{Centering}
 \begin{center}
 Centered environment line one.\linebreak Centered environment line two.


### PR DESCRIPTION
## Summary\n- add typeset_minimal tabular subset extraction markers and tests\n- add figure stub markers and fail-closed extraction\n- render table grid + figure placeholder/caption in pdf preview with deterministic invariants\n\n## Proof\n- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests\n- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml\n- ./scripts/proof_wasm_typeset_minimal_v0.sh\n- ./scripts/proof_wasm_fixture_gallery_v0.sh