### PR TITLE
typeset_minimal bibliography stub v0 + cite v0 + typed artifacts

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -23,8 +23,13 @@ const FLUSHRIGHT_ENV_V0: &[u8] = b"flushright";
 const RIGHTLINE_CONTROL_V0: &[u8] = b"rightline";
 const TABULAR_ENV_V0: &[u8] = b"tabular";
 const FIGURE_ENV_V0: &[u8] = b"figure";
+const THEBIBLIOGRAPHY_ENV_V0: &[u8] = b"thebibliography";
 const CAPTION_CONTROL_V0: &[u8] = b"caption";
 const INCLUDEGRAPHICS_CONTROL_V0: &[u8] = b"includegraphics";
+const BIBITEM_CONTROL_V0: &[u8] = b"bibitem";
+const BIBLIOGRAPHY_CONTROL_V0: &[u8] = b"bibliography";
+const BIBLIOGRAPHYSTYLE_CONTROL_V0: &[u8] = b"bibliographystyle";
+const CITE_CONTROL_V0: &[u8] = b"cite";
 const FOOTNOTE_CONTROL_V0: &[u8] = b"footnote";
 const HREF_CONTROL_V0: &[u8] = b"href";
 const LABEL_CONTROL_V0: &[u8] = b"label";
@@ -33,6 +38,8 @@ const FOOTNOTE_LINE_PREFIX_MARKER_V0: &[u8] = b"!f ";
 const HREF_URL_LINE_PREFIX_MARKER_V0: &[u8] = b"!u ";
 const LABEL_LINE_PREFIX_MARKER_V0: &[u8] = b"!l ";
 const REF_LINE_PREFIX_MARKER_V0: &[u8] = b"!r ";
+const BIBITEM_LINE_PREFIX_MARKER_V0: &[u8] = b"!b ";
+const CITE_LINE_PREFIX_MARKER_V0: &[u8] = b"!c ";
 const TABLE_ROW_PREFIX_MARKER_V0: &[u8] = b"!t ";
 const FIGURE_BOX_PREFIX_MARKER_V0: &[u8] = b"!gbox";
 const FIGURE_CAPTION_PREFIX_MARKER_V0: &[u8] = b"!gcap ";
@@ -40,6 +47,8 @@ const TOC_PLACEHOLDER_MARKER_V0: &[u8] = b"!toc";
 const TOC_ENTRY_LINE_PREFIX_MARKER_V0: &[u8] = b"!toc ";
 const REF_MARKER_PREFIX_V0: &[u8] = b"@@REF:";
 const REF_MARKER_SUFFIX_V0: &[u8] = b"@@";
+const CITE_MARKER_PREFIX_V0: &[u8] = b"@@CITE:";
+const CITE_MARKER_SUFFIX_V0: &[u8] = b"@@";
 const LINK_START_MARKER_V0: u8 = b'<';
 const LINK_END_MARKER_V0: u8 = b'>';
 const NOINDENT_PREFIX_MARKER_V0: &[u8] = b"~ ";
@@ -89,6 +98,21 @@ struct RefOccurrenceMetaV0 {
     key: Vec<u8>,
     line_index: u32,
     resolved_anchor_id: Option<u32>,
+}
+
+#[derive(Clone)]
+struct BibItemMetaV0 {
+    key: Vec<u8>,
+    ordinal: u32,
+    text: Vec<u8>,
+    text_len: u32,
+}
+
+#[derive(Clone)]
+struct CiteOccurrenceMetaV0 {
+    key: Vec<u8>,
+    line_index: u32,
+    resolved_ordinal: Option<u32>,
 }
 
 #[derive(Default)]
@@ -1399,6 +1423,60 @@ fn resolve_ref_markers_v0(
     Some(out)
 }
 
+fn resolve_cite_markers_v0(
+    body: &[u8],
+    bibitems_by_key: &BTreeMap<Vec<u8>, u32>,
+    cite_occurrences: &mut Vec<CiteOccurrenceMetaV0>,
+) -> Option<Vec<u8>> {
+    let mut out = Vec::<u8>::with_capacity(body.len());
+    let mut index = 0usize;
+    let mut line_index = 1u32;
+
+    while index < body.len() {
+        if body[index..].starts_with(CITE_MARKER_PREFIX_V0) {
+            let key_start = index + CITE_MARKER_PREFIX_V0.len();
+            let mut key_end = key_start;
+            while key_end < body.len() {
+                if body[key_end..].starts_with(CITE_MARKER_SUFFIX_V0) {
+                    break;
+                }
+                if !is_safe_label_key_byte_v0(body[key_end]) {
+                    return None;
+                }
+                key_end += 1;
+            }
+            if key_end == key_start || key_end >= body.len() {
+                return None;
+            }
+            let key = body[key_start..key_end].to_vec();
+            let resolved_ordinal = bibitems_by_key.get(&key).copied();
+            cite_occurrences.push(CiteOccurrenceMetaV0 {
+                key,
+                line_index,
+                resolved_ordinal,
+            });
+
+            if let Some(ordinal) = resolved_ordinal {
+                out.push(b'[');
+                out.extend_from_slice(ordinal.to_string().as_bytes());
+                out.push(b']');
+            } else {
+                out.extend_from_slice(b"[?]");
+            }
+            index = key_end + CITE_MARKER_SUFFIX_V0.len();
+            continue;
+        }
+
+        let byte = body[index];
+        out.push(byte);
+        if byte == NEWLINE_MARKER_V0 {
+            line_index = line_index.checked_add(1)?;
+        }
+        index += 1;
+    }
+    Some(out)
+}
+
 fn consume_label_command_v0(
     tokens: &[TokenV0],
     index: usize,
@@ -1440,6 +1518,117 @@ fn consume_ref_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -
     out.extend_from_slice(&key);
     out.extend_from_slice(REF_MARKER_SUFFIX_V0);
     Some(next)
+}
+
+fn consume_cite_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+    if !matches!(
+        tokens.get(index),
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == CITE_CONTROL_V0
+    ) {
+        return None;
+    }
+    let (key, next) = parse_label_or_ref_key_group_v0(tokens, index)?;
+    out.extend_from_slice(CITE_MARKER_PREFIX_V0);
+    out.extend_from_slice(&key);
+    out.extend_from_slice(CITE_MARKER_SUFFIX_V0);
+    Some(next)
+}
+
+fn emit_bibliography_block_v0(out: &mut Vec<u8>, items: &[BibItemMetaV0]) {
+    push_paragraph_break(out);
+    out.extend_from_slice(SECTION_HEADING_PREFIX_MARKER_V0);
+    out.push(BOLD_START_MARKER_V0);
+    out.extend_from_slice(b"References");
+    out.push(BOLD_END_MARKER_V0);
+    push_paragraph_break(out);
+    for item in items {
+        out.push(b'[');
+        out.extend_from_slice(item.ordinal.to_string().as_bytes());
+        out.extend_from_slice(b"] ");
+        out.extend_from_slice(&item.text);
+        push_newline(out);
+    }
+    push_paragraph_break(out);
+}
+
+fn consume_thebibliography_environment_v0(
+    tokens: &[TokenV0],
+    index: usize,
+    out: &mut Vec<u8>,
+    bibitems: &mut Vec<BibItemMetaV0>,
+) -> Option<usize> {
+    let (env_name, mut cursor) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
+    if env_name.as_slice() != THEBIBLIOGRAPHY_ENV_V0 {
+        return None;
+    }
+
+    let (width_group_start, width_group_end, width_group_next) = consume_group_bounds(tokens, cursor)?;
+    let width_hint = parse_char_space_group_trimmed_v0(tokens, width_group_start, width_group_end)?;
+    if width_hint.is_empty() {
+        return None;
+    }
+    cursor = width_group_next;
+
+    let mut local_items = Vec::<BibItemMetaV0>::new();
+    loop {
+        cursor = skip_spaces(tokens, cursor);
+        if matches!(
+            tokens.get(cursor),
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == END_CONTROL_V0
+        ) {
+            let (end_env, next) = consume_env_name_command_v0(tokens, cursor, END_CONTROL_V0)?;
+            if end_env.as_slice() != THEBIBLIOGRAPHY_ENV_V0 || local_items.is_empty() {
+                return None;
+            }
+            emit_bibliography_block_v0(out, &local_items);
+            bibitems.extend(local_items);
+            return Some(next);
+        }
+
+        if !matches!(
+            tokens.get(cursor),
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == BIBITEM_CONTROL_V0
+        ) {
+            return None;
+        }
+
+        let (key, next_after_key) = parse_label_or_ref_key_group_v0(tokens, cursor)?;
+        if local_items.iter().any(|item| item.key == key) || bibitems.iter().any(|item| item.key == key) {
+            return None;
+        }
+        cursor = next_after_key;
+
+        let mut item_text = Vec::<u8>::new();
+        loop {
+            match tokens.get(cursor) {
+                Some(TokenV0::ControlSeq(name)) if name.as_slice() == BIBITEM_CONTROL_V0 => break,
+                Some(TokenV0::ControlSeq(name)) if name.as_slice() == END_CONTROL_V0 => break,
+                Some(TokenV0::ControlSeq(name)) if name.as_slice() == BEGIN_CONTROL_V0 => return None,
+                Some(_) => {
+                    cursor = consume_fragment_token_v0(tokens, cursor, &mut item_text, false, true)?;
+                }
+                None => return None,
+            }
+        }
+        trim_trailing_spaces(&mut item_text);
+        if item_text.is_empty() {
+            return None;
+        }
+        let ordinal = u32::try_from(
+            bibitems
+                .len()
+                .checked_add(local_items.len())?
+                .checked_add(1)?,
+        )
+        .ok()?;
+        let text_len = u32::try_from(item_text.len()).ok()?;
+        local_items.push(BibItemMetaV0 {
+            key,
+            ordinal,
+            text: item_text,
+            text_len,
+        });
+    }
 }
 
 fn consume_footnote_command_v0(
@@ -1569,9 +1758,11 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
     let mut body = Vec::<u8>::new();
     let mut footnotes = Vec::<Vec<u8>>::new();
     let mut href_urls = Vec::<Vec<u8>>::new();
+    let mut bibitems = Vec::<BibItemMetaV0>::new();
     let mut toc_entries = Vec::<TocEntryMetaV0>::new();
     let mut labels_by_key = BTreeMap::<Vec<u8>, LabelEntryMetaV0>::new();
     let mut ref_occurrences = Vec::<RefOccurrenceMetaV0>::new();
+    let mut cite_occurrences = Vec::<CiteOccurrenceMetaV0>::new();
     let mut next_anchor_id = 1u32;
     let mut saw_maketitle = false;
     let mut saw_body_content_after_maketitle = false;
@@ -1621,6 +1812,9 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
                         level: None,
                         title: None,
                     });
+                } else if env_name.as_slice() == THEBIBLIOGRAPHY_ENV_V0 {
+                    pending_label_target = None;
+                    index = consume_thebibliography_environment_v0(tokens, index, &mut body, &mut bibitems)?;
                 } else {
                     pending_label_target = None;
                     index = consume_body_environment_v0(tokens, index, &mut body)?;
@@ -1669,6 +1863,18 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
                 maybe_emit_pending_noindent_prefix_v0(&mut body, &mut pending_noindent_after_heading);
                 pending_label_target = None;
                 index = consume_ref_command_v0(tokens, index, &mut body)?;
+            }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == CITE_CONTROL_V0 => {
+                saw_body_content_after_maketitle = true;
+                maybe_emit_pending_noindent_prefix_v0(&mut body, &mut pending_noindent_after_heading);
+                pending_label_target = None;
+                index = consume_cite_command_v0(tokens, index, &mut body)?;
+            }
+            Some(TokenV0::ControlSeq(name))
+                if name.as_slice() == BIBLIOGRAPHY_CONTROL_V0
+                    || name.as_slice() == BIBLIOGRAPHYSTYLE_CONTROL_V0 =>
+            {
+                return None;
             }
             Some(TokenV0::ControlSeq(name)) if is_heading_control_v0(name.as_slice()) => {
                 saw_body_content_after_maketitle = true;
@@ -1719,6 +1925,11 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
     body = normalize_tex_ellipsis_v0(&body);
     body = normalize_bracket_spacing_v0(&body);
     body = resolve_ref_markers_v0(&body, &labels_by_key, &mut ref_occurrences)?;
+    let bibitems_by_key = bibitems
+        .iter()
+        .map(|item| (item.key.clone(), item.ordinal))
+        .collect::<BTreeMap<Vec<u8>, u32>>();
+    body = resolve_cite_markers_v0(&body, &bibitems_by_key, &mut cite_occurrences)?;
 
     if !footnotes.is_empty() {
         push_paragraph_break(&mut body);
@@ -1787,6 +1998,36 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
             body.extend_from_slice(
                 occurrence
                     .resolved_anchor_id
+                    .unwrap_or(0)
+                    .to_string()
+                    .as_bytes(),
+            );
+            push_newline(&mut body);
+        }
+    }
+    if !bibitems.is_empty() {
+        push_paragraph_break(&mut body);
+        for item in &bibitems {
+            body.extend_from_slice(BIBITEM_LINE_PREFIX_MARKER_V0);
+            body.extend_from_slice(&item.key);
+            body.push(b' ');
+            body.extend_from_slice(item.ordinal.to_string().as_bytes());
+            body.push(b' ');
+            body.extend_from_slice(item.text_len.to_string().as_bytes());
+            push_newline(&mut body);
+        }
+    }
+    if !cite_occurrences.is_empty() {
+        push_paragraph_break(&mut body);
+        for occurrence in &cite_occurrences {
+            body.extend_from_slice(CITE_LINE_PREFIX_MARKER_V0);
+            body.extend_from_slice(&occurrence.key);
+            body.push(b' ');
+            body.extend_from_slice(occurrence.line_index.to_string().as_bytes());
+            body.push(b' ');
+            body.extend_from_slice(
+                occurrence
+                    .resolved_ordinal
                     .unwrap_or(0)
                     .to_string()
                     .as_bytes(),

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -304,6 +304,43 @@ fn typeset_minimal_rejects_duplicate_label_keys() {
 }
 
 #[test]
+fn typeset_minimal_bibliography_and_cites_emit_block_and_metadata() {
+    let main = b"\\documentclass{article}\\begin{document}See \\cite{ref:a} and \\cite{missing}.\\begin{thebibliography}{9}\\bibitem{ref:a}Alpha source text.\\end{thebibliography}\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("See [1] and [?]."), "body={text:?}");
+    assert!(text.contains("@S {References}"), "body={text:?}");
+    assert!(text.contains("[1] Alpha source text."), "body={text:?}");
+    assert!(text.contains("!b ref:a 1 18"), "body={text:?}");
+    assert!(text.contains("!c ref:a "), "body={text:?}");
+    assert!(text.contains("!c missing "), "body={text:?}");
+}
+
+#[test]
+fn typeset_minimal_rejects_bibliography_command_stub() {
+    let main = b"\\documentclass{article}\\begin{document}\\bibliography{refs}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_bibliographystyle_command_stub() {
+    let main = b"\\documentclass{article}\\begin{document}\\bibliographystyle{plain}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_thebibliography_without_bibitem() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{thebibliography}{9}\\end{thebibliography}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
 fn typeset_minimal_rejects_label_with_unsafe_key_bytes() {
     let main = b"\\documentclass{article}\\begin{document}\\section{A}\\label{../bad}\\end{document}";
     let result = compile_typeset(main);

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -25,6 +25,8 @@ const FOOTNOTE_LINE_PREFIX_MARKER_V0: &[u8] = b"!f ";
 const HREF_URL_LINE_PREFIX_MARKER_V0: &[u8] = b"!u ";
 const LABEL_LINE_PREFIX_MARKER_V0: &[u8] = b"!l ";
 const REF_LINE_PREFIX_MARKER_V0: &[u8] = b"!r ";
+const BIBITEM_LINE_PREFIX_MARKER_V0: &[u8] = b"!b ";
+const CITE_LINE_PREFIX_MARKER_V0: &[u8] = b"!c ";
 const NOINDENT_PREFIX_MARKER_V0: u8 = b'~';
 const LINK_START_MARKER_V0: u8 = b'<';
 const LINK_END_MARKER_V0: u8 = b'>';
@@ -903,6 +905,22 @@ fn has_ref_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
             .eq(REF_LINE_PREFIX_MARKER_V0.iter().copied())
 }
 
+fn has_bibitem_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() >= BIBITEM_LINE_PREFIX_MARKER_V0.len()
+        && glyphs[..BIBITEM_LINE_PREFIX_MARKER_V0.len()]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .eq(BIBITEM_LINE_PREFIX_MARKER_V0.iter().copied())
+}
+
+fn has_cite_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() >= CITE_LINE_PREFIX_MARKER_V0.len()
+        && glyphs[..CITE_LINE_PREFIX_MARKER_V0.len()]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .eq(CITE_LINE_PREFIX_MARKER_V0.iter().copied())
+}
+
 fn parse_href_url_line_v0(glyphs: &[GlyphPlanV0]) -> Option<(u32, Vec<u8>)> {
     if glyphs.len() < HREF_URL_LINE_PREFIX_MARKER_V0.len() {
         return None;
@@ -1007,6 +1025,55 @@ fn parse_ref_line_v0(glyphs: &[GlyphPlanV0]) -> Option<()> {
         return None;
     }
     if resolved_anchor_id == 0 {
+        return Some(());
+    }
+    Some(())
+}
+
+fn parse_bibitem_line_v0(glyphs: &[GlyphPlanV0]) -> Option<()> {
+    if glyphs.len() < BIBITEM_LINE_PREFIX_MARKER_V0.len() {
+        return None;
+    }
+    let bytes: Vec<u8> = glyphs.iter().map(|glyph| glyph.byte).collect();
+    if !bytes.starts_with(BIBITEM_LINE_PREFIX_MARKER_V0) {
+        return None;
+    }
+    let line = String::from_utf8(bytes).ok()?;
+    let mut parts = line.splitn(4, ' ');
+    let prefix = parts.next()?;
+    if prefix != "!b" {
+        return None;
+    }
+    let key = parts.next()?.trim();
+    let ordinal = parts.next()?.trim().parse::<u32>().ok()?;
+    let text = parts.next()?.trim();
+    if key.is_empty() || ordinal == 0 || text.is_empty() {
+        return None;
+    }
+    Some(())
+}
+
+fn parse_cite_line_v0(glyphs: &[GlyphPlanV0]) -> Option<()> {
+    if glyphs.len() < CITE_LINE_PREFIX_MARKER_V0.len() {
+        return None;
+    }
+    let bytes: Vec<u8> = glyphs.iter().map(|glyph| glyph.byte).collect();
+    if !bytes.starts_with(CITE_LINE_PREFIX_MARKER_V0) {
+        return None;
+    }
+    let line = String::from_utf8(bytes).ok()?;
+    let mut parts = line.splitn(4, ' ');
+    let prefix = parts.next()?;
+    if prefix != "!c" {
+        return None;
+    }
+    let key = parts.next()?.trim();
+    let line_index = parts.next()?.trim().parse::<u32>().ok()?;
+    let resolved_ordinal = parts.next()?.trim().parse::<u32>().ok()?;
+    if key.is_empty() || line_index == 0 {
+        return None;
+    }
+    if resolved_ordinal == 0 {
         return Some(());
     }
     Some(())
@@ -1188,6 +1255,8 @@ fn split_body_and_metadata_lines_v0(pages: &[PagePlanV0]) -> (Vec<Vec<LinePlanV0
                 || has_toc_entry_line_prefix_v0(&line.glyphs)
                 || has_label_line_prefix_v0(&line.glyphs)
                 || has_ref_line_prefix_v0(&line.glyphs)
+                || has_bibitem_line_prefix_v0(&line.glyphs)
+                || has_cite_line_prefix_v0(&line.glyphs)
             {
                 in_metadata = true;
             }
@@ -1251,6 +1320,14 @@ fn parse_metadata_lines_v0(
             continue;
         }
         if parse_ref_line_v0(&line.glyphs).is_some() {
+            current_footnote_id = None;
+            continue;
+        }
+        if parse_bibitem_line_v0(&line.glyphs).is_some() {
+            current_footnote_id = None;
+            continue;
+        }
+        if parse_cite_line_v0(&line.glyphs).is_some() {
             current_footnote_id = None;
             continue;
         }

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -2013,6 +2013,47 @@ fn pdf_renderer_multipage_footnotes_and_annots_associate_per_page_v0() {
 }
 
 #[test]
+fn pdf_renderer_accepts_bibliography_and_cite_metadata_lines_v0() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"Body cite [1] and unresolved [?].\n\n!b ref:a 1 Alpha source text.\n!c ref:a 1 1\n!c missing 1 0",
+    )
+    .expect("writer should accept bibliography marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    assert!(
+        pdf_text.contains("(Body cite "),
+        "body prefix text should render: {pdf_text}"
+    );
+    assert!(
+        pdf_text.contains("(1) Tj"),
+        "resolved cite token should render: {pdf_text}"
+    );
+    assert!(
+        pdf_text.contains("(?) Tj"),
+        "unresolved cite token should render: {pdf_text}"
+    );
+    assert!(
+        !pdf_text.contains("!b ref:a"),
+        "bibliography metadata prefix should be hidden in pdf output: {pdf_text}"
+    );
+    assert!(
+        !pdf_text.contains("!c ref:a"),
+        "cite metadata prefix should be hidden in pdf output: {pdf_text}"
+    );
+}
+
+#[test]
+fn pdf_renderer_rejects_malformed_cite_metadata_line_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"Body text.\n\n!c ref:a 0 1")
+        .expect("writer should accept marker text bytes");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed on malformed cite metadata line"
+    );
+}
+
+#[test]
 fn pdf_renderer_table_rows_use_stable_column_x_offsets_v0() {
     let xdv = write_dvi_v2_text_page_v0(
         b"Before.\n\n!t Alpha||Beta||Gamma\n!t Delta||Epsilon||Zeta\n\nAfter.",

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -97,4 +97,12 @@ Flushright environment line one.\linebreak Flushright environment line two.
 \end{flushright}
 \rightline{Single right-aligned command line.}
 
+\subsection{Bibliography}
+This paragraph cites one known source \cite{ref:alpha} and one unresolved source \cite{ref:missing} to keep cite rendering deterministic.
+
+\begin{thebibliography}{9}
+\bibitem{ref:alpha}Alpha bibliography entry text for deterministic cite rendering.
+\bibitem{ref:beta}Beta bibliography entry text for deterministic ordering checks.
+\end{thebibliography}
+
 \end{document}

--- a/scripts/wasm_fixture_gallery_v1/main.mjs
+++ b/scripts/wasm_fixture_gallery_v1/main.mjs
@@ -23,7 +23,7 @@ const STATUS_FAIL_V0 = 'FAIL';
 const STATUS_MISMATCH_V0 = 'MISMATCH';
 const EXPECTED_STATUS_VALUES_V0 = new Set([STATUS_OK_V0, STATUS_NI_V0, STATUS_INVALID_V0, STATUS_FAIL_V0]);
 const DEFAULT_ONDEMAND_FIXEDPOINT_MAX_ITERS_V1 = 3;
-const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'refs', 'bib', 'hyperref', 'pkgopt', 'graphics'];
+const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'refs', 'bib', 'bibitems', 'cites', 'hyperref', 'pkgopt', 'graphics'];
 const TYPED_ARTIFACTS_VERSION_V0 = 1;
 const MAX_TOC_ENTRIES_V0 = 256;
 const MAX_TOC_TITLE_BYTES_V0 = 256;
@@ -1823,6 +1823,193 @@ function extractBibEntriesFromSourceV0(sourceBytes) {
   return entries;
 }
 
+function extractBibitemsAndCitesFromSourceV1(sourceBytes) {
+  const bibitems = [];
+  const bibOrdinalByKey = new Map();
+  const citesByKey = new Map();
+  const citeCommands = new Set(['cite']);
+  let inBibliography = false;
+  let index = 0;
+
+  const addBibitem = (key, text, startByte, endByte) => {
+    const keyBytes = Buffer.from(key, 'utf8');
+    if (keyBytes.length > MAX_BIB_VALUE_BYTES_V0) {
+      throw new Error(`bibitems_v1 key exceeds cap ${MAX_BIB_VALUE_BYTES_V0}`);
+    }
+    const textBytes = Buffer.from(text, 'utf8');
+    if (textBytes.length > MAX_BIB_VALUE_BYTES_V0 * 8) {
+      throw new Error(`bibitems_v1 text exceeds cap ${MAX_BIB_VALUE_BYTES_V0 * 8}`);
+    }
+    if (bibOrdinalByKey.has(key)) {
+      throw new Error(`bibitems_v1 duplicate key '${key}'`);
+    }
+    const ordinal = bibitems.length + 1;
+    const sourceSpan = buildSourceSpanV0(sourceBytes, startByte, endByte, 'bibitems_v1');
+    bibOrdinalByKey.set(key, ordinal);
+    bibitems.push({
+      key,
+      ordinal,
+      text_sha256: sha256HexV0(textBytes),
+      source_span: sourceSpan,
+    });
+    if (bibitems.length > MAX_BIB_ENTRIES_V0) {
+      throw new Error(`bibitems_v1 entries exceed cap ${MAX_BIB_ENTRIES_V0}`);
+    }
+  };
+
+  const addCiteOccurrence = (key, startByte, endByte) => {
+    const keyBytes = Buffer.from(key, 'utf8');
+    if (keyBytes.length > MAX_BIB_VALUE_BYTES_V0) {
+      throw new Error(`cites_v1 key exceeds cap ${MAX_BIB_VALUE_BYTES_V0}`);
+    }
+    let entry = citesByKey.get(key);
+    if (!entry) {
+      entry = {
+        key,
+        occurrences: [],
+        resolved: false,
+        ordinal: null,
+        source_span: buildSourceSpanV0(sourceBytes, startByte, endByte, 'cites_v1'),
+      };
+      citesByKey.set(key, entry);
+    }
+    entry.occurrences.push({
+      line_index: lineIndexForByteOffsetV1(sourceBytes, startByte),
+    });
+    if (entry.occurrences.length > MAX_REF_OCCURRENCES_PER_KEY_V0) {
+      throw new Error(`cites_v1 occurrences exceed cap ${MAX_REF_OCCURRENCES_PER_KEY_V0} for key ${key}`);
+    }
+  };
+
+  const normalizeBibitemText = (bytes) => {
+    const raw = Buffer.from(bytes).toString('utf8');
+    return raw.replace(/\s+/g, ' ').trim();
+  };
+
+  while (index < sourceBytes.length) {
+    if (sourceBytes[index] !== 0x5c) {
+      index += 1;
+      continue;
+    }
+    let commandIndex = index + 1;
+    while (commandIndex < sourceBytes.length && isAsciiLetterByteV0(sourceBytes[commandIndex])) {
+      commandIndex += 1;
+    }
+    if (commandIndex === index + 1) {
+      index += 1;
+      continue;
+    }
+    const command = Buffer.from(sourceBytes.slice(index + 1, commandIndex)).toString('ascii');
+
+    if (command === 'begin' || command === 'end') {
+      const envGroup = readBracedGroupV0(sourceBytes, commandIndex);
+      if (!envGroup.ok) {
+        index = commandIndex;
+        continue;
+      }
+      const envName = envGroup.value.trim();
+      if (envName === 'thebibliography') {
+        inBibliography = command === 'begin';
+      }
+      index = envGroup.next;
+      continue;
+    }
+
+    if (inBibliography && command === 'bibitem') {
+      const keyGroup = readBracedGroupV0(sourceBytes, commandIndex);
+      if (!keyGroup.ok) {
+        index = commandIndex;
+        continue;
+      }
+      const key = keyGroup.value.trim();
+      if (!isSafeLabelRefKeyValueV1(key)) {
+        index = keyGroup.next;
+        continue;
+      }
+      let cursor = keyGroup.next;
+      let textEnd = cursor;
+      while (cursor < sourceBytes.length) {
+        if (sourceBytes[cursor] !== 0x5c) {
+          cursor += 1;
+          continue;
+        }
+        let nestedCommandEnd = cursor + 1;
+        while (
+          nestedCommandEnd < sourceBytes.length
+          && isAsciiLetterByteV0(sourceBytes[nestedCommandEnd])
+        ) {
+          nestedCommandEnd += 1;
+        }
+        if (nestedCommandEnd === cursor + 1) {
+          cursor += 1;
+          continue;
+        }
+        const nestedCommand = Buffer.from(sourceBytes.slice(cursor + 1, nestedCommandEnd)).toString('ascii');
+        if (nestedCommand === 'bibitem') {
+          break;
+        }
+        if (nestedCommand === 'end') {
+          const envGroup = readBracedGroupV0(sourceBytes, nestedCommandEnd);
+          if (envGroup.ok && envGroup.value.trim() === 'thebibliography') {
+            break;
+          }
+        }
+        cursor = nestedCommandEnd;
+      }
+      textEnd = cursor;
+      const text = normalizeBibitemText(sourceBytes.slice(keyGroup.next, textEnd));
+      if (text.length > 0) {
+        addBibitem(key, text, index, textEnd);
+      }
+      index = textEnd;
+      continue;
+    }
+
+    if (citeCommands.has(command)) {
+      let next = commandIndex;
+      for (let i = 0; i < 2; i += 1) {
+        const optGroup = readBracketGroupV0(sourceBytes, next);
+        if (!optGroup.ok) {
+          break;
+        }
+        next = optGroup.next;
+      }
+      const citeGroup = readBracedGroupV0(sourceBytes, next);
+      if (!citeGroup.ok) {
+        index = commandIndex;
+        continue;
+      }
+      for (const key of splitCommaValuesV0(citeGroup.value)) {
+        if (!isSafeLabelRefKeyValueV1(key)) {
+          continue;
+        }
+        addCiteOccurrence(key, index, citeGroup.next);
+      }
+      index = citeGroup.next;
+      continue;
+    }
+
+    index = commandIndex;
+  }
+
+  const cites = [...citesByKey.values()].sort((left, right) => left.key.localeCompare(right.key));
+  for (const cite of cites) {
+    const ordinal = bibOrdinalByKey.get(cite.key);
+    if (ordinal) {
+      cite.resolved = true;
+      cite.ordinal = ordinal;
+    }
+  }
+  if (cites.length > MAX_BIB_ENTRIES_V0) {
+    throw new Error(`cites_v1 entries exceed cap ${MAX_BIB_ENTRIES_V0}`);
+  }
+
+  return {
+    bibitems,
+    cites,
+  };
+}
+
 function extractHyperrefLinksFromSourceV0(sourceBytes) {
   const links = [];
   let index = 0;
@@ -2171,6 +2358,44 @@ async function emitBibTypedArtifactV0(caseOutDir, fixtureBytes) {
   };
 }
 
+async function emitBibitemsTypedArtifactV0(caseOutDir, fixtureBytes) {
+  const extracted = extractBibitemsAndCitesFromSourceV1(fixtureBytes);
+  const payload = {
+    version: TYPED_ARTIFACTS_VERSION_V0,
+    schema: 'bibitems_v1',
+    entries: extracted.bibitems,
+  };
+  const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  const relpath = 'bibitems_v1.json';
+  const fullPath = path.join(caseOutDir, relpath);
+  await writeFile(fullPath, bytes);
+  return {
+    present: true,
+    items: payload.entries.length,
+    artifact_relpath: relpath,
+    artifact_sha256: sha256HexV0(bytes),
+  };
+}
+
+async function emitCitesTypedArtifactV0(caseOutDir, fixtureBytes) {
+  const extracted = extractBibitemsAndCitesFromSourceV1(fixtureBytes);
+  const payload = {
+    version: TYPED_ARTIFACTS_VERSION_V0,
+    schema: 'cites_v1',
+    entries: extracted.cites,
+  };
+  const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  const relpath = 'cites_v1.json';
+  const fullPath = path.join(caseOutDir, relpath);
+  await writeFile(fullPath, bytes);
+  return {
+    present: true,
+    items: payload.entries.length,
+    artifact_relpath: relpath,
+    artifact_sha256: sha256HexV0(bytes),
+  };
+}
+
 async function emitPkgoptTypedArtifactV0(caseOutDir, fixtureBytes) {
   const payload = {
     version: TYPED_ARTIFACTS_VERSION_V0,
@@ -2258,6 +2483,10 @@ async function emitTypedArtifactsV0(caseSpec, caseOutDir, typedArtifacts, fixtur
   }
   if (caseSpec.id === 'typeset_demo_bib_probe_v0') {
     typedArtifacts.bib = await emitBibTypedArtifactV0(caseOutDir, fixtureBytes);
+  }
+  if (caseSpec.id === 'typeset_demo_minimal_v0') {
+    typedArtifacts.bibitems = await emitBibitemsTypedArtifactV0(caseOutDir, fixtureBytes);
+    typedArtifacts.cites = await emitCitesTypedArtifactV0(caseOutDir, fixtureBytes);
   }
   if (caseSpec.id === 'typeset_demo_hyperref_probe_v0') {
     typedArtifacts.hyperref = await emitHyperrefTypedArtifactV0(caseOutDir, fixtureBytes);


### PR DESCRIPTION
## Summary\n- add typeset_minimal bibliography stub via \begin{thebibliography} + \bibitem and inline \cite resolution ([n]/[?])\n- emit/parse deterministic bibliography + cite metadata lines used by preview/render pipeline\n- wire typed artifacts for bibitems_v1/cites_v1 in fixture gallery and update minimal fixture coverage\n\n## Proofs\n- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests\n- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml\n- ./scripts/proof_wasm_typeset_minimal_v0.sh\n- ./scripts/proof_wasm_fixture_gallery_v0.sh