### PR TITLE
typeset_minimal typography spacing+alignment bundle v5

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -533,6 +533,28 @@ fn is_punctuation_spacing_target_v0(byte: u8) -> bool {
     matches!(byte, b'.' | b',' | b';' | b':' | b'!' | b'?')
 }
 
+fn normalize_space_before_punctuation_v0(body: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(body.len());
+    let mut index = 0usize;
+    while index < body.len() {
+        let byte = body[index];
+        if byte != b' ' {
+            out.push(byte);
+            index += 1;
+            continue;
+        }
+        let spaces_start = index;
+        while index < body.len() && body[index] == b' ' {
+            index += 1;
+        }
+        if index < body.len() && is_punctuation_spacing_target_v0(body[index]) {
+            continue;
+        }
+        out.extend_from_slice(&body[spaces_start..index]);
+    }
+    out
+}
+
 fn normalize_punctuation_spacing_v0(body: &[u8]) -> Vec<u8> {
     let mut out = Vec::with_capacity(body.len());
     let mut index = 0usize;
@@ -694,6 +716,48 @@ fn normalize_bracket_spacing_v0(body: &[u8]) -> Vec<u8> {
         index += 1;
     }
 
+    out
+}
+
+fn is_style_wrapper_start_marker_v0(byte: u8) -> bool {
+    byte == ITALIC_START_MARKER_V0 || byte == BOLD_START_MARKER_V0
+}
+
+fn is_style_wrapper_end_marker_v0(byte: u8) -> bool {
+    byte == ITALIC_END_MARKER_V0 || byte == BOLD_END_MARKER_V0
+}
+
+fn normalize_wrapper_marker_spacing_v0(body: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(body.len());
+    let mut index = 0usize;
+    while index < body.len() {
+        let byte = body[index];
+        if is_style_wrapper_start_marker_v0(byte) {
+            out.push(byte);
+            index += 1;
+            while index < body.len() && body[index] == b' ' {
+                let next = body.get(index + 1).copied().unwrap_or_default();
+                if next == NEWLINE_MARKER_V0 || next == PAGE_BREAK_MARKER_V0 {
+                    break;
+                }
+                index += 1;
+            }
+            continue;
+        }
+        if byte == b' ' {
+            let spaces_start = index;
+            while index < body.len() && body[index] == b' ' {
+                index += 1;
+            }
+            if index < body.len() && is_style_wrapper_end_marker_v0(body[index]) {
+                continue;
+            }
+            out.extend_from_slice(&body[spaces_start..index]);
+            continue;
+        }
+        out.push(byte);
+        index += 1;
+    }
     out
 }
 
@@ -2014,11 +2078,13 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
         return None;
     }
 
+    body = normalize_space_before_punctuation_v0(&body);
     body = normalize_punctuation_spacing_v0(&body);
     body = normalize_tex_double_quotes_v0(&body);
     body = normalize_tex_dashes_v0(&body);
     body = normalize_tex_ellipsis_v0(&body);
     body = normalize_bracket_spacing_v0(&body);
+    body = normalize_wrapper_marker_spacing_v0(&body);
     body = resolve_ref_markers_v0(&body, &labels_by_key, &mut ref_occurrences)?;
     let bibitems_by_key = bibitems
         .iter()

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -658,6 +658,16 @@ fn typeset_minimal_punctuation_collapses_following_spaces_to_one() {
 }
 
 #[test]
+fn typeset_minimal_punctuation_removes_spaces_before_markers_and_punctuation() {
+    let main = b"\\documentclass{article}\\begin{document}lead\\emph{core} , trail and lead\\textbf{core} ! done.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("lead[core], trail and lead{core}! done."), "body={text:?}");
+    assert!(!text.contains("[core] ,"), "body={text:?}");
+    assert!(!text.contains("{core} !"), "body={text:?}");
+}
+
+#[test]
 fn typeset_minimal_tex_double_quotes_normalize_to_ascii_quote() {
     let main = b"\\documentclass{article}\\begin{document}``Hello''\\end{document}";
     let body = extract_typeset_body(main);
@@ -711,6 +721,26 @@ fn typeset_minimal_brackets_and_braces_remove_inner_spaces_same_line() {
     assert!(text.contains("[A] {B}"), "body={text:?}");
     assert!(!text.contains("[ A ]"), "body={text:?}");
     assert!(!text.contains("{ B }"), "body={text:?}");
+}
+
+#[test]
+fn typeset_minimal_wrapper_markers_trim_inner_spaces_without_newlines() {
+    let main = b"\\documentclass{article}\\begin{document}\\emph{   lead   } and \\textbf{  core  }\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("[lead] and {core}"), "body={text:?}");
+    assert!(!text.contains("[ lead"), "body={text:?}");
+    assert!(!text.contains("core }"), "body={text:?}");
+}
+
+#[test]
+fn typeset_minimal_nested_wrapper_boundary_spacing_is_stable() {
+    let main = b"\\documentclass{article}\\begin{document}word\\emph{\\textbf{ mid }}word and word\\textbf{\\emph{ core }} ,trail\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("word[{mid}]word and word{[core]},trail"), "body={text:?}");
+    assert!(!text.contains("word [{mid}]word"), "body={text:?}");
+    assert!(!text.contains("} ,trail"), "body={text:?}");
 }
 
 #[test]

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -743,21 +743,17 @@ fn emit_styled_segments_v0(
     if segments.is_empty() {
         return;
     }
-    out.extend_from_slice(b"1 0 0 1 ");
-    out.extend_from_slice(format!("{:.2} {:.2} Tm ", x_pt, y_pt).as_bytes());
+    let mut render_segments = Vec::<PdfRenderSegmentV0>::with_capacity(segments.len());
     for segment in segments {
-        if segment.glyphs.is_empty() {
-            continue;
-        }
-        let escaped = escape_pdf_string_bytes(&bytes_from_glyphs_v0(&segment.glyphs));
-        out.extend_from_slice(b"/");
-        out.extend_from_slice(style_font_alias_v0(segment.style));
-        out.extend_from_slice(b" ");
-        out.extend_from_slice(format!("{font_size_pt}").as_bytes());
-        out.extend_from_slice(b" Tf (");
-        out.extend_from_slice(&escaped);
-        out.extend_from_slice(b") Tj ");
+        render_segments.push(PdfRenderSegmentV0 {
+            style: segment.style,
+            bytes: bytes_from_glyphs_v0(&segment.glyphs),
+            advance_pt: segment.advance_pt,
+            is_link: segment.is_link,
+            superscript: false,
+        });
     }
+    emit_render_segments_with_superscript_v0(out, &render_segments, x_pt, y_pt, font_size_pt);
 }
 
 fn emit_render_segments_with_superscript_v0(
@@ -770,12 +766,14 @@ fn emit_render_segments_with_superscript_v0(
     if segments.is_empty() {
         return;
     }
-    out.extend_from_slice(b"1 0 0 1 ");
-    out.extend_from_slice(format!("{:.2} {:.2} Tm ", x_pt, y_pt).as_bytes());
+    let mut cursor_x = x_pt;
     for segment in segments {
         if segment.bytes.is_empty() {
+            cursor_x += segment.advance_pt;
             continue;
         }
+        out.extend_from_slice(b"1 0 0 1 ");
+        out.extend_from_slice(format!("{:.2} {:.2} Tm ", cursor_x, y_pt).as_bytes());
         let escaped = escape_pdf_string_bytes(&segment.bytes);
         let segment_font_size_pt = if segment.superscript {
             FOOTNOTE_MARKER_FONT_SIZE_PT_V0
@@ -795,6 +793,7 @@ fn emit_render_segments_with_superscript_v0(
         out.extend_from_slice(b" Tf (");
         out.extend_from_slice(&escaped);
         out.extend_from_slice(b") Tj ");
+        cursor_x += segment.advance_pt;
     }
     out.extend_from_slice(b"0 Ts ");
 }

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -302,6 +302,146 @@ fn max_tm_gap_pt_for_line_containing_v0(pdf: &[u8], needle: &str) -> Option<f32>
     None
 }
 
+fn tm_line_start_xs_for_segment_text_v0(pdf: &[u8], segment_text: &str) -> Vec<f32> {
+    let target_token = format!("({segment_text})");
+    let text = String::from_utf8_lossy(pdf);
+    let mut xs = Vec::<f32>::new();
+    for line in text.lines() {
+        if !line.contains(&target_token) || !line.contains(" Tm ") {
+            continue;
+        }
+        let fields = line.split_whitespace().collect::<Vec<_>>();
+        let mut index = 0usize;
+        while index + 6 < fields.len() {
+            let is_tm = fields[index] == "1"
+                && fields[index + 1] == "0"
+                && fields[index + 2] == "0"
+                && fields[index + 3] == "1"
+                && fields[index + 6] == "Tm";
+            if !is_tm {
+                index += 1;
+                continue;
+            }
+            if let Ok(x_pt) = fields[index + 4].parse::<f32>() {
+                xs.push(x_pt);
+            }
+            break;
+        }
+    }
+    xs
+}
+
+fn segment_width_pt_v0(segment: &[u8]) -> f32 {
+    let layout = plan_layout_width_v0(segment, 65_536, 786_432, 10_000_000, 16)
+        .expect("segment layout should parse");
+    let line = &layout.pages[0].lines[0];
+    line.width_sp as f32 / 65_536.0
+}
+
+fn decode_pdf_text_segments_from_line_v0(line: &str) -> Option<String> {
+    let mut out = Vec::<u8>::new();
+    let bytes = line.as_bytes();
+    let mut index = 0usize;
+    while index < bytes.len() {
+        if bytes[index] != b'(' {
+            index += 1;
+            continue;
+        }
+        index += 1;
+        while index < bytes.len() {
+            let byte = bytes[index];
+            if byte == b'\\' {
+                index += 1;
+                if index < bytes.len() {
+                    out.push(bytes[index]);
+                    index += 1;
+                }
+                continue;
+            }
+            if byte == b')' {
+                index += 1;
+                break;
+            }
+            out.push(byte);
+            index += 1;
+        }
+    }
+    String::from_utf8(out).ok()
+}
+
+fn rendered_text_for_line_containing_segment_v0(pdf: &[u8], segment_text: &str) -> Option<String> {
+    let target_token = format!("({segment_text})");
+    let text = String::from_utf8_lossy(pdf);
+    for line in text.lines() {
+        if !line.contains(&target_token) || !line.contains(" Tj ") {
+            continue;
+        }
+        return decode_pdf_text_segments_from_line_v0(line);
+    }
+    None
+}
+
+fn rendered_text_for_first_text_line_v0(pdf: &[u8]) -> Option<String> {
+    let text = String::from_utf8_lossy(pdf);
+    for line in text.lines() {
+        if line.contains(" Tj ") {
+            return decode_pdf_text_segments_from_line_v0(line);
+        }
+    }
+    None
+}
+
+fn parse_tm_positions_in_line_v0(line: &str) -> Vec<(usize, f32, f32)> {
+    let mut positions = Vec::<(usize, f32, f32)>::new();
+    let mut search_from = 0usize;
+    while let Some(rel_start) = line[search_from..].find("1 0 0 1 ") {
+        let start = search_from + rel_start + "1 0 0 1 ".len();
+        let x_end = match line[start..].find(' ') {
+            Some(value) => start + value,
+            None => break,
+        };
+        let x_pt = match line[start..x_end].parse::<f32>() {
+            Ok(value) => value,
+            Err(_) => break,
+        };
+        let y_start = x_end + 1;
+        let y_end = match line[y_start..].find(' ') {
+            Some(value) => y_start + value,
+            None => break,
+        };
+        let y_pt = match line[y_start..y_end].parse::<f32>() {
+            Ok(value) => value,
+            Err(_) => break,
+        };
+        if !line[y_end..].starts_with(" Tm") {
+            break;
+        }
+        let tm_end = y_end + " Tm".len();
+        positions.push((tm_end, x_pt, y_pt));
+        search_from = tm_end;
+    }
+    positions
+}
+
+fn tm_x_for_segment_substring_v0(pdf: &[u8], line_needle: &str, segment_substring: &str) -> Option<f32> {
+    let text = String::from_utf8_lossy(pdf);
+    for line in text.lines() {
+        if !line.contains(line_needle) || !line.contains(segment_substring) {
+            continue;
+        }
+        let target_index = line.find(segment_substring)?;
+        let positions = parse_tm_positions_in_line_v0(line);
+        let mut best_x = None::<f32>;
+        for (tm_end, x_pt, _) in positions {
+            if tm_end <= target_index {
+                best_x = Some(x_pt);
+            }
+        }
+        return best_x;
+    }
+    None
+}
+
 fn tm_count_for_line_containing_v0(pdf: &[u8], needle: &str) -> usize {
     let text = String::from_utf8_lossy(pdf);
     for line in text.lines() {
@@ -662,135 +802,89 @@ fn pdf_renderer_inline_wrapper_spacing_invariants_v0() {
         write_dvi_v2_text_page_v0(b"word[mid]word word [lead] trail,{bold}!")
             .expect("writer should accept styled text");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
-    let line_text = String::from_utf8_lossy(&pdf);
+    let rendered = rendered_text_for_line_containing_segment_v0(&pdf, "word")
+        .expect("styled line should decode");
+    assert_eq!(rendered, "wordmidword word lead trail,bold!");
+
+    let word_x = tm_xs_for_segment_text_v0(&pdf, "word")[0];
+    let mid_x = tm_xs_for_segment_text_v0(&pdf, "mid")[0];
+    let trailing_word_x = tm_x_for_segment_substring_v0(&pdf, "(word)", "(word word )")
+        .expect("word word segment x");
+    let lead_x = tm_xs_for_segment_text_v0(&pdf, "lead")[0];
+    let trail_x = tm_x_for_segment_substring_v0(&pdf, "(word)", "( trail,)")
+        .expect("trail segment x");
+    let bold_x = tm_xs_for_segment_text_v0(&pdf, "bold")[0];
+
+    let epsilon_pt = 0.02f32;
     assert!(
-        line_text.contains("(word) Tj /F2 12 Tf (mid) Tj /F1 12 Tf (word word ) Tj /F2 12 Tf (lead) Tj"),
-        "styled boundary sequence missing: {line_text}"
+        ((mid_x - word_x) - segment_width_pt_v0(b"word")).abs() <= epsilon_pt,
+        "word->mid advance mismatch: word_x={word_x}, mid_x={mid_x}"
     );
     assert!(
-        line_text.contains("/F1 12 Tf ( trail,) Tj /F3 12 Tf (bold) Tj /F1 12 Tf (!) Tj"),
-        "styled punctuation sequence missing: {line_text}"
+        ((trailing_word_x - mid_x) - segment_width_pt_v0(b"mid")).abs() <= epsilon_pt,
+        "mid->trailing advance mismatch: mid_x={mid_x}, trailing_word_x={trailing_word_x}"
     );
     assert!(
-        !line_text.contains("(word ) Tj /F2 12 Tf (mid)"),
-        "unexpected extra space before inline emph boundary: {line_text}"
+        ((trail_x - lead_x) - segment_width_pt_v0(b"lead")).abs() <= epsilon_pt,
+        "lead->trail advance mismatch: lead_x={lead_x}, trail_x={trail_x}"
     );
-    let tm_count = tm_count_for_line_containing_v0(&pdf, "(word)");
-    assert_eq!(tm_count, 1, "styled line should use a single Tm: {line_text}");
-    let max_tm_gap = max_tm_gap_pt_for_line_containing_v0(&pdf, "(word)")
-        .expect("styled line should parse");
     assert!(
-        max_tm_gap <= 0.02,
-        "styled inline boundary should not create matrix gaps: {max_tm_gap}"
+        ((bold_x - trail_x) - segment_width_pt_v0(b" trail,")).abs() <= epsilon_pt,
+        "trail->bold advance mismatch: trail_x={trail_x}, bold_x={bold_x}"
     );
 }
 
 #[test]
 fn pdf_renderer_punctuation_adjacent_wrapper_gap_invariants_v0() {
     let xdv = write_dvi_v2_text_page_v0(
-        b"word[mid],word word,[mid]word word{mid}. (alpha[mid]beta) [lead], trail lead, [trail]",
+        b"word[mid],word word,[mid]word word{mid}. (a[mid]b) lead, [trail]",
     )
     .expect("writer should accept punctuation-adjacent styled text");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
-    let line_text = String::from_utf8_lossy(&pdf);
-    assert!(
-        line_text.contains("(word) Tj /F2 12 Tf (mid) Tj /F1 12 Tf (,word word,) Tj /F2 12 Tf (mid) Tj"),
-        "first punctuation-adjacent styled sequence missing: {line_text}"
-    );
-    assert!(
-        line_text.contains("/F3 12 Tf (mid) Tj /F1 12 Tf (. \\(alpha) Tj /F2 12 Tf (mid) Tj"),
-        "second punctuation-adjacent styled sequence missing: {line_text}"
-    );
-    assert!(
-        line_text.contains("/F1 12 Tf (beta\\) ) Tj /F2 12 Tf (lead) Tj /F1 12 Tf (, trail lead,) Tj"),
-        "wrapper-near-punctuation trail sequence missing: {line_text}"
-    );
-    assert!(
-        line_text.contains("/F2 12 Tf (trail) Tj"),
-        "trailing styled segment missing: {line_text}"
-    );
-    assert!(
-        !line_text.contains("word ) Tj /F2 12 Tf (mid)"),
-        "unexpected extra space before wrapper boundary: {line_text}"
-    );
-    assert!(
-        !line_text.contains(") Tj /F1 12 Tf ( ,"),
-        "unexpected space inserted before punctuation at boundary: {line_text}"
-    );
-    let tm_count = tm_count_for_line_containing_v0(&pdf, "(word)");
+    let rendered = rendered_text_for_line_containing_segment_v0(&pdf, "word")
+        .expect("punctuation-adjacent line should decode");
     assert_eq!(
-        tm_count, 1,
-        "punctuation-adjacent styled line should use single Tm: {line_text}"
+        rendered,
+        "wordmid,word word,midword wordmid. (amidb) lead, trail"
     );
-    let max_tm_gap = max_tm_gap_pt_for_line_containing_v0(&pdf, "(word)")
-        .expect("punctuation-adjacent styled line should parse");
+
+    let word_x = tm_xs_for_segment_text_v0(&pdf, "word")[0];
+    let mid_x = tm_xs_for_segment_text_v0(&pdf, "mid")[0];
+    let comma_word_x = tm_x_for_segment_substring_v0(&pdf, "(word)", "(,word word,)")
+        .expect("comma-word segment x");
+    let epsilon_pt = 0.02f32;
     assert!(
-        max_tm_gap <= 0.02,
-        "punctuation-adjacent styled line should not create matrix gaps: {max_tm_gap}"
+        ((mid_x - word_x) - segment_width_pt_v0(b"word")).abs() <= epsilon_pt,
+        "word->mid punctuation boundary drifted: word_x={word_x}, mid_x={mid_x}"
+    );
+    assert!(
+        ((comma_word_x - mid_x) - segment_width_pt_v0(b"mid")).abs() <= epsilon_pt,
+        "mid->comma segment boundary drifted: mid_x={mid_x}, comma_word_x={comma_word_x}"
     );
 }
 
 #[test]
 fn pdf_renderer_wrapper_punctuation_patterns_are_stable_v0() {
-    let cases: [(&[u8], &str, &str); 6] = [
-        (
-            b"alpha[beta],gamma",
-            "(alpha) Tj /F2 12 Tf (beta) Tj /F1 12 Tf (,gamma) Tj",
-            "(alpha ) Tj /F2 12 Tf (beta)",
-        ),
-        (
-            b"alpha,[beta]gamma",
-            "(alpha,) Tj /F2 12 Tf (beta) Tj /F1 12 Tf (gamma) Tj",
-            "(alpha, ) Tj /F2 12 Tf (beta)",
-        ),
-        (
-            b"(alpha[beta]gamma)",
-            "(\\(alpha) Tj /F2 12 Tf (beta) Tj /F1 12 Tf (gamma\\)) Tj",
-            "(\\(alpha ) Tj /F2 12 Tf (beta)",
-        ),
-        (
-            b"alpha{beta}. gamma",
-            "(alpha) Tj /F3 12 Tf (beta) Tj /F1 12 Tf (. gamma) Tj",
-            "(alpha ) Tj /F3 12 Tf (beta)",
-        ),
-        (
-            b"{lead}, trail",
-            "/F3 12 Tf (lead) Tj /F1 12 Tf (, trail) Tj",
-            "/F3 12 Tf (lead) Tj /F1 12 Tf ( , trail) Tj",
-        ),
-        (
-            b"lead, [trail]",
-            "(lead, ) Tj /F2 12 Tf (trail) Tj",
-            "(lead,) Tj /F2 12 Tf (trail) Tj",
-        ),
+    let cases: [(&[u8], &str); 6] = [
+        (b"alpha[beta],gamma", "alphabeta,gamma"),
+        (b"alpha,[beta]gamma", "alpha,betagamma"),
+        (b"(alpha[beta]gamma)", "(alphabetagamma)"),
+        (b"alpha{beta}. gamma", "alphabeta. gamma"),
+        (b"{lead}, trail", "lead, trail"),
+        (b"lead, [trail]", "lead, trail"),
     ];
 
-    for (input, expected_fragment, forbidden_fragment) in cases {
+    for (input, expected_rendered) in cases {
         let xdv = write_dvi_v2_text_page_v0(input).expect("writer should accept punctuation case");
         let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
-        let line_text = String::from_utf8_lossy(&pdf);
+        let rendered =
+            rendered_text_for_first_text_line_v0(&pdf).expect("punctuation case should decode");
         assert!(
-            line_text.contains(expected_fragment),
-            "expected punctuation fragment missing for input {:?}: {line_text}",
+            rendered == expected_rendered,
+            "rendered punctuation mismatch for input {:?}: got {:?}, want {:?}",
             String::from_utf8_lossy(input),
-        );
-        assert!(
-            !line_text.contains(forbidden_fragment),
-            "forbidden punctuation fragment present for input {:?}: {line_text}",
-            String::from_utf8_lossy(input),
-        );
-        let tm_count = tm_count_for_line_containing_v0(&pdf, "(");
-        assert_eq!(
-            tm_count, 1,
-            "punctuation wrapper case should remain single-line Tm for input {:?}: {line_text}",
-            String::from_utf8_lossy(input),
-        );
-        let max_tm_gap = max_tm_gap_pt_for_line_containing_v0(&pdf, "(")
-            .expect("punctuation wrapper line should parse");
-        assert!(
-            max_tm_gap <= 0.02,
-            "punctuation wrapper case should not add matrix gaps for input {:?}: {max_tm_gap}",
-            String::from_utf8_lossy(input),
+            rendered,
+            expected_rendered,
         );
     }
 }
@@ -800,23 +894,24 @@ fn pdf_renderer_wrapper_punctuation_segment_positions_progress_monotonically_v0(
     let xdv = write_dvi_v2_text_page_v0(b"A[mid],B C,[mid]D E{mid}. F")
         .expect("writer should accept wrapper punctuation sequence");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let rendered = rendered_text_for_line_containing_segment_v0(&pdf, "A")
+        .expect("wrapper punctuation line should decode");
+    assert_eq!(rendered, "Amid,B C,midD Emid. F");
 
-    let line_text = String::from_utf8_lossy(&pdf);
+    let a_x = tm_xs_for_segment_text_v0(&pdf, "A")[0];
+    let mid_x = tm_xs_for_segment_text_v0(&pdf, "mid")[0];
+    let trailing_x = tm_x_for_segment_substring_v0(&pdf, "(A)", "(,B C,)")
+        .expect("trailing punctuation segment x");
+    let mid_two_x = tm_xs_for_segment_text_v0(&pdf, "mid")[1];
+    assert!(a_x < mid_x && mid_x < trailing_x && trailing_x < mid_two_x);
+    let epsilon_pt = 0.02f32;
     assert!(
-        line_text.contains("(A) Tj /F2 12 Tf (mid) Tj /F1 12 Tf (,B C,) Tj /F2 12 Tf (mid) Tj"),
-        "expected first styled punctuation sequence missing: {line_text}"
+        ((mid_x - a_x) - segment_width_pt_v0(b"A")).abs() <= epsilon_pt,
+        "A->mid boundary drifted: a_x={a_x}, mid_x={mid_x}"
     );
     assert!(
-        line_text.contains("/F1 12 Tf (D E) Tj /F3 12 Tf (mid) Tj /F1 12 Tf (. F) Tj"),
-        "expected trailing styled punctuation sequence missing: {line_text}"
-    );
-    let tm_count = tm_count_for_line_containing_v0(&pdf, "(A)");
-    assert_eq!(tm_count, 1, "expected single matrix for test line: {line_text}");
-    let max_tm_gap = max_tm_gap_pt_for_line_containing_v0(&pdf, "(A)")
-        .expect("wrapper punctuation line should parse");
-    assert!(
-        max_tm_gap <= 0.02,
-        "wrapper punctuation matrix gaps should remain zero: {max_tm_gap}"
+        ((trailing_x - mid_x) - segment_width_pt_v0(b"mid")).abs() <= epsilon_pt,
+        "mid->trail boundary drifted: mid_x={mid_x}, trailing_x={trailing_x}"
     );
 }
 
@@ -1307,8 +1402,8 @@ fn pdf_renderer_enumerate_number_column_alignment_across_wraps_v0() {
     let ten_number_x = tm_xs_for_segment_text_v0(&pdf, "10.");
     let nine_start_x = tm_xs_for_segment_text_v0(&pdf, "NINESTART");
     let ten_start_x = tm_xs_for_segment_text_v0(&pdf, "TENSTART");
-    let nine_wrap_x = tm_xs_for_segment_text_v0(&pdf, "WRAPNINE");
-    let ten_wrap_x = tm_xs_for_segment_text_v0(&pdf, "WRAPTEN");
+    let nine_wrap_x = tm_line_start_xs_for_segment_text_v0(&pdf, "WRAPNINE");
+    let ten_wrap_x = tm_line_start_xs_for_segment_text_v0(&pdf, "WRAPTEN");
 
     assert_eq!(nine_number_x.len(), 1, "expected 9. number render");
     assert_eq!(ten_number_x.len(), 1, "expected 10. number render");
@@ -1356,9 +1451,9 @@ fn pdf_renderer_nested_list_indentation_and_wrap_invariants_v0() {
 
     let bullet_xs = tm_xs_for_segment_text_v0(&pdf, "-");
     let outer_start_x = tm_xs_for_segment_text_v0(&pdf, "OUTERSTART");
-    let outer_wrap_x = tm_xs_for_segment_text_v0(&pdf, "OUTERWRAPTOKEN");
+    let outer_wrap_x = tm_line_start_xs_for_segment_text_v0(&pdf, "OUTERWRAPTOKEN");
     let nested_start_x = tm_xs_for_segment_text_v0(&pdf, "NESTEDSTART");
-    let nested_wrap_x = tm_xs_for_segment_text_v0(&pdf, "NESTEDWRAPTOKEN");
+    let nested_wrap_x = tm_line_start_xs_for_segment_text_v0(&pdf, "NESTEDWRAPTOKEN");
 
     assert_eq!(bullet_xs.len(), 2, "expected two bullets: {bullet_xs:?}");
     assert_eq!(outer_start_x.len(), 1, "expected outer start render");
@@ -1595,6 +1690,117 @@ fn pdf_renderer_applies_right_alignment_per_line_width_v0() {
     let epsilon_pt = 0.02f32;
     assert!((x_one - expected_one).abs() <= epsilon_pt);
     assert!((x_two - expected_two).abs() <= epsilon_pt);
+}
+
+#[test]
+fn pdf_renderer_center_alignment_handles_styled_segments_without_drift_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"\n^ alpha[mid],gamma\n^ short{bold}.")
+        .expect("writer should accept styled centered lines");
+    let layout = parse_dvi_v2_text_page_to_layout_v0(&xdv, 786_432).expect("layout parse");
+    let line_one = layout.pages[0]
+        .lines
+        .iter()
+        .find(|line| {
+            line.glyphs.iter().map(|glyph| glyph.byte).collect::<Vec<_>>()
+                == b"^ alpha[mid],gamma"
+        })
+        .expect("center styled line one");
+    let line_two = layout.pages[0]
+        .lines
+        .iter()
+        .find(|line| {
+            line.glyphs.iter().map(|glyph| glyph.byte).collect::<Vec<_>>() == b"^ short{bold}."
+        })
+        .expect("center styled line two");
+
+    let expected_one = expected_center_x_pt_v0(
+        width_sp_for_prefixed_rendered_line_v0(line_one, [b'^', b' ']).expect("line one width"),
+    );
+    let expected_two = expected_center_x_pt_v0(
+        width_sp_for_prefixed_rendered_line_v0(line_two, [b'^', b' ']).expect("line two width"),
+    );
+
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let line_one_x = tm_x_for_line_containing_text_v0(&pdf, "(alpha)").expect("line one x");
+    let line_two_x = tm_x_for_line_containing_text_v0(&pdf, "(short)").expect("line two x");
+    let epsilon_pt = 0.02f32;
+    assert!(
+        (line_one_x - expected_one).abs() <= epsilon_pt,
+        "line one center drift: actual={line_one_x}, expected={expected_one}"
+    );
+    assert!(
+        (line_two_x - expected_two).abs() <= epsilon_pt,
+        "line two center drift: actual={line_two_x}, expected={expected_two}"
+    );
+
+    let alpha_x = tm_xs_for_segment_text_v0(&pdf, "alpha")[0];
+    let mid_x = tm_xs_for_segment_text_v0(&pdf, "mid")[0];
+    let gamma_x = tm_x_for_segment_substring_v0(&pdf, "(alpha)", "(,gamma)")
+        .expect("gamma segment x");
+    assert!(
+        ((mid_x - alpha_x) - segment_width_pt_v0(b"alpha")).abs() <= epsilon_pt,
+        "alpha->mid spacing drift: alpha_x={alpha_x}, mid_x={mid_x}"
+    );
+    assert!(
+        ((gamma_x - mid_x) - segment_width_pt_v0(b"mid")).abs() <= epsilon_pt,
+        "mid->gamma spacing drift: mid_x={mid_x}, gamma_x={gamma_x}"
+    );
+}
+
+#[test]
+fn pdf_renderer_right_alignment_handles_styled_segments_without_drift_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"\n| edge, [core] trail\n| alpha{beta}.")
+        .expect("writer should accept styled right-aligned lines");
+    let layout = parse_dvi_v2_text_page_to_layout_v0(&xdv, 786_432).expect("layout parse");
+    let line_one = layout.pages[0]
+        .lines
+        .iter()
+        .find(|line| {
+            line.glyphs.iter().map(|glyph| glyph.byte).collect::<Vec<_>>()
+                == b"| edge, [core] trail"
+        })
+        .expect("right styled line one");
+    let line_two = layout.pages[0]
+        .lines
+        .iter()
+        .find(|line| {
+            line.glyphs.iter().map(|glyph| glyph.byte).collect::<Vec<_>>() == b"| alpha{beta}."
+        })
+        .expect("right styled line two");
+
+    let expected_one = expected_right_x_pt_v0(
+        width_sp_for_prefixed_rendered_line_v0(line_one, [b'|', b' ']).expect("line one width"),
+    );
+    let expected_two = expected_right_x_pt_v0(
+        width_sp_for_prefixed_rendered_line_v0(line_two, [b'|', b' ']).expect("line two width"),
+    );
+
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let line_one_x = tm_x_for_line_containing_text_v0(&pdf, "(edge, )").expect("line one x");
+    let line_two_x = tm_x_for_line_containing_text_v0(&pdf, "(alpha)").expect("line two x");
+    let epsilon_pt = 0.02f32;
+    assert!(
+        (line_one_x - expected_one).abs() <= epsilon_pt,
+        "line one right drift: actual={line_one_x}, expected={expected_one}"
+    );
+    assert!(
+        (line_two_x - expected_two).abs() <= epsilon_pt,
+        "line two right drift: actual={line_two_x}, expected={expected_two}"
+    );
+
+    let edge_x = tm_x_for_segment_substring_v0(&pdf, "(edge, )", "(edge, )")
+        .expect("edge segment x");
+    let core_x = tm_xs_for_segment_text_v0(&pdf, "core")[0];
+    let trail_x = tm_x_for_segment_substring_v0(&pdf, "(edge, )", "( trail)")
+        .expect("trail segment x");
+    assert!(
+        ((core_x - edge_x) - segment_width_pt_v0(b"edge, ")).abs() <= epsilon_pt,
+        "edge->core spacing drift: edge_x={edge_x}, core_x={core_x}"
+    );
+    assert!(
+        ((trail_x - core_x) - segment_width_pt_v0(b"core")).abs() <= epsilon_pt,
+        "core->trail spacing drift: core_x={core_x}, trail_x={trail_x}"
+    );
 }
 
 #[test]
@@ -1879,18 +2085,22 @@ fn pdf_renderer_link_style_near_punctuation_stays_single_matrix_v0() {
     let xdv = write_dvi_v2_text_page_v0(b"See,{Example}. Tail")
         .expect("writer should accept styled punctuation link line");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
-    let pdf_text = String::from_utf8_lossy(&pdf);
+    let rendered = rendered_text_for_line_containing_segment_v0(&pdf, "See,")
+        .expect("link punctuation line should decode");
+    assert_eq!(rendered, "See,Example. Tail");
+
+    let see_x = tm_xs_for_segment_text_v0(&pdf, "See,")[0];
+    let example_x = tm_xs_for_segment_text_v0(&pdf, "Example")[0];
+    let tail_x = tm_x_for_segment_substring_v0(&pdf, "(See,)", "(. Tail)")
+        .expect("tail segment x");
+    let epsilon_pt = 0.02f32;
     assert!(
-        pdf_text.contains("/F1 12 Tf (See,) Tj /F3 12 Tf (Example) Tj /F1 12 Tf (. Tail) Tj"),
-        "styled punctuation link sequence missing: {pdf_text}"
+        ((example_x - see_x) - segment_width_pt_v0(b"See,")).abs() <= epsilon_pt,
+        "See->Example boundary drifted: see_x={see_x}, example_x={example_x}"
     );
-    let tm_count = tm_count_for_line_containing_v0(&pdf, "(See,)");
-    assert_eq!(tm_count, 1, "expected single Tm for link punctuation line");
-    let max_tm_gap = max_tm_gap_pt_for_line_containing_v0(&pdf, "(See,)")
-        .expect("link punctuation line should parse");
     assert!(
-        max_tm_gap <= 0.02,
-        "link punctuation line should not create matrix gaps: {max_tm_gap}"
+        ((tail_x - example_x) - segment_width_pt_v0(b"Example")).abs() <= epsilon_pt,
+        "Example->tail boundary drifted: example_x={example_x}, tail_x={tail_x}"
     );
 }
 

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -92,14 +92,20 @@ The figure block below is a deterministic placeholder stub with caption spacing 
 \subsection{Centering}
 \begin{center}
 Centered environment line one.\linebreak Centered environment line two.
+Centered wrapper stress: alpha \emph{beta},gamma and alpha,\textbf{beta}gamma.
+Centered punctuation stress: edge,\emph{core} trail and edge \textbf{core}!
 \end{center}
 \centerline{Single centered command line.}
+\centerline{Punctuated \emph{center},line and \textbf{bold} end.}
 
 \subsection{FlushRight}
 \begin{flushright}
 Flushright environment line one.\linebreak Flushright environment line two.
+Flushright wrapper stress: alpha \emph{beta},gamma and alpha,\textbf{beta}gamma.
+Flushright punctuation stress: edge,\emph{core} trail and edge \textbf{core}!
 \end{flushright}
 \rightline{Single right-aligned command line.}
+\rightline{Punctuated \emph{right},line and \textbf{bold} end.}
 
 \subsection{Bibliography}
 This paragraph cites one known source \cite{ref:alpha} and one unresolved source \cite{ref:missing} to keep cite rendering deterministic.

--- a/scripts/wasm_typeset_minimal_v0_emit_pdf.mjs
+++ b/scripts/wasm_typeset_minimal_v0_emit_pdf.mjs
@@ -101,51 +101,122 @@ function parseTmYForNeedleV0(streamBody, needle) {
 
 function maxTmGapPtV0(pdfBytes) {
   const text = Buffer.from(pdfBytes).toString('utf8');
+  const BASE_GLYPH_PT_V0 = 7.2;
+  const glyphWidthPtForByteV0 = (byte) => {
+    if (
+      byte === 0x5b || // [
+      byte === 0x5d || // ]
+      byte === 0x7b || // {
+      byte === 0x7d || // }
+      byte === 0x3c || // <
+      byte === 0x3e // >
+    ) {
+      return 0.0;
+    }
+    if (
+      byte === 0x20 || // space
+      byte === 0x2e || // .
+      byte === 0x2c || // ,
+      byte === 0x3b || // ;
+      byte === 0x3a || // :
+      byte === 0x21 || // !
+      byte === 0x3f || // ?
+      byte === 0x27 || // '
+      byte === 0x22 || // "
+      byte === 0x69 || // i
+      byte === 0x6c || // l
+      byte === 0x49 || // I
+      byte === 0x7c // |
+    ) {
+      return BASE_GLYPH_PT_V0 * 0.5;
+    }
+    if (
+      byte === 0x6d || // m
+      byte === 0x77 || // w
+      byte === 0x4d || // M
+      byte === 0x57 // W
+    ) {
+      return BASE_GLYPH_PT_V0 * 1.5;
+    }
+    return BASE_GLYPH_PT_V0;
+  };
+
+  const parsePdfStringTokenV0 = (line, startIndex) => {
+    if (line[startIndex] !== '(') return null;
+    const out = [];
+    let index = startIndex + 1;
+    while (index < line.length) {
+      const ch = line[index];
+      if (ch === '\\') {
+        index += 1;
+        if (index >= line.length) return null;
+        out.push(line[index]);
+        index += 1;
+        continue;
+      }
+      if (ch === ')') {
+        return { text: out.join(''), end: index + 1 };
+      }
+      out.push(ch);
+      index += 1;
+    }
+    return null;
+  };
+
+  const parseTmSegmentsForLineV0 = (line) => {
+    const segments = [];
+    let index = 0;
+    while (index < line.length) {
+      const tmStart = line.indexOf('1 0 0 1 ', index);
+      if (tmStart < 0) break;
+      const tmMatch = line
+        .slice(tmStart)
+        .match(/^1 0 0 1 ([+-]?\d+(?:\.\d+)?) ([+-]?\d+(?:\.\d+)?) Tm /);
+      if (!tmMatch) break;
+      const x = Number.parseFloat(tmMatch[1]);
+      if (!Number.isFinite(x)) break;
+      let cursor = tmStart + tmMatch[0].length;
+      const openParen = line.indexOf('(', cursor);
+      if (openParen < 0) break;
+      const parsed = parsePdfStringTokenV0(line, openParen);
+      if (!parsed) break;
+      const tjStart = line.indexOf(' Tj', parsed.end);
+      if (tjStart < 0) break;
+      const fontMatch = line
+        .slice(tmStart, parsed.end)
+        .match(/\/(F[123])\s+[+-]?\d+(?:\.\d+)?\s+Tf\s+\(/);
+      const font = fontMatch ? fontMatch[1] : '';
+      segments.push({ x, text: parsed.text, font });
+      index = tjStart + 3;
+    }
+    return segments;
+  };
+
+  const segmentAdvancePtV0 = (segmentText) => {
+    const bytes = Buffer.from(segmentText, 'utf8');
+    let total = 0;
+    for (const byte of bytes) {
+      total += glyphWidthPtForByteV0(byte);
+    }
+    return total;
+  };
+
   let maxGapPt = 0;
   for (const line of text.split('\n')) {
-    const fields = line.trim().split(/\s+/).filter((field) => field.length > 0);
-    const segments = [];
-    for (let index = 0; index + 6 < fields.length; index += 1) {
-      if (
-        fields[index] === '1' &&
-        fields[index + 1] === '0' &&
-        fields[index + 2] === '0' &&
-        fields[index + 3] === '1' &&
-        fields[index + 6] === 'Tm'
-      ) {
-        const parsedX = Number.parseFloat(fields[index + 4]);
-        if (!Number.isFinite(parsedX)) {
-          throw new Error(`invalid Tm x field: ${fields[index + 4]}`);
-        }
-        let textToken = '';
-        let cursor = index + 7;
-        while (cursor < fields.length) {
-          if (
-            fields[cursor] === '1' &&
-            cursor + 6 < fields.length &&
-            fields[cursor + 1] === '0' &&
-            fields[cursor + 2] === '0' &&
-            fields[cursor + 3] === '1' &&
-            fields[cursor + 6] === 'Tm'
-          ) {
-            break;
-          }
-          if (fields[cursor].startsWith('(') && fields[cursor].endsWith(')')) {
-            textToken = fields[cursor].slice(1, -1);
-          }
-          cursor += 1;
-        }
-        segments.push({ x: parsedX, text: textToken });
-      }
-    }
+    if (!line.includes(' Tm ') || !line.includes(' Tj')) continue;
+    const segments = parseTmSegmentsForLineV0(line);
     if (segments.length < 2) continue;
-    for (let index = 1; index < segments.length; index += 1) {
-      const previous = segments[index - 1];
-      const current = segments[index];
+    for (let segIndex = 1; segIndex < segments.length; segIndex += 1) {
+      const previous = segments[segIndex - 1];
+      const current = segments[segIndex];
       if (previous.text === '-' || /^\d+\.$/.test(previous.text)) {
         continue;
       }
-      const gapPt = current.x - previous.x;
+      if (!previous.font || !current.font || previous.font === current.font) {
+        continue;
+      }
+      const expectedCurrentX = previous.x + segmentAdvancePtV0(previous.text);
+      const gapPt = current.x - expectedCurrentX;
       if (gapPt > maxGapPt) {
         maxGapPt = gapPt;
       }


### PR DESCRIPTION
Implements carreltex#384 (locked bundle leaf) as a single PR.\n\nScope:\n- deterministic inline wrapper spacing normalization and punctuation-boundary cleanup in typeset_minimal extraction\n- per-segment PDF text-matrix emission so style switches use exact segment advances\n- expanded xdv invariants for wrapper boundaries and center/right alignment stability\n- fixture stress additions for center/flushright wrapper+punctuation cases\n- robust proof gap parser based on parsed Tm/Tj segments and stable metrics\n\nNo guardrails relaxed; behavior remains fail-closed.