### PR TITLE
typeset_minimal labels+refs v0 typed artifacts and preview

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -1,4 +1,5 @@
 use crate::tex::tokenize_v0::TokenV0;
+use std::collections::BTreeMap;
 
 const NEWLINE_MARKER_V0: u8 = 0x0a;
 const PAGE_BREAK_MARKER_V0: u8 = 0x0c;
@@ -26,13 +27,19 @@ const CAPTION_CONTROL_V0: &[u8] = b"caption";
 const INCLUDEGRAPHICS_CONTROL_V0: &[u8] = b"includegraphics";
 const FOOTNOTE_CONTROL_V0: &[u8] = b"footnote";
 const HREF_CONTROL_V0: &[u8] = b"href";
+const LABEL_CONTROL_V0: &[u8] = b"label";
+const REF_CONTROL_V0: &[u8] = b"ref";
 const FOOTNOTE_LINE_PREFIX_MARKER_V0: &[u8] = b"!f ";
 const HREF_URL_LINE_PREFIX_MARKER_V0: &[u8] = b"!u ";
+const LABEL_LINE_PREFIX_MARKER_V0: &[u8] = b"!l ";
+const REF_LINE_PREFIX_MARKER_V0: &[u8] = b"!r ";
 const TABLE_ROW_PREFIX_MARKER_V0: &[u8] = b"!t ";
 const FIGURE_BOX_PREFIX_MARKER_V0: &[u8] = b"!gbox";
 const FIGURE_CAPTION_PREFIX_MARKER_V0: &[u8] = b"!gcap ";
 const TOC_PLACEHOLDER_MARKER_V0: &[u8] = b"!toc";
 const TOC_ENTRY_LINE_PREFIX_MARKER_V0: &[u8] = b"!toc ";
+const REF_MARKER_PREFIX_V0: &[u8] = b"@@REF:";
+const REF_MARKER_SUFFIX_V0: &[u8] = b"@@";
 const LINK_START_MARKER_V0: u8 = b'<';
 const LINK_END_MARKER_V0: u8 = b'>';
 const NOINDENT_PREFIX_MARKER_V0: &[u8] = b"~ ";
@@ -53,6 +60,35 @@ struct TocEntryMetaV0 {
     level: u8,
     anchor_id: u32,
     title: Vec<u8>,
+}
+
+#[derive(Clone, Copy)]
+enum LabelKindV0 {
+    Heading,
+    Figure,
+}
+
+#[derive(Clone)]
+struct LabelEntryMetaV0 {
+    anchor_id: u32,
+    kind: LabelKindV0,
+    level: Option<u8>,
+    title: Option<Vec<u8>>,
+}
+
+#[derive(Clone)]
+struct PendingLabelTargetV0 {
+    anchor_id: u32,
+    kind: LabelKindV0,
+    level: Option<u8>,
+    title: Option<Vec<u8>>,
+}
+
+#[derive(Clone)]
+struct RefOccurrenceMetaV0 {
+    key: Vec<u8>,
+    line_index: u32,
+    resolved_anchor_id: Option<u32>,
 }
 
 #[derive(Default)]
@@ -670,8 +706,8 @@ fn consume_heading_command_v0(
     tokens: &[TokenV0],
     index: usize,
     out: &mut Vec<u8>,
-    toc_entries: Option<(&mut Vec<TocEntryMetaV0>, &mut u32)>,
-) -> Option<usize> {
+    allow_deeper_levels: bool,
+) -> Option<(usize, Option<(u8, Vec<u8>)>)> {
     let TokenV0::ControlSeq(name) = tokens.get(index)? else {
         return None;
     };
@@ -693,17 +729,13 @@ fn consume_heading_command_v0(
     out.push(BOLD_END_MARKER_V0);
     push_paragraph_break(out);
 
-    if let Some((entries, next_anchor_id)) = toc_entries {
-        let level = heading_toc_level_for_control_v0(name.as_slice())?;
-        let anchor_id = *next_anchor_id;
-        *next_anchor_id = next_anchor_id.checked_add(1)?;
-        entries.push(TocEntryMetaV0 {
-            level,
-            anchor_id,
-            title: heading,
-        });
+    let heading_level = heading_toc_level_for_control_v0(name.as_slice());
+    if !allow_deeper_levels && heading_level.is_none() {
+        return None;
     }
-    Some(next)
+
+    let label_candidate = heading_level.map(|level| (level, heading));
+    Some((next, label_candidate))
 }
 
 fn is_hard_line_break_control_v0(name: &[u8]) -> bool {
@@ -1292,6 +1324,124 @@ fn is_safe_href_url_byte_v0(byte: u8) -> bool {
         )
 }
 
+fn is_safe_label_key_byte_v0(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b':' | b'-' | b'_' | b'.' | b'/')
+}
+
+fn parse_label_or_ref_key_group_v0(tokens: &[TokenV0], index: usize) -> Option<(Vec<u8>, usize)> {
+    let (group_start, group_end, next) = consume_group_bounds(tokens, index + 1)?;
+    let mut key = Vec::<u8>::new();
+    for token in &tokens[group_start..group_end] {
+        match token {
+            TokenV0::Char(byte) if is_safe_label_key_byte_v0(*byte) => key.push(*byte),
+            TokenV0::Space => return None,
+            _ => return None,
+        }
+    }
+    if key.is_empty() {
+        return None;
+    }
+    if key.starts_with(b"/") || key.windows(2).any(|window| window == b"..") {
+        return None;
+    }
+    Some((key, next))
+}
+
+fn resolve_ref_markers_v0(
+    body: &[u8],
+    labels_by_key: &BTreeMap<Vec<u8>, LabelEntryMetaV0>,
+    ref_occurrences: &mut Vec<RefOccurrenceMetaV0>,
+) -> Option<Vec<u8>> {
+    let mut out = Vec::<u8>::with_capacity(body.len());
+    let mut index = 0usize;
+    let mut line_index = 1u32;
+
+    while index < body.len() {
+        if body[index..].starts_with(REF_MARKER_PREFIX_V0) {
+            let key_start = index + REF_MARKER_PREFIX_V0.len();
+            let mut key_end = key_start;
+            while key_end < body.len() {
+                if body[key_end..].starts_with(REF_MARKER_SUFFIX_V0) {
+                    break;
+                }
+                if !is_safe_label_key_byte_v0(body[key_end]) {
+                    return None;
+                }
+                key_end += 1;
+            }
+            if key_end == key_start || key_end >= body.len() {
+                return None;
+            }
+            let key = body[key_start..key_end].to_vec();
+            let resolved_anchor_id = labels_by_key.get(&key).map(|entry| entry.anchor_id);
+            ref_occurrences.push(RefOccurrenceMetaV0 {
+                key,
+                line_index,
+                resolved_anchor_id,
+            });
+
+            if let Some(anchor_id) = resolved_anchor_id {
+                out.extend_from_slice(anchor_id.to_string().as_bytes());
+            } else {
+                out.extend_from_slice(b"??");
+            }
+            index = key_end + REF_MARKER_SUFFIX_V0.len();
+            continue;
+        }
+
+        let byte = body[index];
+        out.push(byte);
+        if byte == NEWLINE_MARKER_V0 {
+            line_index = line_index.checked_add(1)?;
+        }
+        index += 1;
+    }
+    Some(out)
+}
+
+fn consume_label_command_v0(
+    tokens: &[TokenV0],
+    index: usize,
+    labels_by_key: &mut BTreeMap<Vec<u8>, LabelEntryMetaV0>,
+    pending_label_target: &mut Option<PendingLabelTargetV0>,
+) -> Option<usize> {
+    if !matches!(
+        tokens.get(index),
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == LABEL_CONTROL_V0
+    ) {
+        return None;
+    }
+    let target = pending_label_target.take()?;
+    let (key, next) = parse_label_or_ref_key_group_v0(tokens, index)?;
+    if labels_by_key.contains_key(&key) {
+        return None;
+    }
+    labels_by_key.insert(
+        key,
+        LabelEntryMetaV0 {
+            anchor_id: target.anchor_id,
+            kind: target.kind,
+            level: target.level,
+            title: target.title,
+        },
+    );
+    Some(next)
+}
+
+fn consume_ref_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+    if !matches!(
+        tokens.get(index),
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == REF_CONTROL_V0
+    ) {
+        return None;
+    }
+    let (key, next) = parse_label_or_ref_key_group_v0(tokens, index)?;
+    out.extend_from_slice(REF_MARKER_PREFIX_V0);
+    out.extend_from_slice(&key);
+    out.extend_from_slice(REF_MARKER_SUFFIX_V0);
+    Some(next)
+}
+
 fn consume_footnote_command_v0(
     tokens: &[TokenV0],
     index: usize,
@@ -1420,11 +1570,14 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
     let mut footnotes = Vec::<Vec<u8>>::new();
     let mut href_urls = Vec::<Vec<u8>>::new();
     let mut toc_entries = Vec::<TocEntryMetaV0>::new();
-    let mut next_toc_anchor_id = 1u32;
+    let mut labels_by_key = BTreeMap::<Vec<u8>, LabelEntryMetaV0>::new();
+    let mut ref_occurrences = Vec::<RefOccurrenceMetaV0>::new();
+    let mut next_anchor_id = 1u32;
     let mut saw_maketitle = false;
     let mut saw_body_content_after_maketitle = false;
     let mut toc_requested = false;
     let mut pending_noindent_after_heading = false;
+    let mut pending_label_target = None::<PendingLabelTargetV0>;
     loop {
         match tokens.get(index) {
             Some(TokenV0::Space) => {
@@ -1435,6 +1588,7 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
                 emit_maketitle_block_v0(&mut body, &meta);
                 saw_maketitle = true;
                 pending_noindent_after_heading = false;
+                pending_label_target = None;
                 index += 1;
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == TABLEOFCONTENTS_CONTROL_V0 => {
@@ -1446,6 +1600,7 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
                 push_newline(&mut body);
                 push_paragraph_break(&mut body);
                 toc_requested = true;
+                pending_label_target = None;
                 index += 1;
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == END_CONTROL_V0 => {
@@ -1455,49 +1610,96 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == BEGIN_CONTROL_V0 => {
                 saw_body_content_after_maketitle = true;
                 pending_noindent_after_heading = false;
-                index = consume_body_environment_v0(tokens, index, &mut body)?;
+                let (env_name, _) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
+                if env_name.as_slice() == FIGURE_ENV_V0 {
+                    index = consume_figure_environment_v0(tokens, index, &mut body)?;
+                    let anchor_id = next_anchor_id;
+                    next_anchor_id = next_anchor_id.checked_add(1)?;
+                    pending_label_target = Some(PendingLabelTargetV0 {
+                        anchor_id,
+                        kind: LabelKindV0::Figure,
+                        level: None,
+                        title: None,
+                    });
+                } else {
+                    pending_label_target = None;
+                    index = consume_body_environment_v0(tokens, index, &mut body)?;
+                }
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == CARRELPAR_MARKER_CONTROL_V0 => {
                 push_paragraph_break(&mut body);
+                pending_label_target = None;
                 index += 1;
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == CENTERLINE_CONTROL_V0 => {
                 saw_body_content_after_maketitle = true;
                 pending_noindent_after_heading = false;
+                pending_label_target = None;
                 index = consume_centerline_command_v0(tokens, index, &mut body)?;
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == RIGHTLINE_CONTROL_V0 => {
                 saw_body_content_after_maketitle = true;
                 pending_noindent_after_heading = false;
+                pending_label_target = None;
                 index = consume_rightline_command_v0(tokens, index, &mut body)?;
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == FOOTNOTE_CONTROL_V0 => {
                 saw_body_content_after_maketitle = true;
                 maybe_emit_pending_noindent_prefix_v0(&mut body, &mut pending_noindent_after_heading);
+                pending_label_target = None;
                 index = consume_footnote_command_v0(tokens, index, &mut body, &mut footnotes)?;
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == HREF_CONTROL_V0 => {
                 saw_body_content_after_maketitle = true;
                 maybe_emit_pending_noindent_prefix_v0(&mut body, &mut pending_noindent_after_heading);
+                pending_label_target = None;
                 index = consume_href_command_v0(tokens, index, &mut body, &mut href_urls)?;
+            }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == LABEL_CONTROL_V0 => {
+                saw_body_content_after_maketitle = true;
+                index = consume_label_command_v0(
+                    tokens,
+                    index,
+                    &mut labels_by_key,
+                    &mut pending_label_target,
+                )?;
+            }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == REF_CONTROL_V0 => {
+                saw_body_content_after_maketitle = true;
+                maybe_emit_pending_noindent_prefix_v0(&mut body, &mut pending_noindent_after_heading);
+                pending_label_target = None;
+                index = consume_ref_command_v0(tokens, index, &mut body)?;
             }
             Some(TokenV0::ControlSeq(name)) if is_heading_control_v0(name.as_slice()) => {
                 saw_body_content_after_maketitle = true;
-                index = if toc_requested {
-                    consume_heading_command_v0(
-                        tokens,
-                        index,
-                        &mut body,
-                        Some((&mut toc_entries, &mut next_toc_anchor_id)),
-                    )?
+                let (next, heading_meta) =
+                    consume_heading_command_v0(tokens, index, &mut body, !toc_requested)?;
+                index = next;
+                if let Some((level, title)) = heading_meta {
+                    let anchor_id = next_anchor_id;
+                    next_anchor_id = next_anchor_id.checked_add(1)?;
+                    if toc_requested {
+                        toc_entries.push(TocEntryMetaV0 {
+                            level,
+                            anchor_id,
+                            title: title.clone(),
+                        });
+                    }
+                    pending_label_target = Some(PendingLabelTargetV0 {
+                        anchor_id,
+                        kind: LabelKindV0::Heading,
+                        level: Some(level),
+                        title: Some(title),
+                    });
                 } else {
-                    consume_heading_command_v0(tokens, index, &mut body, None)?
-                };
+                    pending_label_target = None;
+                }
                 pending_noindent_after_heading = true;
             }
             Some(_) => {
                 saw_body_content_after_maketitle = true;
                 maybe_emit_pending_noindent_prefix_v0(&mut body, &mut pending_noindent_after_heading);
+                pending_label_target = None;
                 index = consume_fragment_token_v0(tokens, index, &mut body, false, true)?;
             }
             None => return None,
@@ -1511,6 +1713,13 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
         return None;
     }
 
+    body = normalize_punctuation_spacing_v0(&body);
+    body = normalize_tex_double_quotes_v0(&body);
+    body = normalize_tex_dashes_v0(&body);
+    body = normalize_tex_ellipsis_v0(&body);
+    body = normalize_bracket_spacing_v0(&body);
+    body = resolve_ref_markers_v0(&body, &labels_by_key, &mut ref_occurrences)?;
+
     if !footnotes.is_empty() {
         push_paragraph_break(&mut body);
         for (note_index, footnote) in footnotes.iter().enumerate() {
@@ -1522,11 +1731,6 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
         }
     }
 
-    body = normalize_punctuation_spacing_v0(&body);
-    body = normalize_tex_double_quotes_v0(&body);
-    body = normalize_tex_dashes_v0(&body);
-    body = normalize_tex_ellipsis_v0(&body);
-    body = normalize_bracket_spacing_v0(&body);
     if !href_urls.is_empty() {
         push_paragraph_break(&mut body);
         for (href_index, href_url) in href_urls.iter().enumerate() {
@@ -1546,6 +1750,47 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
             body.extend_from_slice(entry.anchor_id.to_string().as_bytes());
             body.push(b' ');
             body.extend_from_slice(&entry.title);
+            push_newline(&mut body);
+        }
+    }
+    if !labels_by_key.is_empty() {
+        push_paragraph_break(&mut body);
+        for (key, entry) in &labels_by_key {
+            body.extend_from_slice(LABEL_LINE_PREFIX_MARKER_V0);
+            body.extend_from_slice(key);
+            body.push(b' ');
+            body.extend_from_slice(entry.anchor_id.to_string().as_bytes());
+            body.push(b' ');
+            body.extend_from_slice(match entry.kind {
+                LabelKindV0::Heading => b"heading",
+                LabelKindV0::Figure => b"figure",
+            });
+            body.push(b' ');
+            body.extend_from_slice(entry.level.unwrap_or(0).to_string().as_bytes());
+            body.push(b' ');
+            if let Some(title) = &entry.title {
+                body.extend_from_slice(title);
+            } else {
+                body.push(b'-');
+            }
+            push_newline(&mut body);
+        }
+    }
+    if !ref_occurrences.is_empty() {
+        push_paragraph_break(&mut body);
+        for occurrence in &ref_occurrences {
+            body.extend_from_slice(REF_LINE_PREFIX_MARKER_V0);
+            body.extend_from_slice(&occurrence.key);
+            body.push(b' ');
+            body.extend_from_slice(occurrence.line_index.to_string().as_bytes());
+            body.push(b' ');
+            body.extend_from_slice(
+                occurrence
+                    .resolved_anchor_id
+                    .unwrap_or(0)
+                    .to_string()
+                    .as_bytes(),
+            );
             push_newline(&mut body);
         }
     }

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -274,6 +274,44 @@ fn typeset_minimal_toc_anchor_ids_follow_document_order_even_when_levels_change(
 }
 
 #[test]
+fn typeset_minimal_labels_and_refs_emit_metadata_and_resolve_inline_values() {
+    let main = b"\\documentclass{article}\\title{T}\\author{A}\\date{D}\\begin{document}\\maketitle\\section{Intro}\\label{sec:intro}See \\ref{sec:intro} and \\ref{sec:missing}.\\begin{figure}\\caption{Figure caption}\\end{figure}\\label{fig:cap}Figure \\ref{fig:cap}.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("See 1 and ??."), "body={text:?}");
+    assert!(text.contains("Figure 2."), "body={text:?}");
+    assert!(text.contains("!l sec:intro 1 heading 1 Intro"), "body={text:?}");
+    assert!(text.contains("!l fig:cap 2 figure 0 -"), "body={text:?}");
+    assert!(text.contains("!r sec:intro "), "body={text:?}");
+    assert!(text.contains("!r sec:missing "), "body={text:?}");
+    assert!(text.contains("!r fig:cap "), "body={text:?}");
+}
+
+#[test]
+fn typeset_minimal_rejects_label_not_immediately_after_heading_or_figure() {
+    let main = b"\\documentclass{article}\\begin{document}\\section{Intro}Body first.\\label{sec:intro}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_duplicate_label_keys() {
+    let main = b"\\documentclass{article}\\begin{document}\\section{A}\\label{dup:key}\\subsection{B}\\label{dup:key}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_label_with_unsafe_key_bytes() {
+    let main = b"\\documentclass{article}\\begin{document}\\section{A}\\label{../bad}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
 fn typeset_minimal_heading_at_start_has_no_leading_blank_lines() {
     let main =
         b"\\documentclass{article}\\begin{document}\\paragraph{Lead in}Body text.\\end{document}";

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -23,6 +23,8 @@ const FOOTNOTE_LEADING_PT_V0: f32 = 12.0;
 const FOOTNOTE_BLOCK_GAP_PT_V0: f32 = 12.0;
 const FOOTNOTE_LINE_PREFIX_MARKER_V0: &[u8] = b"!f ";
 const HREF_URL_LINE_PREFIX_MARKER_V0: &[u8] = b"!u ";
+const LABEL_LINE_PREFIX_MARKER_V0: &[u8] = b"!l ";
+const REF_LINE_PREFIX_MARKER_V0: &[u8] = b"!r ";
 const NOINDENT_PREFIX_MARKER_V0: u8 = b'~';
 const LINK_START_MARKER_V0: u8 = b'<';
 const LINK_END_MARKER_V0: u8 = b'>';
@@ -885,6 +887,22 @@ fn has_href_url_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
             .eq(HREF_URL_LINE_PREFIX_MARKER_V0.iter().copied())
 }
 
+fn has_label_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() >= LABEL_LINE_PREFIX_MARKER_V0.len()
+        && glyphs[..LABEL_LINE_PREFIX_MARKER_V0.len()]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .eq(LABEL_LINE_PREFIX_MARKER_V0.iter().copied())
+}
+
+fn has_ref_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() >= REF_LINE_PREFIX_MARKER_V0.len()
+        && glyphs[..REF_LINE_PREFIX_MARKER_V0.len()]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .eq(REF_LINE_PREFIX_MARKER_V0.iter().copied())
+}
+
 fn parse_href_url_line_v0(glyphs: &[GlyphPlanV0]) -> Option<(u32, Vec<u8>)> {
     if glyphs.len() < HREF_URL_LINE_PREFIX_MARKER_V0.len() {
         return None;
@@ -929,6 +947,69 @@ fn parse_href_url_line_v0(glyphs: &[GlyphPlanV0]) -> Option<(u32, Vec<u8>)> {
         return None;
     }
     Some((marker_id, uri))
+}
+
+fn parse_label_line_v0(glyphs: &[GlyphPlanV0]) -> Option<()> {
+    if glyphs.len() < LABEL_LINE_PREFIX_MARKER_V0.len() {
+        return None;
+    }
+    let bytes: Vec<u8> = glyphs.iter().map(|glyph| glyph.byte).collect();
+    if !bytes.starts_with(LABEL_LINE_PREFIX_MARKER_V0) {
+        return None;
+    }
+    let line = String::from_utf8(bytes).ok()?;
+    let mut parts = line.splitn(6, ' ');
+    let prefix = parts.next()?;
+    if prefix != "!l" {
+        return None;
+    }
+    let key = parts.next()?.trim();
+    let anchor_id = parts.next()?.trim().parse::<u32>().ok()?;
+    let kind = parts.next()?.trim();
+    let level = parts.next()?.trim().parse::<u8>().ok()?;
+    let title = parts.next()?.trim();
+    if key.is_empty() || anchor_id == 0 {
+        return None;
+    }
+    if kind != "heading" && kind != "figure" {
+        return None;
+    }
+    if kind == "heading" && !(1..=2).contains(&level) {
+        return None;
+    }
+    if kind == "figure" && level != 0 {
+        return None;
+    }
+    if title.is_empty() {
+        return None;
+    }
+    Some(())
+}
+
+fn parse_ref_line_v0(glyphs: &[GlyphPlanV0]) -> Option<()> {
+    if glyphs.len() < REF_LINE_PREFIX_MARKER_V0.len() {
+        return None;
+    }
+    let bytes: Vec<u8> = glyphs.iter().map(|glyph| glyph.byte).collect();
+    if !bytes.starts_with(REF_LINE_PREFIX_MARKER_V0) {
+        return None;
+    }
+    let line = String::from_utf8(bytes).ok()?;
+    let mut parts = line.splitn(4, ' ');
+    let prefix = parts.next()?;
+    if prefix != "!r" {
+        return None;
+    }
+    let key = parts.next()?.trim();
+    let line_index = parts.next()?.trim().parse::<u32>().ok()?;
+    let resolved_anchor_id = parts.next()?.trim().parse::<u32>().ok()?;
+    if key.is_empty() || line_index == 0 {
+        return None;
+    }
+    if resolved_anchor_id == 0 {
+        return Some(());
+    }
+    Some(())
 }
 
 fn parse_toc_entry_line_v0(glyphs: &[GlyphPlanV0]) -> Option<TocEntryMetadataV0> {
@@ -1105,6 +1186,8 @@ fn split_body_and_metadata_lines_v0(pages: &[PagePlanV0]) -> (Vec<Vec<LinePlanV0
             if has_footnote_line_prefix_v0(&line.glyphs)
                 || has_href_url_line_prefix_v0(&line.glyphs)
                 || has_toc_entry_line_prefix_v0(&line.glyphs)
+                || has_label_line_prefix_v0(&line.glyphs)
+                || has_ref_line_prefix_v0(&line.glyphs)
             {
                 in_metadata = true;
             }
@@ -1160,6 +1243,14 @@ fn parse_metadata_lines_v0(
                 return None;
             }
             toc_entries.push(toc_entry);
+            current_footnote_id = None;
+            continue;
+        }
+        if parse_label_line_v0(&line.glyphs).is_some() {
+            current_footnote_id = None;
+            continue;
+        }
+        if parse_ref_line_v0(&line.glyphs).is_some() {
             current_footnote_id = None;
             continue;
         }

--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -571,9 +571,9 @@ if (labelsSummary?.typed_artifacts?.labels?.present !== true) {
   console.error('FAIL: expected labels typed artifact present after first run');
   process.exit(1);
 }
-const labelsPath = path.join(outDir, 'typeset_demo_labels_probe_v0', 'labels_v0.json');
+const labelsPath = path.join(outDir, 'typeset_demo_labels_probe_v0', 'labels_v1.json');
 if (!fs.existsSync(labelsPath)) {
-  console.error('FAIL: expected labels_v0.json artifact after first run');
+  console.error('FAIL: expected labels_v1.json artifact after first run');
   process.exit(1);
 }
 const labelsShaFirst = labelsSummary.typed_artifacts.labels.artifact_sha256;
@@ -583,15 +583,40 @@ if (typeof labelsShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(labelsShaFirst)
 }
 const labelsArtifactFirst = JSON.parse(fs.readFileSync(labelsPath, 'utf8'));
 if (!Array.isArray(labelsArtifactFirst?.entries)) {
-  console.error('FAIL: expected labels_v0.entries array in first-run artifact');
+  console.error('FAIL: expected labels_v1.entries array in first-run artifact');
   process.exit(1);
 }
 if (labelsArtifactFirst.entries.length <= 0) {
-  console.error('FAIL: expected non-empty labels_v0.entries for labels probe');
+  console.error('FAIL: expected non-empty labels_v1.entries for labels probe');
   process.exit(1);
 }
-assertEntrySourceSpans('typeset_demo_labels_probe_v0', 'labels_v0', labelsArtifactFirst.entries);
-fs.writeFileSync(firstRunShaPath('labels_v0'), `${labelsShaFirst}\n`);
+assertEntrySourceSpans('typeset_demo_labels_probe_v0', 'labels_v1', labelsArtifactFirst.entries);
+fs.writeFileSync(firstRunShaPath('labels_v1'), `${labelsShaFirst}\n`);
+if (labelsSummary?.typed_artifacts?.refs?.present !== true) {
+  console.error('FAIL: expected refs typed artifact present after first run');
+  process.exit(1);
+}
+const refsPath = path.join(outDir, 'typeset_demo_labels_probe_v0', 'refs_v1.json');
+if (!fs.existsSync(refsPath)) {
+  console.error('FAIL: expected refs_v1.json artifact after first run');
+  process.exit(1);
+}
+const refsShaFirst = labelsSummary.typed_artifacts.refs.artifact_sha256;
+if (typeof refsShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(refsShaFirst)) {
+  console.error('FAIL: expected refs artifact sha256 in first summary');
+  process.exit(1);
+}
+const refsArtifactFirst = JSON.parse(fs.readFileSync(refsPath, 'utf8'));
+if (!Array.isArray(refsArtifactFirst?.entries)) {
+  console.error('FAIL: expected refs_v1.entries array in first-run artifact');
+  process.exit(1);
+}
+if (refsArtifactFirst.entries.length <= 0) {
+  console.error('FAIL: expected non-empty refs_v1.entries for labels probe');
+  process.exit(1);
+}
+assertEntrySourceSpans('typeset_demo_labels_probe_v0', 'refs_v1', refsArtifactFirst.entries);
+fs.writeFileSync(firstRunShaPath('refs_v1'), `${refsShaFirst}\n`);
 
 const tocSummary = JSON.parse(
   fs.readFileSync(path.join(outDir, 'typeset_demo_toc_probe_v0', 'summary.json'), 'utf8'),
@@ -1295,8 +1320,9 @@ if (resourceHintsShaSecond !== resourceHintsShaFirst) {
   console.error('FAIL: report.resource_hints_v0 must be stable across reruns');
   process.exit(1);
 }
-const requiredTypedKeys = ['toc', 'labels', 'bib', 'hyperref', 'pkgopt', 'graphics'];
-const labelsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'labels_v0_first.sha256'), 'utf8').trim();
+const requiredTypedKeys = ['toc', 'labels', 'refs', 'bib', 'hyperref', 'pkgopt', 'graphics'];
+const labelsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'labels_v1_first.sha256'), 'utf8').trim();
+const refsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'refs_v1_first.sha256'), 'utf8').trim();
 const tocShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'toc_v1_first.sha256'), 'utf8').trim();
 const bibShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'bib_v0_first.sha256'), 'utf8').trim();
 const hyperrefShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'hyperref_v0_first.sha256'), 'utf8').trim();
@@ -1491,14 +1517,31 @@ if (!labelsArtifact || labelsArtifact.present !== true) {
 }
 const labelsShaSecond = labelsArtifact.artifact_sha256;
 if (labelsShaSecond !== labelsShaFirst) {
-  console.error('FAIL: labels_v0 artifact sha256 must be stable across reruns');
+  console.error('FAIL: labels_v1 artifact sha256 must be stable across reruns');
   process.exit(1);
 }
 const labelsArtifactSecond = JSON.parse(
-  fs.readFileSync(path.join(outDir, 'typeset_demo_labels_probe_v0', 'labels_v0.json'), 'utf8'),
+  fs.readFileSync(path.join(outDir, 'typeset_demo_labels_probe_v0', 'labels_v1.json'), 'utf8'),
 );
 if (!Array.isArray(labelsArtifactSecond?.entries) || labelsArtifactSecond.entries.length <= 0) {
-  console.error('FAIL: expected non-empty labels_v0.entries after rerun');
+  console.error('FAIL: expected non-empty labels_v1.entries after rerun');
+  process.exit(1);
+}
+const refsArtifact = labelsSummary?.typed_artifacts?.refs;
+if (!refsArtifact || refsArtifact.present !== true) {
+  console.error('FAIL: expected refs typed artifact present after second run');
+  process.exit(1);
+}
+const refsShaSecond = refsArtifact.artifact_sha256;
+if (refsShaSecond !== refsShaFirst) {
+  console.error('FAIL: refs_v1 artifact sha256 must be stable across reruns');
+  process.exit(1);
+}
+const refsArtifactSecond = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_labels_probe_v0', 'refs_v1.json'), 'utf8'),
+);
+if (!Array.isArray(refsArtifactSecond?.entries) || refsArtifactSecond.entries.length <= 0) {
+  console.error('FAIL: expected non-empty refs_v1.entries after rerun');
   process.exit(1);
 }
 
@@ -1681,7 +1724,8 @@ console.log(`PASS: typed_artifacts keys ${requiredTypedKeys.join(',')}`);
 console.log('PASS: typed_artifacts_version gate 1');
 console.log(`PASS: resource_hints_v0 sha stable ${resourceHintsShaSecond}`);
 console.log('PASS: resource_hints_v0 excludes ok_demo_v0');
-console.log(`PASS: labels_v0 sha stable ${labelsShaSecond}`);
+console.log(`PASS: labels_v1 sha stable ${labelsShaSecond}`);
+console.log(`PASS: refs_v1 sha stable ${refsShaSecond}`);
 console.log(`PASS: toc_v1 sha stable ${tocShaSecond}`);
 console.log(`PASS: bib_v0 sha stable ${bibShaSecond}`);
 console.log(`PASS: hyperref_v0 sha stable ${hyperrefShaSecond}`);

--- a/scripts/texlive_smoke/fixtures/typeset_demo_labels_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_labels_probe_v0.tex
@@ -8,5 +8,12 @@
 \maketitle
 
 \section{Intro}\label{sec:intro}
-See Section~\ref{sec:intro}.
+See Section~\ref{sec:intro} and unresolved~\ref{sec:missing}.
+
+\begin{figure}
+\caption{Probe figure caption.}
+\end{figure}
+\label{fig:probe}
+
+Figure~\ref{fig:probe} is resolved in-document.
 \end{document}

--- a/scripts/wasm_fixture_gallery_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v0.mjs
@@ -23,12 +23,14 @@ const STATUS_FAIL_V0 = 'FAIL';
 const STATUS_MISMATCH_V0 = 'MISMATCH';
 const EXPECTED_STATUS_VALUES_V0 = new Set([STATUS_OK_V0, STATUS_NI_V0, STATUS_INVALID_V0, STATUS_FAIL_V0]);
 const DEFAULT_ONDEMAND_FIXEDPOINT_MAX_ITERS_V1 = 3;
-const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'bib', 'hyperref', 'pkgopt', 'graphics'];
+const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'refs', 'bib', 'hyperref', 'pkgopt', 'graphics'];
 const TYPED_ARTIFACTS_VERSION_V0 = 1;
 const MAX_TOC_ENTRIES_V0 = 256;
 const MAX_TOC_TITLE_BYTES_V0 = 256;
 const MAX_LABEL_ENTRIES_V0 = 256;
 const MAX_LABEL_VALUE_BYTES_V0 = 256;
+const MAX_REF_ENTRIES_V0 = 256;
+const MAX_REF_OCCURRENCES_PER_KEY_V0 = 256;
 const MAX_BIB_ENTRIES_V0 = 256;
 const MAX_BIB_VALUE_BYTES_V0 = 256;
 const MAX_PKGOPT_ENTRIES_V0 = 256;
@@ -1872,9 +1874,53 @@ function extractHyperrefLinksFromSourceV0(sourceBytes) {
   return links;
 }
 
-function extractLabelEntriesFromSourceV0(sourceBytes) {
-  const entries = [];
+function isSafeLabelRefKeyValueV1(value) {
+  return typeof value === 'string'
+    && value.length > 0
+    && !value.includes(' ')
+    && !value.includes('..')
+    && !value.startsWith('/')
+    && /^[A-Za-z0-9:_./-]+$/.test(value);
+}
+
+function lineIndexForByteOffsetV1(sourceBytes, offset) {
+  let lineIndex = 1;
+  for (let index = 0; index < offset && index < sourceBytes.length; index += 1) {
+    if (sourceBytes[index] === 0x0a) {
+      lineIndex += 1;
+    }
+  }
+  return lineIndex;
+}
+
+function extractLabelsAndRefsFromSourceV1(sourceBytes) {
+  const labelsByKey = new Map();
+  const refsByKey = new Map();
+  let nextAnchorId = 1;
+  let pendingLabelTarget = null;
+  let inFigure = false;
   let index = 0;
+
+  const setPendingHeading = (level, title) => {
+    pendingLabelTarget = {
+      anchor_id: nextAnchorId,
+      kind: 'heading',
+      level,
+      title: title.length > 0 ? title : null,
+    };
+    nextAnchorId += 1;
+  };
+
+  const setPendingFigure = (title) => {
+    pendingLabelTarget = {
+      anchor_id: nextAnchorId,
+      kind: 'figure',
+      level: null,
+      title: title.length > 0 ? title : null,
+    };
+    nextAnchorId += 1;
+  };
+
   while (index < sourceBytes.length) {
     if (sourceBytes[index] !== 0x5c) {
       index += 1;
@@ -1888,43 +1934,179 @@ function extractLabelEntriesFromSourceV0(sourceBytes) {
       index += 1;
       continue;
     }
+
     const command = Buffer.from(sourceBytes.slice(index + 1, commandIndex)).toString('ascii');
-    if (command !== 'label' && command !== 'ref') {
-      index = commandIndex;
+    if (command === 'begin') {
+      const envGroup = readBracedGroupV0(sourceBytes, commandIndex);
+      if (!envGroup.ok) {
+        index = commandIndex;
+        pendingLabelTarget = null;
+        continue;
+      }
+      const envName = envGroup.value.trim();
+      if (envName === 'figure') {
+        inFigure = true;
+      }
+      pendingLabelTarget = null;
+      index = envGroup.next;
       continue;
     }
-    const keyGroup = readBracedGroupV0(sourceBytes, commandIndex);
-    if (!keyGroup.ok) {
-      index = commandIndex;
+    if (command === 'end') {
+      const envGroup = readBracedGroupV0(sourceBytes, commandIndex);
+      if (!envGroup.ok) {
+        index = commandIndex;
+        pendingLabelTarget = null;
+        continue;
+      }
+      const envName = envGroup.value.trim();
+      if (envName === 'figure') {
+        inFigure = false;
+      }
+      pendingLabelTarget = null;
+      index = envGroup.next;
       continue;
     }
-    if (keyGroup.value.length > 0) {
-      const valueBytes = Buffer.from(keyGroup.value, 'utf8');
-      if (valueBytes.length > MAX_LABEL_VALUE_BYTES_V0) {
-        throw new Error(`labels_v0 value exceeds cap ${MAX_LABEL_VALUE_BYTES_V0}`);
+    if (command === 'section' || command === 'subsection') {
+      const titleGroup = readBracedGroupV0(sourceBytes, commandIndex);
+      if (!titleGroup.ok) {
+        index = commandIndex;
+        pendingLabelTarget = null;
+        continue;
       }
-      entries.push({
-        command,
-        key: keyGroup.value,
-        source_span: buildSourceSpanV0(sourceBytes, index, keyGroup.next, 'labels_v0'),
-      });
-      if (entries.length > MAX_LABEL_ENTRIES_V0) {
-        throw new Error(`labels_v0 entries exceed cap ${MAX_LABEL_ENTRIES_V0}`);
-      }
+      const level = command === 'section' ? 1 : 2;
+      setPendingHeading(level, titleGroup.value.trim());
+      index = titleGroup.next;
+      continue;
     }
-    index = keyGroup.next;
+    if (command === 'caption' && inFigure) {
+      const captionGroup = readBracedGroupV0(sourceBytes, commandIndex);
+      if (!captionGroup.ok) {
+        index = commandIndex;
+        pendingLabelTarget = null;
+        continue;
+      }
+      setPendingFigure(captionGroup.value.trim());
+      index = captionGroup.next;
+      continue;
+    }
+    if (command === 'label') {
+      const keyGroup = readBracedGroupV0(sourceBytes, commandIndex);
+      if (!keyGroup.ok) {
+        index = commandIndex;
+        pendingLabelTarget = null;
+        continue;
+      }
+      const key = keyGroup.value.trim();
+      if (
+        pendingLabelTarget
+        && isSafeLabelRefKeyValueV1(key)
+        && !labelsByKey.has(key)
+      ) {
+        const keyBytes = Buffer.from(key, 'utf8');
+        if (keyBytes.length > MAX_LABEL_VALUE_BYTES_V0) {
+          throw new Error(`labels_v1 key exceeds cap ${MAX_LABEL_VALUE_BYTES_V0}`);
+        }
+        labelsByKey.set(key, {
+          key,
+          anchor_id: pendingLabelTarget.anchor_id,
+          kind: pendingLabelTarget.kind,
+          level: pendingLabelTarget.level,
+          title: pendingLabelTarget.title,
+          source_span: buildSourceSpanV0(sourceBytes, index, keyGroup.next, 'labels_v1'),
+        });
+        if (labelsByKey.size > MAX_LABEL_ENTRIES_V0) {
+          throw new Error(`labels_v1 entries exceed cap ${MAX_LABEL_ENTRIES_V0}`);
+        }
+      }
+      pendingLabelTarget = null;
+      index = keyGroup.next;
+      continue;
+    }
+    if (command === 'ref') {
+      const keyGroup = readBracedGroupV0(sourceBytes, commandIndex);
+      if (!keyGroup.ok) {
+        index = commandIndex;
+        pendingLabelTarget = null;
+        continue;
+      }
+      const key = keyGroup.value.trim();
+      if (isSafeLabelRefKeyValueV1(key)) {
+        let entry = refsByKey.get(key);
+        if (!entry) {
+          entry = {
+            key,
+            occurrences: [],
+            resolved: false,
+            source_span: buildSourceSpanV0(sourceBytes, index, keyGroup.next, 'refs_v1'),
+          };
+          refsByKey.set(key, entry);
+        }
+        entry.occurrences.push({
+          line_index: lineIndexForByteOffsetV1(sourceBytes, index),
+          anchor_id: null,
+        });
+        if (entry.occurrences.length > MAX_REF_OCCURRENCES_PER_KEY_V0) {
+          throw new Error(`refs_v1 occurrences exceed cap ${MAX_REF_OCCURRENCES_PER_KEY_V0} for key ${key}`);
+        }
+      }
+      pendingLabelTarget = null;
+      index = keyGroup.next;
+      continue;
+    }
+
+    pendingLabelTarget = null;
+    index = commandIndex;
   }
-  return entries;
+
+  const labels = [...labelsByKey.values()].sort((left, right) => left.key.localeCompare(right.key));
+  const refs = [...refsByKey.values()].sort((left, right) => left.key.localeCompare(right.key));
+  for (const refEntry of refs) {
+    const labelEntry = labelsByKey.get(refEntry.key);
+    if (!labelEntry) {
+      continue;
+    }
+    refEntry.resolved = true;
+    for (const occurrence of refEntry.occurrences) {
+      occurrence.anchor_id = labelEntry.anchor_id;
+    }
+  }
+  if (refs.length > MAX_REF_ENTRIES_V0) {
+    throw new Error(`refs_v1 entries exceed cap ${MAX_REF_ENTRIES_V0}`);
+  }
+  return {
+    labels,
+    refs,
+  };
 }
 
 async function emitLabelsTypedArtifactV0(caseOutDir, fixtureBytes) {
+  const extracted = extractLabelsAndRefsFromSourceV1(fixtureBytes);
   const payload = {
     version: TYPED_ARTIFACTS_VERSION_V0,
-    schema: 'labels_v0',
-    entries: extractLabelEntriesFromSourceV0(fixtureBytes),
+    schema: 'labels_v1',
+    entries: extracted.labels,
   };
   const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
-  const relpath = 'labels_v0.json';
+  const relpath = 'labels_v1.json';
+  const fullPath = path.join(caseOutDir, relpath);
+  await writeFile(fullPath, bytes);
+  return {
+    present: true,
+    items: payload.entries.length,
+    artifact_relpath: relpath,
+    artifact_sha256: sha256HexV0(bytes),
+  };
+}
+
+async function emitRefsTypedArtifactV0(caseOutDir, fixtureBytes) {
+  const extracted = extractLabelsAndRefsFromSourceV1(fixtureBytes);
+  const payload = {
+    version: TYPED_ARTIFACTS_VERSION_V0,
+    schema: 'refs_v1',
+    entries: extracted.refs,
+  };
+  const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  const relpath = 'refs_v1.json';
   const fullPath = path.join(caseOutDir, relpath);
   await writeFile(fullPath, bytes);
   return {
@@ -2072,6 +2254,7 @@ async function emitTypedArtifactsV0(caseSpec, caseOutDir, typedArtifacts, fixtur
   }
   if (caseSpec.id === 'typeset_demo_labels_probe_v0') {
     typedArtifacts.labels = await emitLabelsTypedArtifactV0(caseOutDir, fixtureBytes);
+    typedArtifacts.refs = await emitRefsTypedArtifactV0(caseOutDir, fixtureBytes);
   }
   if (caseSpec.id === 'typeset_demo_bib_probe_v0') {
     typedArtifacts.bib = await emitBibTypedArtifactV0(caseOutDir, fixtureBytes);


### PR DESCRIPTION
## Summary
- add typeset-minimal `\label{}` / `\ref{}` handling with fail-closed key validation and placement constraints
- emit label/ref metadata markers (`!l` / `!r`) and resolve inline refs to anchor ids or `??`
- add labels/refs typed artifact v1 plumbing in fixture gallery (`labels_v1.json`, `refs_v1.json`) with stable-sha proof checks

## Proof
- `cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests`
- `cargo test --manifest-path crates/carreltex-xdv/Cargo.toml`
- `./scripts/proof_wasm_typeset_minimal_v0.sh | tail -n 6`
- `./scripts/proof_wasm_fixture_gallery_v0.sh | tail -n 10`
