### PR TITLE
typeset_minimal: includegraphics figure stub v1 + graphics plumbing

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -42,6 +42,7 @@ const BIBITEM_LINE_PREFIX_MARKER_V0: &[u8] = b"!b ";
 const CITE_LINE_PREFIX_MARKER_V0: &[u8] = b"!c ";
 const TABLE_ROW_PREFIX_MARKER_V0: &[u8] = b"!t ";
 const FIGURE_BOX_PREFIX_MARKER_V0: &[u8] = b"!gbox";
+const FIGURE_IMAGE_PREFIX_MARKER_V0: &[u8] = b"!gimg ";
 const FIGURE_CAPTION_PREFIX_MARKER_V0: &[u8] = b"!gcap ";
 const TOC_PLACEHOLDER_MARKER_V0: &[u8] = b"!toc";
 const TOC_ENTRY_LINE_PREFIX_MARKER_V0: &[u8] = b"!toc ";
@@ -951,6 +952,96 @@ fn parse_char_space_group_trimmed_v0(
     Some(out)
 }
 
+fn is_safe_graphics_path_byte_v0(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b'.' | b'_' | b'-')
+}
+
+fn has_allowed_graphics_extension_v0(path: &[u8]) -> bool {
+    let Some(last_segment) = path.rsplit(|byte| *byte == b'/').next() else {
+        return false;
+    };
+    let Some(dot_index) = last_segment.iter().rposition(|byte| *byte == b'.') else {
+        return false;
+    };
+    if dot_index == 0 || dot_index + 1 >= last_segment.len() {
+        return false;
+    }
+    let ext = last_segment[dot_index + 1..]
+        .iter()
+        .map(u8::to_ascii_lowercase)
+        .collect::<Vec<u8>>();
+    matches!(ext.as_slice(), b"png" | b"jpg" | b"jpeg" | b"pdf")
+}
+
+fn normalize_graphics_path_v0(raw_path: &[u8]) -> Option<Vec<u8>> {
+    if raw_path.is_empty() {
+        return None;
+    }
+    if raw_path.starts_with(b"/") || raw_path.starts_with(b"\\") {
+        return None;
+    }
+    if raw_path.contains(&b'\\') || raw_path.contains(&b':') {
+        return None;
+    }
+    if !raw_path.iter().copied().all(is_safe_graphics_path_byte_v0) {
+        return None;
+    }
+
+    let mut normalized_segments = Vec::<Vec<u8>>::new();
+    for segment in raw_path.split(|byte| *byte == b'/') {
+        if segment.is_empty() || segment == b"." || segment == b".." {
+            return None;
+        }
+        normalized_segments.push(segment.to_vec());
+    }
+    if normalized_segments.is_empty() {
+        return None;
+    }
+
+    let mut normalized = Vec::<u8>::new();
+    for (segment_index, segment) in normalized_segments.iter().enumerate() {
+        if segment_index > 0 {
+            normalized.push(b'/');
+        }
+        normalized.extend_from_slice(segment);
+    }
+    if !has_allowed_graphics_extension_v0(&normalized) {
+        let has_explicit_extension = normalized
+            .rsplit(|byte| *byte == b'/')
+            .next()
+            .map(|last: &[u8]| last.contains(&b'.'))
+            .unwrap_or(false);
+        if has_explicit_extension {
+            return None;
+        }
+        normalized.extend_from_slice(b".png");
+    }
+    Some(normalized)
+}
+
+fn consume_includegraphics_path_v0(tokens: &[TokenV0], index: usize) -> Option<(Vec<u8>, usize)> {
+    if !matches!(
+        tokens.get(index),
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == INCLUDEGRAPHICS_CONTROL_V0
+    ) {
+        return None;
+    }
+    let group_index = skip_spaces(tokens, index + 1);
+    if matches!(tokens.get(group_index), Some(TokenV0::Char(b'['))) {
+        return None;
+    }
+    let (group_start, group_end, next) = consume_group_bounds(tokens, group_index)?;
+    let mut raw_path = Vec::<u8>::new();
+    for token in &tokens[group_start..group_end] {
+        match token {
+            TokenV0::Char(byte) if is_safe_graphics_path_byte_v0(*byte) => raw_path.push(*byte),
+            _ => return None,
+        }
+    }
+    let normalized = normalize_graphics_path_v0(&raw_path)?;
+    Some((normalized, next))
+}
+
 fn consume_tabular_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
     let (env_name, mut cursor) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
     if env_name.as_slice() != TABULAR_ENV_V0 {
@@ -1030,13 +1121,19 @@ fn consume_tabular_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Ve
     }
 }
 
-fn consume_figure_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+fn consume_figure_environment_v0(
+    tokens: &[TokenV0],
+    index: usize,
+    out: &mut Vec<u8>,
+    figure_anchor_id: u32,
+) -> Option<usize> {
     let (env_name, mut cursor) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
     if env_name.as_slice() != FIGURE_ENV_V0 {
         return None;
     }
 
     let mut caption: Option<Vec<u8>> = None;
+    let mut image_path: Option<Vec<u8>> = None;
     loop {
         cursor = skip_spaces(tokens, cursor);
         match tokens.get(cursor) {
@@ -1053,6 +1150,13 @@ fn consume_figure_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec
                 push_paragraph_break(out);
                 out.extend_from_slice(FIGURE_BOX_PREFIX_MARKER_V0);
                 push_newline(out);
+                if let Some(path) = &image_path {
+                    out.extend_from_slice(FIGURE_IMAGE_PREFIX_MARKER_V0);
+                    out.extend_from_slice(figure_anchor_id.to_string().as_bytes());
+                    out.push(b' ');
+                    out.extend_from_slice(path);
+                    push_newline(out);
+                }
                 out.extend_from_slice(FIGURE_CAPTION_PREFIX_MARKER_V0);
                 out.extend_from_slice(&figure_caption);
                 push_newline(out);
@@ -1077,7 +1181,12 @@ fn consume_figure_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec
                 cursor = next;
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == INCLUDEGRAPHICS_CONTROL_V0 => {
-                return None;
+                if image_path.is_some() {
+                    return None;
+                }
+                let (path, next) = consume_includegraphics_path_v0(tokens, cursor)?;
+                image_path = Some(path);
+                cursor = next;
             }
             Some(TokenV0::ControlSeq(name))
                 if name.as_slice() == b"protect" || name.as_slice() == b"relax" =>
@@ -1429,9 +1538,6 @@ fn consume_body_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u
     }
     if env_name.as_slice() == TABULAR_ENV_V0 {
         return consume_tabular_environment_v0(tokens, index, out);
-    }
-    if env_name.as_slice() == FIGURE_ENV_V0 {
-        return consume_figure_environment_v0(tokens, index, out);
     }
     None
 }
@@ -1962,9 +2068,9 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
                 pending_noindent_after_heading = false;
                 let (env_name, _) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
                 if env_name.as_slice() == FIGURE_ENV_V0 {
-                    index = consume_figure_environment_v0(tokens, index, &mut body)?;
                     let anchor_id = next_anchor_id;
                     next_anchor_id = next_anchor_id.checked_add(1)?;
+                    index = consume_figure_environment_v0(tokens, index, &mut body, anchor_id)?;
                     pending_label_target = Some(PendingLabelTargetV0 {
                         anchor_id,
                         kind: LabelKindV0::Figure,

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -544,8 +544,38 @@ fn typeset_minimal_figure_stub_emits_placeholder_and_caption_markers() {
 }
 
 #[test]
-fn typeset_minimal_rejects_figure_with_includegraphics() {
+fn typeset_minimal_figure_stub_accepts_includegraphics_path_marker() {
     let main = b"\\documentclass{article}\\begin{document}\\begin{figure}\\includegraphics{demo.png}\\caption{Nope}\\end{figure}\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("!gbox\n!gimg 1 demo.png\n!gcap Nope"),
+        "body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_figure_stub_accepts_includegraphics_without_extension_by_normalizing_png() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{figure}\\includegraphics{figs/demo}\\caption{No ext}\\end{figure}\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("!gimg 1 figs/demo.png"),
+        "body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_rejects_figure_includegraphics_optional_args() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{figure}\\includegraphics[width=0.5\\textwidth]{demo.png}\\caption{Nope}\\end{figure}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_figure_includegraphics_unsafe_path() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{figure}\\includegraphics{../demo.png}\\caption{Nope}\\end{figure}\\end{document}";
     let result = compile_typeset(main);
     assert_eq!(result.status, CompileStatus::NotImplemented);
     assert!(result.main_xdv_bytes.is_empty());

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -35,6 +35,7 @@ const FOOTNOTE_MARKER_FONT_SIZE_PT_V0: f32 = 8.0;
 const FOOTNOTE_MARKER_RISE_PT_V0: f32 = 4.0;
 const TABLE_ROW_PREFIX_MARKER_V0: &[u8] = b"!t ";
 const FIGURE_BOX_PREFIX_MARKER_V0: &[u8] = b"!gbox";
+const FIGURE_IMAGE_PREFIX_MARKER_V0: &[u8] = b"!gimg ";
 const FIGURE_CAPTION_PREFIX_MARKER_V0: &[u8] = b"!gcap ";
 const TOC_PLACEHOLDER_MARKER_V0: &[u8] = b"!toc";
 const TOC_ENTRY_LINE_PREFIX_MARKER_V0: &[u8] = b"!toc ";
@@ -466,6 +467,14 @@ fn has_figure_caption_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
             .eq(FIGURE_CAPTION_PREFIX_MARKER_V0.iter().copied())
 }
 
+fn has_figure_image_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() >= FIGURE_IMAGE_PREFIX_MARKER_V0.len()
+        && glyphs[..FIGURE_IMAGE_PREFIX_MARKER_V0.len()]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .eq(FIGURE_IMAGE_PREFIX_MARKER_V0.iter().copied())
+}
+
 fn has_toc_placeholder_line_v0(glyphs: &[GlyphPlanV0]) -> bool {
     glyphs.len() == TOC_PLACEHOLDER_MARKER_V0.len()
         && glyphs
@@ -529,8 +538,57 @@ fn parse_figure_caption_line_v0(glyphs: &[GlyphPlanV0]) -> Option<Vec<GlyphPlanV
     Some(caption)
 }
 
-fn placeholder_segments_v0() -> Vec<PdfStyledSegmentV0> {
-    let glyphs: Vec<GlyphPlanV0> = FIGURE_PLACEHOLDER_LINE_V0
+fn is_safe_figure_image_path_byte_v0(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b'.' | b'_' | b'-')
+}
+
+fn parse_figure_image_line_v0(glyphs: &[GlyphPlanV0]) -> Option<(u32, Vec<u8>)> {
+    if !has_figure_image_prefix_v0(glyphs) {
+        return None;
+    }
+    let mut cursor = FIGURE_IMAGE_PREFIX_MARKER_V0.len();
+    let mut anchor_id = 0u32;
+    let mut saw_anchor_digit = false;
+    while cursor < glyphs.len() && glyphs[cursor].byte.is_ascii_digit() {
+        anchor_id = anchor_id
+            .checked_mul(10)?
+            .checked_add(u32::from(glyphs[cursor].byte - b'0'))?;
+        saw_anchor_digit = true;
+        cursor += 1;
+    }
+    if !saw_anchor_digit || anchor_id == 0 {
+        return None;
+    }
+    if cursor >= glyphs.len() || glyphs[cursor].byte != b' ' {
+        return None;
+    }
+    cursor += 1;
+    if cursor >= glyphs.len() {
+        return None;
+    }
+    let mut image_path = Vec::<u8>::new();
+    for glyph in &glyphs[cursor..] {
+        if !is_safe_figure_image_path_byte_v0(glyph.byte) {
+            return None;
+        }
+        image_path.push(glyph.byte);
+    }
+    if image_path.is_empty() {
+        return None;
+    }
+    Some((anchor_id, image_path))
+}
+
+fn placeholder_segments_v0(image_path: Option<&[u8]>) -> Vec<PdfStyledSegmentV0> {
+    let mut placeholder_bytes = Vec::<u8>::new();
+    if let Some(path) = image_path {
+        placeholder_bytes.extend_from_slice(b"[ Figure placeholder: ");
+        placeholder_bytes.extend_from_slice(path);
+        placeholder_bytes.extend_from_slice(b" ]");
+    } else {
+        placeholder_bytes.extend_from_slice(FIGURE_PLACEHOLDER_LINE_V0);
+    }
+    let glyphs: Vec<GlyphPlanV0> = placeholder_bytes
         .iter()
         .copied()
         .map(|byte| GlyphPlanV0 {
@@ -620,6 +678,7 @@ fn emit_table_block_v0(
 
 fn emit_figure_block_v0(
     out: &mut Vec<u8>,
+    image_path: Option<&[u8]>,
     caption_glyphs: &[GlyphPlanV0],
     y: &mut f32,
     min_body_y_pt: f32,
@@ -628,7 +687,7 @@ fn emit_figure_block_v0(
         return None;
     }
 
-    let placeholder_segments = placeholder_segments_v0();
+    let placeholder_segments = placeholder_segments_v0(image_path);
     let placeholder_render_segments = split_superscript_segments_v0(&placeholder_segments);
     let placeholder_width_pt = placeholder_render_segments
         .iter()
@@ -1409,15 +1468,33 @@ fn build_page_content_stream_v0(
             continue;
         }
         if line_index >= title_block_len && has_figure_box_prefix_v0(&line.glyphs) {
-            let caption_line = lines.get(line_index + 1)?;
+            let mut cursor = line_index + 1;
+            let mut image_path: Option<Vec<u8>> = None;
+            if let Some(image_line) = lines.get(cursor) {
+                if has_figure_image_prefix_v0(&image_line.glyphs) {
+                    let (_, parsed_path) = parse_figure_image_line_v0(&image_line.glyphs)?;
+                    image_path = Some(parsed_path);
+                    cursor += 1;
+                }
+            }
+            let caption_line = lines.get(cursor)?;
             let caption_glyphs = parse_figure_caption_line_v0(&caption_line.glyphs)?;
-            emit_figure_block_v0(&mut out, &caption_glyphs, &mut y, min_body_y_pt)?;
+            emit_figure_block_v0(
+                &mut out,
+                image_path.as_deref(),
+                &caption_glyphs,
+                &mut y,
+                min_body_y_pt,
+            )?;
             previous_rendered_line_was_empty = false;
             skip_indent_after_title_block = false;
             active_hang_indent_pt = 0.0;
             active_quote_indent_pt = 0.0;
-            line_index += 2;
+            line_index = cursor + 1;
             continue;
+        }
+        if line_index >= title_block_len && has_figure_image_prefix_v0(&line.glyphs) {
+            return None;
         }
         if line_index >= title_block_len && has_figure_caption_prefix_v0(&line.glyphs) {
             return None;

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -2374,7 +2374,7 @@ fn pdf_renderer_rejects_table_width_overflow_v0() {
 #[test]
 fn pdf_renderer_figure_block_spacing_invariants_v0() {
     let xdv = write_dvi_v2_text_page_v0(
-        b"Before paragraph.\n\n!gbox\n!gcap Figure caption text.\n\nAfter paragraph.",
+        b"Before paragraph.\n\n!gbox\n!gimg 7 figures/demo.png\n!gcap Figure caption text.\n\nAfter paragraph.",
     )
     .expect("writer should accept figure marker lines");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
@@ -2384,8 +2384,8 @@ fn pdf_renderer_figure_block_spacing_invariants_v0() {
         "figure marker should be hidden in pdf output: {pdf_text}"
     );
     assert!(
-        pdf_text.contains("([ Figure placeholder ]) Tj"),
-        "placeholder text should render: {pdf_text}"
+        pdf_text.contains("([ Figure placeholder: figures/demo.png ]) Tj"),
+        "graphics placeholder text should render with normalized path label: {pdf_text}"
     );
     assert!(
         pdf_text.contains("(Figure caption text.) Tj"),
@@ -2399,7 +2399,7 @@ fn pdf_renderer_figure_block_spacing_invariants_v0() {
         tm_position_for_line_containing_text_v0(&pdf, "(Before paragraph.)").expect("before");
     let (placeholder_x, placeholder_y) = tm_position_for_line_containing_text_v0(
         &pdf,
-        "([ Figure placeholder ])",
+        "([ Figure placeholder: figures/demo.png ])",
     )
     .expect("placeholder");
     let (caption_x, caption_y) =
@@ -2420,6 +2420,17 @@ fn pdf_renderer_figure_block_spacing_invariants_v0() {
     assert!(before_y > placeholder_y, "placeholder should render below body");
     assert!(placeholder_y > caption_y, "caption should render below placeholder");
     assert!(caption_y > after_y, "after paragraph should render below caption");
+}
+
+#[test]
+fn pdf_renderer_rejects_malformed_figure_image_metadata_line_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"!gbox\n!gimg demo.png\n!gcap Caption")
+        .expect("writer should accept figure marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed on malformed !gimg metadata"
+    );
 }
 
 #[test]

--- a/scripts/texlive_smoke/fixtures/typeset_demo_graphics_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_graphics_probe_v0.tex
@@ -1,5 +1,4 @@
 \documentclass{article}
-\usepackage{graphicx}
 
 \title{CarrelTeX Graphics Probe}
 \author{Fixture Bot}
@@ -8,5 +7,8 @@
 \begin{document}
 \maketitle
 
-\includegraphics[width=0.5\textwidth]{demo.png}
+\begin{figure}
+\includegraphics{demo}
+\caption{Deterministic graphics stub caption.}
+\end{figure}
 \end{document}

--- a/scripts/texlive_smoke/request_list_from_hints_v0.mjs
+++ b/scripts/texlive_smoke/request_list_from_hints_v0.mjs
@@ -154,7 +154,7 @@ export async function buildRequestListFromHintsV0(options = {}) {
     const variant = normalizeVariantFromCaseIdV0(caseId);
 
     if (hintType === 'graphics_path') {
-      const name = normalizeTexmfNameV0(value, hintType, caseId);
+      const name = ensureDefaultExtensionV0(normalizeTexmfNameV0(value, hintType, caseId), 'png');
       const request = {
         kind: 'texmf',
         format: inferTexmfFormatV0(name, 'graphic'),

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -81,9 +81,9 @@
     },
     {
       "id": "typeset_demo_graphics_probe_v0",
-      "tags": ["typeset", "graphics", "probe", "ni"],
-      "expected_status": "NI",
-      "purpose": "Probes graphics include seam planned for future typed artifacts."
+      "tags": ["typeset", "graphics", "probe", "ok"],
+      "expected_status": "OK",
+      "purpose": "Exercises includegraphics stub v1 in figure mode so graphics dependencies become auditable resource edges."
     },
     {
       "id": "typeset_demo_graphicspath_probe_v0",

--- a/scripts/wasm_fixture_gallery_v1/main.mjs
+++ b/scripts/wasm_fixture_gallery_v1/main.mjs
@@ -1500,6 +1500,7 @@ function extractPkgoptEntriesFromSourceV0(sourceBytes) {
 }
 
 function extractGraphicsEntriesFromSourceV0(sourceBytes) {
+  const allowedExtensions = new Set(['png', 'jpg', 'jpeg', 'pdf']);
   const entries = [];
   let index = 0;
   while (index < sourceBytes.length) {
@@ -1532,17 +1533,35 @@ function extractGraphicsEntriesFromSourceV0(sourceBytes) {
       index = commandIndex;
       continue;
     }
-    const pathBytes = Buffer.from(pathGroup.value, 'utf8');
+    const pathAsWritten = pathGroup.value.trim();
+    if (pathAsWritten.length === 0) {
+      index = pathGroup.next;
+      continue;
+    }
+    const normalizedToken = normalizePathHintTokenV0(pathAsWritten, 'graphics_path');
+    if (normalizedToken === null) {
+      index = pathGroup.next;
+      continue;
+    }
+    const resolverPath = ensureDefaultExtensionV0(normalizedToken, 'png');
+    const dotIndex = resolverPath.lastIndexOf('.');
+    const extension = dotIndex >= 0 ? resolverPath.slice(dotIndex + 1).toLowerCase() : '';
+    if (!allowedExtensions.has(extension)) {
+      throw new Error(`graphics_v1 unsupported extension '${extension}'`);
+    }
+
+    const pathBytes = Buffer.from(pathAsWritten, 'utf8');
     if (pathBytes.length > MAX_GRAPHICS_PATH_BYTES_V0) {
-      throw new Error(`graphics_v0 path exceeds cap ${MAX_GRAPHICS_PATH_BYTES_V0}`);
+      throw new Error(`graphics_v1 path exceeds cap ${MAX_GRAPHICS_PATH_BYTES_V0}`);
     }
     entries.push({
       command,
-      path: pathGroup.value,
-      source_span: buildSourceSpanV0(sourceBytes, index, pathGroup.next, 'graphics_v0'),
+      path: pathAsWritten,
+      resolver_path: resolverPath,
+      source_span: buildSourceSpanV0(sourceBytes, index, pathGroup.next, 'graphics_v1'),
     });
     if (entries.length > MAX_GRAPHICS_ENTRIES_V0) {
-      throw new Error(`graphics_v0 entries exceed cap ${MAX_GRAPHICS_ENTRIES_V0}`);
+      throw new Error(`graphics_v1 entries exceed cap ${MAX_GRAPHICS_ENTRIES_V0}`);
     }
     index = pathGroup.next;
   }
@@ -2577,11 +2596,11 @@ async function emitPkgoptTypedArtifactV0(caseOutDir, fixtureBytes) {
 async function emitGraphicsTypedArtifactV0(caseOutDir, fixtureBytes) {
   const payload = {
     version: TYPED_ARTIFACTS_VERSION_V0,
-    schema: 'graphics_v0',
+    schema: 'graphics_v1',
     entries: extractGraphicsEntriesFromSourceV0(fixtureBytes),
   };
   const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
-  const relpath = 'graphics_v0.json';
+  const relpath = 'graphics_v1.json';
   const fullPath = path.join(caseOutDir, relpath);
   await writeFile(fullPath, bytes);
   return {

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
@@ -365,9 +365,9 @@ if (graphicsSummary?.typed_artifacts?.graphics?.present !== true) {
   console.error('FAIL: expected graphics typed artifact present after first run');
   process.exit(1);
 }
-const graphicsPath = path.join(outDir, 'typeset_demo_graphics_probe_v0', 'graphics_v0.json');
+const graphicsPath = path.join(outDir, 'typeset_demo_graphics_probe_v0', 'graphics_v1.json');
 if (!fs.existsSync(graphicsPath)) {
-  console.error('FAIL: expected graphics_v0.json artifact after first run');
+  console.error('FAIL: expected graphics_v1.json artifact after first run');
   process.exit(1);
 }
 const graphicsShaFirst = graphicsSummary.typed_artifacts.graphics.artifact_sha256;
@@ -377,15 +377,15 @@ if (typeof graphicsShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(graphicsShaFi
 }
 const graphicsArtifactFirst = JSON.parse(fs.readFileSync(graphicsPath, 'utf8'));
 if (!Array.isArray(graphicsArtifactFirst?.entries)) {
-  console.error('FAIL: expected graphics_v0.entries array in first-run artifact');
+  console.error('FAIL: expected graphics_v1.entries array in first-run artifact');
   process.exit(1);
 }
 if (graphicsArtifactFirst.entries.length <= 0) {
-  console.error('FAIL: expected non-empty graphics_v0.entries for graphics probe');
+  console.error('FAIL: expected non-empty graphics_v1.entries for graphics probe');
   process.exit(1);
 }
-assertEntrySourceSpans('typeset_demo_graphics_probe_v0', 'graphics_v0', graphicsArtifactFirst.entries);
-fs.writeFileSync(firstRunShaPath('graphics_v0'), `${graphicsShaFirst}\n`);
+assertEntrySourceSpans('typeset_demo_graphics_probe_v0', 'graphics_v1', graphicsArtifactFirst.entries);
+fs.writeFileSync(firstRunShaPath('graphics_v1'), `${graphicsShaFirst}\n`);
 
 const mathSummary = JSON.parse(
   fs.readFileSync(path.join(outDir, 'typeset_demo_minimal_v0', 'summary.json'), 'utf8'),

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
@@ -70,7 +70,7 @@ const tocShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'toc_v1_firs
 const bibShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'bib_v0_first.sha256'), 'utf8').trim();
 const hyperrefShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'hyperref_v0_first.sha256'), 'utf8').trim();
 const pkgoptShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'pkgopt_v0_first.sha256'), 'utf8').trim();
-const graphicsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'graphics_v0_first.sha256'), 'utf8').trim();
+const graphicsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'graphics_v1_first.sha256'), 'utf8').trim();
 const mathShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'math_v1_first.sha256'), 'utf8').trim();
 
 if (resolvedCount <= 0) {
@@ -401,14 +401,14 @@ if (!graphicsArtifact || graphicsArtifact.present !== true) {
 }
 const graphicsShaSecond = graphicsArtifact.artifact_sha256;
 if (graphicsShaSecond !== graphicsShaFirst) {
-  console.error('FAIL: graphics_v0 artifact sha256 must be stable across reruns');
+  console.error('FAIL: graphics_v1 artifact sha256 must be stable across reruns');
   process.exit(1);
 }
 const graphicsArtifactSecond = JSON.parse(
-  fs.readFileSync(path.join(outDir, 'typeset_demo_graphics_probe_v0', 'graphics_v0.json'), 'utf8'),
+  fs.readFileSync(path.join(outDir, 'typeset_demo_graphics_probe_v0', 'graphics_v1.json'), 'utf8'),
 );
 if (!Array.isArray(graphicsArtifactSecond?.entries) || graphicsArtifactSecond.entries.length <= 0) {
-  console.error('FAIL: expected non-empty graphics_v0.entries after rerun');
+  console.error('FAIL: expected non-empty graphics_v1.entries after rerun');
   process.exit(1);
 }
 
@@ -495,7 +495,7 @@ console.log(`PASS: toc_v1 sha stable ${tocShaSecond}`);
 console.log(`PASS: bib_v0 sha stable ${bibShaSecond}`);
 console.log(`PASS: hyperref_v0 sha stable ${hyperrefShaSecond}`);
 console.log(`PASS: pkgopt_v0 sha stable ${pkgoptShaSecond}`);
-console.log(`PASS: graphics_v0 sha stable ${graphicsShaSecond}`);
+console.log(`PASS: graphics_v1 sha stable ${graphicsShaSecond}`);
 console.log(`PASS: math_v1 sha stable ${mathShaSecond}`);
 console.log('PASS: report typed_artifact_sha256 map present and stable');
 console.log('PASS: report top-level case_artifact_sha256 present');


### PR DESCRIPTION
Implements carreltex#386 as a single bundle leaf.\n\nScope:\n- typeset_minimal_v0 accepts strict \includegraphics{...} in figure stub only (fail-closed path rules, no optional args).\n- engine emits figure image metadata markers for deterministic preview rendering.\n- xdv/pdf renderer consumes figure image markers and renders deterministic graphics placeholder label.\n- fixture gallery updates graphics typed artifact to graphics_v1 and request mapping defaults graphics paths to .png.\n- graphics probe fixture now exercises the supported includegraphics-in-figure path and is marked OK in manifest.\n\nProofs run locally:\n- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests\n- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml\n- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 6\n- ./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 18\n