### PR TITLE
typeset_minimal math inline/display v0 with math_v1 artifacts

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -49,6 +49,8 @@ const REF_MARKER_PREFIX_V0: &[u8] = b"@@REF:";
 const REF_MARKER_SUFFIX_V0: &[u8] = b"@@";
 const CITE_MARKER_PREFIX_V0: &[u8] = b"@@CITE:";
 const CITE_MARKER_SUFFIX_V0: &[u8] = b"@@";
+const INLINE_MATH_PLACEHOLDER_V0: &[u8] = b"MATH";
+const DISPLAY_MATH_PLACEHOLDER_V0: &[u8] = b"MATH DISPLAY";
 const LINK_START_MARKER_V0: u8 = b'<';
 const LINK_END_MARKER_V0: u8 = b'>';
 const NOINDENT_PREFIX_MARKER_V0: &[u8] = b"~ ";
@@ -436,6 +438,93 @@ fn is_supported_literal_char_v0(byte: u8) -> bool {
     )
 }
 
+fn is_safe_math_payload_char_v0(byte: u8) -> bool {
+    (0x20..=0x7e).contains(&byte)
+        && !matches!(
+            byte,
+            b'$'
+                | b'\\'
+                | ITALIC_START_MARKER_V0
+                | ITALIC_END_MARKER_V0
+                | BOLD_START_MARKER_V0
+                | BOLD_END_MARKER_V0
+                | LINK_START_MARKER_V0
+                | LINK_END_MARKER_V0
+        )
+}
+
+fn consume_inline_math_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+    if !matches!(tokens.get(index), Some(TokenV0::Char(b'$'))) {
+        return None;
+    }
+    let mut cursor = index + 1;
+    let mut payload = Vec::<u8>::new();
+    loop {
+        match tokens.get(cursor) {
+            Some(TokenV0::Char(b'$')) => {
+                trim_trailing_spaces(&mut payload);
+                if payload.is_empty() {
+                    return None;
+                }
+                out.extend_from_slice(INLINE_MATH_PLACEHOLDER_V0);
+                return Some(cursor + 1);
+            }
+            Some(TokenV0::Char(byte)) if *byte == NEWLINE_MARKER_V0 => {
+                push_space(&mut payload);
+                cursor += 1;
+            }
+            Some(TokenV0::Char(byte)) if is_safe_math_payload_char_v0(*byte) => {
+                payload.push(*byte);
+                cursor += 1;
+            }
+            Some(TokenV0::Space) => {
+                push_space(&mut payload);
+                cursor += 1;
+            }
+            _ => return None,
+        }
+    }
+}
+
+fn consume_display_math_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+    if !matches!(
+        tokens.get(index),
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"["
+    ) {
+        return None;
+    }
+    let mut cursor = index + 1;
+    let mut payload = Vec::<u8>::new();
+    loop {
+        match tokens.get(cursor) {
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"]" => {
+                trim_trailing_spaces(&mut payload);
+                if payload.is_empty() {
+                    return None;
+                }
+                push_paragraph_break(out);
+                out.extend_from_slice(b"^ ");
+                out.extend_from_slice(DISPLAY_MATH_PLACEHOLDER_V0);
+                push_paragraph_break(out);
+                return Some(cursor + 1);
+            }
+            Some(TokenV0::Char(byte)) if *byte == NEWLINE_MARKER_V0 => {
+                push_space(&mut payload);
+                cursor += 1;
+            }
+            Some(TokenV0::Char(byte)) if is_safe_math_payload_char_v0(*byte) => {
+                payload.push(*byte);
+                cursor += 1;
+            }
+            Some(TokenV0::Space) => {
+                push_space(&mut payload);
+                cursor += 1;
+            }
+            _ => return None,
+        }
+    }
+}
+
 fn is_spacing_or_newline_v0(byte: u8) -> bool {
     matches!(byte, b' ' | NEWLINE_MARKER_V0)
 }
@@ -616,6 +705,9 @@ fn consume_fragment_token_v0(
     allow_hard_break: bool,
 ) -> Option<usize> {
     match tokens.get(index)? {
+        TokenV0::Char(byte) if allow_hard_break && *byte == b'$' => {
+            consume_inline_math_command_v0(tokens, index, out)
+        }
         TokenV0::Char(byte) if allow_hard_break && *byte == PAGE_BREAK_MARKER_V0 => {
             push_page_break(out);
             Some(index + 1)
@@ -655,6 +747,9 @@ fn consume_fragment_token_v0(
         {
             push_page_break(out);
             Some(index + 1)
+        }
+        TokenV0::ControlSeq(name) if allow_hard_break && name.as_slice() == b"[" => {
+            consume_display_math_command_v0(tokens, index, out)
         }
         TokenV0::ControlSeq(name) if name.as_slice() == b"protect" || name.as_slice() == b"relax" => {
             Some(index + 1)

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -770,3 +770,47 @@ fn typeset_minimal_pagebreak_alias_emits_forced_page_split() {
     assert_eq!(first_line, b"A");
     assert_eq!(second_line, b"B");
 }
+
+#[test]
+fn typeset_minimal_inline_math_emits_placeholder_text() {
+    let main = b"\\documentclass{article}\\begin{document}Before $x + y$ after.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("Before MATH after."), "body={text:?}");
+}
+
+#[test]
+fn typeset_minimal_display_math_emits_centered_placeholder_block() {
+    let main =
+        b"\\documentclass{article}\\begin{document}Before.\\[x+y\\]After.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("Before.\n\n^ MATH DISPLAY\n\nAfter."),
+        "body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_rejects_inline_math_with_control_sequence_payload() {
+    let main = b"\\documentclass{article}\\begin{document}$\\alpha$\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_unterminated_inline_math() {
+    let main = b"\\documentclass{article}\\begin{document}A $x+y\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_unterminated_display_math() {
+    let main = b"\\documentclass{article}\\begin{document}A \\[x+y\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -1895,6 +1895,54 @@ fn pdf_renderer_link_style_near_punctuation_stays_single_matrix_v0() {
 }
 
 #[test]
+fn pdf_renderer_inline_math_placeholder_keeps_single_text_matrix_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"Before MATH after.")
+        .expect("writer should accept inline math placeholder line");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    assert!(
+        pdf_text.contains("(Before MATH after.)"),
+        "inline math placeholder line should render: {pdf_text}"
+    );
+    let tm_count = tm_count_for_line_containing_v0(&pdf, "(Before MATH after.)");
+    assert_eq!(tm_count, 1, "inline placeholder line should use a single Tm");
+}
+
+#[test]
+fn pdf_renderer_display_math_placeholder_line_is_centered_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"Before.\n\n^ MATH DISPLAY\n\nAfter.")
+        .expect("writer should accept display math placeholder marker line");
+    let layout = parse_dvi_v2_text_page_to_layout_v0(&xdv, 786_432).expect("layout parse");
+    let display_line = layout.pages[0]
+        .lines
+        .iter()
+        .find(|line| {
+            line.glyphs.len() >= 2
+                && line.glyphs[0].byte == b'^'
+                && line.glyphs[1].byte == b' '
+        })
+        .expect("display line with center prefix should exist");
+    let display_width_pt: f32 = display_line.glyphs[2..]
+        .iter()
+        .map(|glyph| glyph.advance_sp as f32 / 65_536.0)
+        .sum();
+    let expected_x_pt = ((612.0 - display_width_pt) * 0.5).clamp(72.0, 540.0);
+
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    assert!(
+        !pdf_text.contains("^ MATH DISPLAY"),
+        "internal center prefix should be hidden in pdf output: {pdf_text}"
+    );
+    let (actual_x_pt, _) = tm_position_for_line_containing_text_v0(&pdf, "(MATH DISPLAY)")
+        .expect("display placeholder x coordinate");
+    assert!(
+        (actual_x_pt - expected_x_pt).abs() <= 0.05,
+        "display placeholder should be centered: actual={actual_x_pt} expected={expected_x_pt}"
+    );
+}
+
+#[test]
 fn pdf_renderer_emits_link_annotation_with_in_bounds_rect_v0() {
     let xdv =
         write_dvi_v2_text_page_v0(b"Visit <{Example link}> now.\n\n!u 1 https://example.com")

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -28,6 +28,10 @@ This wrapper adjacency stress keeps boundaries tight: word\emph{mid},word and wo
 This wrapper-stop stress keeps joins stable: word\textbf{mid}. and (\emph{mid}) and \emph{lead}, trail.
 This mixed-wrapper stress keeps no giant gaps: alpha\emph{beta},gamma and alpha,\textbf{beta}gamma.
 This final boundary stress checks rhythm: start,\emph{middle}. end and start \textbf{middle}, end.
+This inline math placeholder stress keeps wrapping deterministic: alpha $x^2 + y^2 = z^2$ omega and beta,$a+b=c$ gamma.
+\[
+x^2 + y^2 = z^2
+\]
 This second paragraph is intentionally plain text and separated by a blank line so paragraph flow,\linebreak
 first-line indentation, and width-sensitive wrapping are visible in the PDF preview with words like WWWW and iiiii.
 This paragraph adds a second marker\footnote{Second demo footnote text with \textbf{bold emphasis}.} and a second visible link style through \href{https://example.com/page2}{CarrelTeX demo link page two},right beside punctuation in regular body flow.

--- a/scripts/wasm_fixture_gallery_v1/main.mjs
+++ b/scripts/wasm_fixture_gallery_v1/main.mjs
@@ -23,7 +23,7 @@ const STATUS_FAIL_V0 = 'FAIL';
 const STATUS_MISMATCH_V0 = 'MISMATCH';
 const EXPECTED_STATUS_VALUES_V0 = new Set([STATUS_OK_V0, STATUS_NI_V0, STATUS_INVALID_V0, STATUS_FAIL_V0]);
 const DEFAULT_ONDEMAND_FIXEDPOINT_MAX_ITERS_V1 = 3;
-const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'refs', 'bib', 'bibitems', 'cites', 'hyperref', 'pkgopt', 'graphics'];
+const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'refs', 'bib', 'bibitems', 'cites', 'hyperref', 'pkgopt', 'graphics', 'math'];
 const TYPED_ARTIFACTS_VERSION_V0 = 1;
 const MAX_TOC_ENTRIES_V0 = 256;
 const MAX_TOC_TITLE_BYTES_V0 = 256;
@@ -38,6 +38,8 @@ const MAX_PKGOPT_VALUE_BYTES_V0 = 256;
 const MAX_PKGOPT_OPTIONS_PER_ENTRY_V0 = 64;
 const MAX_GRAPHICS_ENTRIES_V0 = 256;
 const MAX_GRAPHICS_PATH_BYTES_V0 = 256;
+const MAX_MATH_ENTRIES_V0 = 256;
+const MAX_MATH_PAYLOAD_BYTES_V0 = 1024;
 const MAX_RESOURCE_HINT_ENTRIES_V0 = 512;
 const MAX_RESOURCE_HINT_VALUE_BYTES_V0 = 256;
 const RESOURCE_HINTS_V0_VERSION = 1;
@@ -999,6 +1001,164 @@ function extractTocEntriesFromSourceV0(sourceBytes) {
     }
 
     index = titleGroup.next;
+  }
+  return entries;
+}
+
+function isMathPayloadWhitespaceByteV0(byte) {
+  return byte === 0x20 || byte === 0x09 || byte === 0x0a || byte === 0x0d;
+}
+
+function isSafeMathPayloadByteV0(byte) {
+  return byte >= 0x20
+    && byte <= 0x7e
+    && byte !== 0x24
+    && byte !== 0x5c
+    && byte !== 0x5b
+    && byte !== 0x5d
+    && byte !== 0x7b
+    && byte !== 0x7d
+    && byte !== 0x3c
+    && byte !== 0x3e;
+}
+
+function pushMathPayloadSpaceV0(payloadBytes) {
+  if (payloadBytes.length > 0 && payloadBytes[payloadBytes.length - 1] !== 0x20) {
+    payloadBytes.push(0x20);
+  }
+}
+
+function trimMathPayloadTrailingSpaceV0(payloadBytes) {
+  while (payloadBytes.length > 0 && payloadBytes[payloadBytes.length - 1] === 0x20) {
+    payloadBytes.pop();
+  }
+}
+
+function addMathEntryV1(entries, kind, payloadBytes, lineIndex, sourceBytes, startByte, endByte) {
+  trimMathPayloadTrailingSpaceV0(payloadBytes);
+  if (payloadBytes.length === 0) {
+    throw new Error('math_v1 payload must be non-empty');
+  }
+  if (payloadBytes.length > MAX_MATH_PAYLOAD_BYTES_V0) {
+    throw new Error(`math_v1 payload exceeds cap ${MAX_MATH_PAYLOAD_BYTES_V0}`);
+  }
+  if (!Number.isInteger(lineIndex) || lineIndex <= 0) {
+    throw new Error('math_v1 line_index must be a positive integer');
+  }
+  const payload = Uint8Array.from(payloadBytes);
+  entries.push({
+    kind,
+    payload_sha256: sha256HexV0(payload),
+    line_index: lineIndex,
+    source_span: buildSourceSpanV0(sourceBytes, startByte, endByte, 'math_v1'),
+  });
+  if (entries.length > MAX_MATH_ENTRIES_V0) {
+    throw new Error(`math_v1 entries exceed cap ${MAX_MATH_ENTRIES_V0}`);
+  }
+}
+
+function extractMathEntriesFromSourceV1(sourceBytes) {
+  const entries = [];
+  let index = 0;
+  let lineIndex = 1;
+  while (index < sourceBytes.length) {
+    const byte = sourceBytes[index];
+
+    if (byte === 0x0a) {
+      lineIndex += 1;
+      index += 1;
+      continue;
+    }
+    if (byte === 0x0d) {
+      if (index + 1 < sourceBytes.length && sourceBytes[index + 1] === 0x0a) {
+        index += 1;
+      }
+      lineIndex += 1;
+      index += 1;
+      continue;
+    }
+
+    if (byte === 0x24) {
+      const startByte = index;
+      const startLineIndex = lineIndex;
+      const payloadBytes = [];
+      let cursor = index + 1;
+      let closed = false;
+      while (cursor < sourceBytes.length) {
+        const current = sourceBytes[cursor];
+        if (current === 0x24) {
+          addMathEntryV1(entries, 'inline', payloadBytes, startLineIndex, sourceBytes, startByte, cursor + 1);
+          cursor += 1;
+          index = cursor;
+          closed = true;
+          break;
+        }
+        if (isMathPayloadWhitespaceByteV0(current)) {
+          pushMathPayloadSpaceV0(payloadBytes);
+          if (current === 0x0a) {
+            lineIndex += 1;
+          } else if (current === 0x0d) {
+            if (cursor + 1 < sourceBytes.length && sourceBytes[cursor + 1] === 0x0a) {
+              cursor += 1;
+            }
+            lineIndex += 1;
+          }
+          cursor += 1;
+          continue;
+        }
+        if (!isSafeMathPayloadByteV0(current)) {
+          throw new Error(`math_v1 inline payload has unsupported byte 0x${current.toString(16).padStart(2, '0')}`);
+        }
+        payloadBytes.push(current);
+        cursor += 1;
+      }
+      if (!closed) {
+        throw new Error('math_v1 inline payload missing closing $ delimiter');
+      }
+      continue;
+    }
+
+    if (byte === 0x5c && index + 1 < sourceBytes.length && sourceBytes[index + 1] === 0x5b) {
+      const startByte = index;
+      const startLineIndex = lineIndex;
+      const payloadBytes = [];
+      let cursor = index + 2;
+      let closed = false;
+      while (cursor < sourceBytes.length) {
+        if (sourceBytes[cursor] === 0x5c && cursor + 1 < sourceBytes.length && sourceBytes[cursor + 1] === 0x5d) {
+          addMathEntryV1(entries, 'display', payloadBytes, startLineIndex, sourceBytes, startByte, cursor + 2);
+          cursor += 2;
+          index = cursor;
+          closed = true;
+          break;
+        }
+        const current = sourceBytes[cursor];
+        if (isMathPayloadWhitespaceByteV0(current)) {
+          pushMathPayloadSpaceV0(payloadBytes);
+          if (current === 0x0a) {
+            lineIndex += 1;
+          } else if (current === 0x0d) {
+            if (cursor + 1 < sourceBytes.length && sourceBytes[cursor + 1] === 0x0a) {
+              cursor += 1;
+            }
+            lineIndex += 1;
+          }
+          cursor += 1;
+          continue;
+        }
+        if (!isSafeMathPayloadByteV0(current)) {
+          throw new Error(`math_v1 display payload has unsupported byte 0x${current.toString(16).padStart(2, '0')}`);
+        }
+        payloadBytes.push(current);
+        cursor += 1;
+      }
+      if (!closed) {
+        throw new Error('math_v1 display payload missing closing \\] delimiter');
+      }
+      continue;
+    }
+
+    index += 1;
   }
   return entries;
 }
@@ -2432,6 +2592,24 @@ async function emitGraphicsTypedArtifactV0(caseOutDir, fixtureBytes) {
   };
 }
 
+async function emitMathTypedArtifactV0(caseOutDir, fixtureBytes) {
+  const payload = {
+    version: TYPED_ARTIFACTS_VERSION_V0,
+    schema: 'math_v1',
+    entries: extractMathEntriesFromSourceV1(fixtureBytes),
+  };
+  const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  const relpath = 'math_v1.json';
+  const fullPath = path.join(caseOutDir, relpath);
+  await writeFile(fullPath, bytes);
+  return {
+    present: true,
+    items: payload.entries.length,
+    artifact_relpath: relpath,
+    artifact_sha256: sha256HexV0(bytes),
+  };
+}
+
 async function emitResourceHintsArtifactV0(caseOutDir, fixtureBytes, mode) {
   const caseId = path.basename(caseOutDir);
   const entries = mode === 'typeset' ? extractResourceHintEntriesFromSourceV0(fixtureBytes, caseId) : [];
@@ -2487,6 +2665,7 @@ async function emitTypedArtifactsV0(caseSpec, caseOutDir, typedArtifacts, fixtur
   if (caseSpec.id === 'typeset_demo_minimal_v0') {
     typedArtifacts.bibitems = await emitBibitemsTypedArtifactV0(caseOutDir, fixtureBytes);
     typedArtifacts.cites = await emitCitesTypedArtifactV0(caseOutDir, fixtureBytes);
+    typedArtifacts.math = await emitMathTypedArtifactV0(caseOutDir, fixtureBytes);
   }
   if (caseSpec.id === 'typeset_demo_hyperref_probe_v0') {
     typedArtifacts.hyperref = await emitHyperrefTypedArtifactV0(caseOutDir, fixtureBytes);

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_baseline_generator.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_baseline_generator.cjs
@@ -47,7 +47,7 @@ if (!indexB.typed_artifact_sha256 || typeof indexB.typed_artifact_sha256 !== 'ob
   console.error('FAIL: baseline index rerun missing typed_artifact_sha256 map');
   process.exit(1);
 }
-const typedKeys = ['toc', 'labels', 'bib', 'hyperref', 'pkgopt', 'graphics'];
+const typedKeys = ['toc', 'labels', 'bib', 'hyperref', 'pkgopt', 'graphics', 'math'];
 for (const key of typedKeys) {
   const valueA = indexA.typed_artifact_sha256[key];
   const valueB = indexB.typed_artifact_sha256[key];

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
@@ -387,6 +387,53 @@ if (graphicsArtifactFirst.entries.length <= 0) {
 assertEntrySourceSpans('typeset_demo_graphics_probe_v0', 'graphics_v0', graphicsArtifactFirst.entries);
 fs.writeFileSync(firstRunShaPath('graphics_v0'), `${graphicsShaFirst}\n`);
 
+const mathSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_minimal_v0', 'summary.json'), 'utf8'),
+);
+if (mathSummary?.typed_artifacts?.math?.present !== true) {
+  console.error('FAIL: expected math typed artifact present for minimal demo after first run');
+  process.exit(1);
+}
+const mathPath = path.join(outDir, 'typeset_demo_minimal_v0', 'math_v1.json');
+if (!fs.existsSync(mathPath)) {
+  console.error('FAIL: expected math_v1.json artifact after first run');
+  process.exit(1);
+}
+const mathShaFirst = mathSummary.typed_artifacts.math.artifact_sha256;
+if (typeof mathShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(mathShaFirst)) {
+  console.error('FAIL: expected math artifact sha256 in first summary');
+  process.exit(1);
+}
+const mathArtifactFirst = JSON.parse(fs.readFileSync(mathPath, 'utf8'));
+if (!Array.isArray(mathArtifactFirst?.entries)) {
+  console.error('FAIL: expected math_v1.entries array in first-run artifact');
+  process.exit(1);
+}
+if (mathArtifactFirst?.schema !== 'math_v1') {
+  console.error('FAIL: expected math_v1 schema in first-run artifact');
+  process.exit(1);
+}
+if (mathArtifactFirst.entries.length <= 0) {
+  console.error('FAIL: expected non-empty math_v1.entries for minimal demo');
+  process.exit(1);
+}
+for (const [index, entry] of mathArtifactFirst.entries.entries()) {
+  if (entry?.kind !== 'inline' && entry?.kind !== 'display') {
+    console.error(`FAIL: math_v1.entries[${index}] has invalid kind`);
+    process.exit(1);
+  }
+  if (!Number.isInteger(entry?.line_index) || entry.line_index <= 0) {
+    console.error(`FAIL: math_v1.entries[${index}] has invalid line_index`);
+    process.exit(1);
+  }
+  if (typeof entry?.payload_sha256 !== 'string' || !/^[0-9a-f]{64}$/.test(entry.payload_sha256)) {
+    console.error(`FAIL: math_v1.entries[${index}] has invalid payload_sha256`);
+    process.exit(1);
+  }
+}
+assertEntrySourceSpans('typeset_demo_minimal_v0', 'math_v1', mathArtifactFirst.entries);
+fs.writeFileSync(firstRunShaPath('math_v1'), `${mathShaFirst}\n`);
+
 const report = JSON.parse(fs.readFileSync(path.join(outDir, 'report.json'), 'utf8'));
 if (report?.typed_artifacts_version !== 1) {
   console.error('FAIL: expected report.typed_artifacts_version=1 after first run');
@@ -467,7 +514,7 @@ if (!typedArtifactShaMap || typeof typedArtifactShaMap !== 'object') {
   console.error('FAIL: expected report.typed_artifact_sha256 map after first run');
   process.exit(1);
 }
-const typedKeys = ['toc', 'labels', 'bib', 'hyperref', 'pkgopt', 'graphics'];
+const typedKeys = ['toc', 'labels', 'bib', 'hyperref', 'pkgopt', 'graphics', 'math'];
 for (const key of typedKeys) {
   const value = typedArtifactShaMap[key];
   if (typeof value !== 'string' || !/^[0-9a-f]{64}$/.test(value)) {

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
@@ -63,7 +63,7 @@ if (resourceHintsShaSecond !== resourceHintsShaFirst) {
   console.error('FAIL: report.resource_hints_v0 must be stable across reruns');
   process.exit(1);
 }
-const requiredTypedKeys = ['toc', 'labels', 'refs', 'bib', 'hyperref', 'pkgopt', 'graphics'];
+const requiredTypedKeys = ['toc', 'labels', 'refs', 'bib', 'hyperref', 'pkgopt', 'graphics', 'math'];
 const labelsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'labels_v1_first.sha256'), 'utf8').trim();
 const refsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'refs_v1_first.sha256'), 'utf8').trim();
 const tocShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'toc_v1_first.sha256'), 'utf8').trim();
@@ -71,6 +71,7 @@ const bibShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'bib_v0_firs
 const hyperrefShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'hyperref_v0_first.sha256'), 'utf8').trim();
 const pkgoptShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'pkgopt_v0_first.sha256'), 'utf8').trim();
 const graphicsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'graphics_v0_first.sha256'), 'utf8').trim();
+const mathShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'math_v1_first.sha256'), 'utf8').trim();
 
 if (resolvedCount <= 0) {
   console.error('FAIL: expected at least one resolved resource in fixture gallery summaries');
@@ -411,6 +412,27 @@ if (!Array.isArray(graphicsArtifactSecond?.entries) || graphicsArtifactSecond.en
   process.exit(1);
 }
 
+const mathSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_minimal_v0', 'summary.json'), 'utf8'),
+);
+const mathArtifact = mathSummary?.typed_artifacts?.math;
+if (!mathArtifact || mathArtifact.present !== true) {
+  console.error('FAIL: expected math typed artifact present after second run');
+  process.exit(1);
+}
+const mathShaSecond = mathArtifact.artifact_sha256;
+if (mathShaSecond !== mathShaFirst) {
+  console.error('FAIL: math_v1 artifact sha256 must be stable across reruns');
+  process.exit(1);
+}
+const mathArtifactSecond = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_minimal_v0', 'math_v1.json'), 'utf8'),
+);
+if (!Array.isArray(mathArtifactSecond?.entries) || mathArtifactSecond.entries.length <= 0) {
+  console.error('FAIL: expected non-empty math_v1.entries after rerun');
+  process.exit(1);
+}
+
 const reportCaseSha = report.case_artifact_sha256;
 if (!reportCaseSha || typeof reportCaseSha !== 'object') {
   console.error('FAIL: report missing top-level case_artifact_sha256');
@@ -474,5 +496,6 @@ console.log(`PASS: bib_v0 sha stable ${bibShaSecond}`);
 console.log(`PASS: hyperref_v0 sha stable ${hyperrefShaSecond}`);
 console.log(`PASS: pkgopt_v0 sha stable ${pkgoptShaSecond}`);
 console.log(`PASS: graphics_v0 sha stable ${graphicsShaSecond}`);
+console.log(`PASS: math_v1 sha stable ${mathShaSecond}`);
 console.log('PASS: report typed_artifact_sha256 map present and stable');
 console.log('PASS: report top-level case_artifact_sha256 present');


### PR DESCRIPTION
## Summary\n- add typeset_minimal parsing for inline \$...\$ and display \[..\] math with fail-closed payload checks\n- render deterministic placeholders (, centered ) and extend fixture stress lines\n- emit  typed artifact in gallery and wire stable-sha proof checks\n\n## Proofs\n- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests\n- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml\n- ./scripts/proof_wasm_typeset_minimal_v0.sh | tail -n 6\n- ./scripts/proof_wasm_fixture_gallery_v0.sh | tail -n 10