### PR TITLE
typeset_minimal crossref pass v1

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -38,6 +38,7 @@ const FOOTNOTE_LINE_PREFIX_MARKER_V0: &[u8] = b"!f ";
 const HREF_URL_LINE_PREFIX_MARKER_V0: &[u8] = b"!u ";
 const LABEL_LINE_PREFIX_MARKER_V0: &[u8] = b"!l ";
 const REF_LINE_PREFIX_MARKER_V0: &[u8] = b"!r ";
+const REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0: &[u8] = b"!ra ";
 const BIBITEM_LINE_PREFIX_MARKER_V0: &[u8] = b"!b ";
 const CITE_LINE_PREFIX_MARKER_V0: &[u8] = b"!c ";
 const TABLE_ROW_PREFIX_MARKER_V0: &[u8] = b"!t ";
@@ -101,6 +102,24 @@ struct RefOccurrenceMetaV0 {
     key: Vec<u8>,
     line_index: u32,
     resolved_anchor_id: Option<u32>,
+}
+
+#[derive(Clone)]
+struct HrefLinkMetaV0 {
+    link_id: u32,
+    url: Vec<u8>,
+}
+
+#[derive(Clone)]
+struct RefAnchorLinkMetaV0 {
+    link_id: u32,
+    anchor_id: u32,
+}
+
+struct CrossRefArtifactsV1 {
+    labels_by_key: BTreeMap<Vec<u8>, LabelEntryMetaV0>,
+    heading_anchor_ids: BTreeMap<u32, ()>,
+    hyperref_enabled: bool,
 }
 
 #[derive(Clone)]
@@ -815,6 +834,13 @@ fn consume_fragment_token_v0(
         }
         TokenV0::ControlSeq(name) if allow_hard_break && name.as_slice() == b"[" => {
             consume_display_math_command_v0(tokens, index, out)
+        }
+        TokenV0::ControlSeq(name) if name.as_slice() == REF_CONTROL_V0 => {
+            let (key, next) = parse_label_or_ref_key_group_v0(tokens, index)?;
+            out.extend_from_slice(REF_MARKER_PREFIX_V0);
+            out.extend_from_slice(&key);
+            out.extend_from_slice(REF_MARKER_SUFFIX_V0);
+            Some(next)
         }
         TokenV0::ControlSeq(name) if name.as_slice() == b"protect" || name.as_slice() == b"relax" => {
             Some(index + 1)
@@ -1636,10 +1662,34 @@ fn parse_label_or_ref_key_group_v0(tokens: &[TokenV0], index: usize) -> Option<(
     Some((key, next))
 }
 
-fn resolve_ref_markers_v0(
-    body: &[u8],
+fn build_crossref_artifacts_v1(
     labels_by_key: &BTreeMap<Vec<u8>, LabelEntryMetaV0>,
+    toc_entries: &[TocEntryMetaV0],
+    hyperref_enabled: bool,
+) -> Option<CrossRefArtifactsV1> {
+    let mut heading_anchor_ids = BTreeMap::<u32, ()>::new();
+    for entry in toc_entries {
+        if heading_anchor_ids.insert(entry.anchor_id, ()).is_some() {
+            return None;
+        }
+    }
+    for entry in labels_by_key.values() {
+        if matches!(entry.kind, LabelKindV0::Heading) {
+            heading_anchor_ids.entry(entry.anchor_id).or_insert(());
+        }
+    }
+    Some(CrossRefArtifactsV1 {
+        labels_by_key: labels_by_key.clone(),
+        heading_anchor_ids,
+        hyperref_enabled,
+    })
+}
+
+fn apply_crossref_pass_v1(
+    body: &[u8],
+    artifacts: &CrossRefArtifactsV1,
     ref_occurrences: &mut Vec<RefOccurrenceMetaV0>,
+    ref_link_anchor_ids: &mut Vec<u32>,
 ) -> Option<Vec<u8>> {
     let mut out = Vec::<u8>::with_capacity(body.len());
     let mut index = 0usize;
@@ -1662,18 +1712,33 @@ fn resolve_ref_markers_v0(
                 return None;
             }
             let key = body[key_start..key_end].to_vec();
-            let resolved_anchor_id = labels_by_key.get(&key).map(|entry| entry.anchor_id);
+            let resolved_anchor_id = artifacts.labels_by_key.get(&key).map(|entry| entry.anchor_id);
+            if let Some(anchor_id) = resolved_anchor_id {
+                if let Some(label) = artifacts.labels_by_key.get(&key) {
+                    if matches!(label.kind, LabelKindV0::Heading)
+                        && !artifacts.heading_anchor_ids.contains_key(&anchor_id)
+                    {
+                        return None;
+                    }
+                }
+            }
+            if let Some(anchor_id) = resolved_anchor_id {
+                if artifacts.hyperref_enabled {
+                    out.push(LINK_START_MARKER_V0);
+                    out.extend_from_slice(anchor_id.to_string().as_bytes());
+                    out.push(LINK_END_MARKER_V0);
+                    ref_link_anchor_ids.push(anchor_id);
+                } else {
+                    out.extend_from_slice(anchor_id.to_string().as_bytes());
+                }
+            } else {
+                out.extend_from_slice(b"??");
+            }
             ref_occurrences.push(RefOccurrenceMetaV0 {
                 key,
                 line_index,
                 resolved_anchor_id,
             });
-
-            if let Some(anchor_id) = resolved_anchor_id {
-                out.extend_from_slice(anchor_id.to_string().as_bytes());
-            } else {
-                out.extend_from_slice(b"??");
-            }
             index = key_end + REF_MARKER_SUFFIX_V0.len();
             continue;
         }
@@ -1686,6 +1751,57 @@ fn resolve_ref_markers_v0(
         index += 1;
     }
     Some(out)
+}
+
+fn assign_link_metadata_v1(
+    body: &[u8],
+    href_urls: &[Vec<u8>],
+    ref_link_anchor_ids: &[u32],
+) -> Option<(Vec<HrefLinkMetaV0>, Vec<RefAnchorLinkMetaV0>)> {
+    let mut href_links = Vec::<HrefLinkMetaV0>::new();
+    let mut ref_links = Vec::<RefAnchorLinkMetaV0>::new();
+    let mut href_cursor = 0usize;
+    let mut ref_cursor = 0usize;
+    let mut next_link_id = 1u32;
+    let mut index = 0usize;
+
+    while index < body.len() {
+        if body[index] != LINK_START_MARKER_V0 {
+            index += 1;
+            continue;
+        }
+        let segment_start = index + 1;
+        let mut segment_end = segment_start;
+        while segment_end < body.len() && body[segment_end] != LINK_END_MARKER_V0 {
+            segment_end += 1;
+        }
+        if segment_end >= body.len() || segment_end == segment_start {
+            return None;
+        }
+        let segment = &body[segment_start..segment_end];
+        if segment.first().copied() == Some(BOLD_START_MARKER_V0) {
+            let href_url = href_urls.get(href_cursor)?.clone();
+            href_links.push(HrefLinkMetaV0 {
+                link_id: next_link_id,
+                url: href_url,
+            });
+            href_cursor += 1;
+        } else {
+            let anchor_id = *ref_link_anchor_ids.get(ref_cursor)?;
+            ref_links.push(RefAnchorLinkMetaV0 {
+                link_id: next_link_id,
+                anchor_id,
+            });
+            ref_cursor += 1;
+        }
+        next_link_id = next_link_id.checked_add(1)?;
+        index = segment_end + 1;
+    }
+
+    if href_cursor != href_urls.len() || ref_cursor != ref_link_anchor_ids.len() {
+        return None;
+    }
+    Some((href_links, ref_links))
 }
 
 fn resolve_cite_markers_v0(
@@ -2027,6 +2143,7 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
     let mut toc_entries = Vec::<TocEntryMetaV0>::new();
     let mut labels_by_key = BTreeMap::<Vec<u8>, LabelEntryMetaV0>::new();
     let mut ref_occurrences = Vec::<RefOccurrenceMetaV0>::new();
+    let mut ref_link_anchor_ids = Vec::<u32>::new();
     let mut cite_occurrences = Vec::<CiteOccurrenceMetaV0>::new();
     let mut next_anchor_id = 1u32;
     let mut saw_maketitle = false;
@@ -2191,7 +2308,19 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
     body = normalize_tex_ellipsis_v0(&body);
     body = normalize_bracket_spacing_v0(&body);
     body = normalize_wrapper_marker_spacing_v0(&body);
-    body = resolve_ref_markers_v0(&body, &labels_by_key, &mut ref_occurrences)?;
+    let crossref_artifacts = build_crossref_artifacts_v1(
+        &labels_by_key,
+        &toc_entries,
+        !href_urls.is_empty(),
+    )?;
+    body = apply_crossref_pass_v1(
+        &body,
+        &crossref_artifacts,
+        &mut ref_occurrences,
+        &mut ref_link_anchor_ids,
+    )?;
+    let (href_links, ref_anchor_links) =
+        assign_link_metadata_v1(&body, &href_urls, &ref_link_anchor_ids)?;
     let bibitems_by_key = bibitems
         .iter()
         .map(|item| (item.key.clone(), item.ordinal))
@@ -2209,13 +2338,13 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
         }
     }
 
-    if !href_urls.is_empty() {
+    if !href_links.is_empty() {
         push_paragraph_break(&mut body);
-        for (href_index, href_url) in href_urls.iter().enumerate() {
+        for href in &href_links {
             body.extend_from_slice(HREF_URL_LINE_PREFIX_MARKER_V0);
-            body.extend_from_slice((href_index + 1).to_string().as_bytes());
+            body.extend_from_slice(href.link_id.to_string().as_bytes());
             body.push(b' ');
-            body.extend_from_slice(href_url);
+            body.extend_from_slice(&href.url);
             push_newline(&mut body);
         }
     }
@@ -2269,6 +2398,16 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
                     .to_string()
                     .as_bytes(),
             );
+            push_newline(&mut body);
+        }
+    }
+    if !ref_anchor_links.is_empty() {
+        push_paragraph_break(&mut body);
+        for link in &ref_anchor_links {
+            body.extend_from_slice(REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0);
+            body.extend_from_slice(link.link_id.to_string().as_bytes());
+            body.push(b' ');
+            body.extend_from_slice(link.anchor_id.to_string().as_bytes());
             push_newline(&mut body);
         }
     }

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -288,6 +288,21 @@ fn typeset_minimal_labels_and_refs_emit_metadata_and_resolve_inline_values() {
 }
 
 #[test]
+fn typeset_minimal_crossref_pass_v1_wraps_resolved_refs_as_links_when_hyperref_is_present() {
+    let main = b"\\documentclass{article}\\begin{document}\\section{Intro}\\label{sec:intro}See \\ref{sec:intro} and \\ref{sec:missing} with \\href{https://example.com}{link}.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("~ See <1> and ?? with <{link}>."),
+        "body={text:?}"
+    );
+    assert!(text.contains("!r sec:intro 3 1"), "body={text:?}");
+    assert!(text.contains("!r sec:missing 3 0"), "body={text:?}");
+    assert!(text.contains("!ra 1 1"), "body={text:?}");
+    assert!(text.contains("!u 2 https://example.com"), "body={text:?}");
+}
+
+#[test]
 fn typeset_minimal_rejects_label_not_immediately_after_heading_or_figure() {
     let main = b"\\documentclass{article}\\begin{document}\\section{Intro}Body first.\\label{sec:intro}\\end{document}";
     let result = compile_typeset(main);
@@ -377,6 +392,16 @@ fn typeset_minimal_lists_emit_expected_itemize_and_enumerate_lines() {
         text.contains("Before.\n\n- First [item]\n- Second item\n\n1. One\n2. Two\n\nAfter."),
         "body={text:?}"
     );
+}
+
+#[test]
+fn typeset_minimal_refs_resolve_inside_list_and_quote_content() {
+    let main = b"\\documentclass{article}\\begin{document}\\section{Intro}\\label{sec:intro}\\begin{itemize}\\item Item ref \\ref{sec:intro}\\end{itemize}\\begin{quote}Quote ref \\ref{sec:intro}.\\end{quote}\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("- Item ref 1"), "body={text:?}");
+    assert!(text.contains("> Quote ref 1."), "body={text:?}");
+    assert!(text.contains("!r sec:intro "), "body={text:?}");
 }
 
 #[test]

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -25,6 +25,7 @@ const FOOTNOTE_LINE_PREFIX_MARKER_V0: &[u8] = b"!f ";
 const HREF_URL_LINE_PREFIX_MARKER_V0: &[u8] = b"!u ";
 const LABEL_LINE_PREFIX_MARKER_V0: &[u8] = b"!l ";
 const REF_LINE_PREFIX_MARKER_V0: &[u8] = b"!r ";
+const REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0: &[u8] = b"!ra ";
 const BIBITEM_LINE_PREFIX_MARKER_V0: &[u8] = b"!b ";
 const CITE_LINE_PREFIX_MARKER_V0: &[u8] = b"!c ";
 const NOINDENT_PREFIX_MARKER_V0: u8 = b'~';
@@ -150,8 +151,14 @@ struct PdfRenderSegmentV0 {
 
 #[derive(Clone)]
 struct PdfLinkAnnotationV0 {
-    uri: Vec<u8>,
+    target: PdfLinkTargetV0,
     rect: [f32; 4],
+}
+
+#[derive(Clone)]
+enum PdfLinkTargetV0 {
+    Uri(Vec<u8>),
+    Anchor(u32),
 }
 
 #[derive(Clone)]
@@ -165,6 +172,18 @@ struct TocEntryMetadataV0 {
     level: u8,
     anchor_id: u32,
     title_glyphs: Vec<GlyphPlanV0>,
+}
+
+#[derive(Clone)]
+struct RefAnchorLinkMetadataV0 {
+    link_id: u32,
+    anchor_id: u32,
+}
+
+#[derive(Clone, Copy)]
+struct AnchorDestinationV0 {
+    page_index: usize,
+    y_pt: f32,
 }
 
 fn parse_styled_segments_v0(glyphs: &[GlyphPlanV0]) -> Option<Vec<PdfStyledSegmentV0>> {
@@ -963,6 +982,14 @@ fn has_ref_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
             .eq(REF_LINE_PREFIX_MARKER_V0.iter().copied())
 }
 
+fn has_ref_anchor_link_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() >= REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0.len()
+        && glyphs[..REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0.len()]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .eq(REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0.iter().copied())
+}
+
 fn has_bibitem_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
     glyphs.len() >= BIBITEM_LINE_PREFIX_MARKER_V0.len()
         && glyphs[..BIBITEM_LINE_PREFIX_MARKER_V0.len()]
@@ -1088,6 +1115,28 @@ fn parse_ref_line_v0(glyphs: &[GlyphPlanV0]) -> Option<()> {
     Some(())
 }
 
+fn parse_ref_anchor_link_line_v0(glyphs: &[GlyphPlanV0]) -> Option<RefAnchorLinkMetadataV0> {
+    if glyphs.len() < REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0.len() {
+        return None;
+    }
+    let bytes: Vec<u8> = glyphs.iter().map(|glyph| glyph.byte).collect();
+    if !bytes.starts_with(REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0) {
+        return None;
+    }
+    let line = String::from_utf8(bytes).ok()?;
+    let mut parts = line.splitn(3, ' ');
+    let prefix = parts.next()?;
+    if prefix != "!ra" {
+        return None;
+    }
+    let link_id = parts.next()?.trim().parse::<u32>().ok()?;
+    let anchor_id = parts.next()?.trim().parse::<u32>().ok()?;
+    if link_id == 0 || anchor_id == 0 {
+        return None;
+    }
+    Some(RefAnchorLinkMetadataV0 { link_id, anchor_id })
+}
+
 fn parse_bibitem_line_v0(glyphs: &[GlyphPlanV0]) -> Option<()> {
     if glyphs.len() < BIBITEM_LINE_PREFIX_MARKER_V0.len() {
         return None;
@@ -1198,9 +1247,9 @@ fn collect_link_annotations_for_line_v0(
     line_x_pt: f32,
     line_y_pt: f32,
     font_size_pt: f32,
-    href_url_by_id: &BTreeMap<u32, Vec<u8>>,
+    link_targets_by_id: &BTreeMap<u32, PdfLinkTargetV0>,
     next_link_id: &mut u32,
-    active_link_uri: &mut Option<Vec<u8>>,
+    active_link_target: &mut Option<PdfLinkTargetV0>,
     link_active_at_line_end: bool,
 ) -> Option<Vec<PdfLinkAnnotationV0>> {
     let mut annotations = Vec::<PdfLinkAnnotationV0>::new();
@@ -1214,15 +1263,15 @@ fn collect_link_annotations_for_line_v0(
         if segment.is_link {
             if run_start_x.is_none() {
                 run_start_x = Some(start_x);
-                if active_link_uri.is_none() {
-                    let uri = href_url_by_id.get(next_link_id)?.clone();
+                if active_link_target.is_none() {
+                    let target = link_targets_by_id.get(next_link_id)?.clone();
                     *next_link_id = next_link_id.checked_add(1)?;
-                    *active_link_uri = Some(uri);
+                    *active_link_target = Some(target);
                 }
             }
             run_end_x = end_x;
         } else if let Some(run_x) = run_start_x.take() {
-            let uri = active_link_uri.clone()?;
+            let target = active_link_target.clone()?;
             if run_end_x <= run_x {
                 return None;
             }
@@ -1235,15 +1284,18 @@ fn collect_link_annotations_for_line_v0(
             if rect[2] <= rect[0] || rect[3] <= rect[1] {
                 return None;
             }
-            annotations.push(PdfLinkAnnotationV0 { uri, rect });
-            *active_link_uri = None;
+            annotations.push(PdfLinkAnnotationV0 { target, rect });
+            *active_link_target = None;
         }
         cursor_x = end_x;
     }
 
     if let Some(run_x) = run_start_x.take() {
-        let uri = active_link_uri.clone()?;
+        let target = active_link_target.clone()?;
         if run_end_x <= run_x {
+            if link_active_at_line_end {
+                return Some(annotations);
+            }
             return None;
         }
         let rect = [
@@ -1255,12 +1307,12 @@ fn collect_link_annotations_for_line_v0(
         if rect[2] <= rect[0] || rect[3] <= rect[1] {
             return None;
         }
-        annotations.push(PdfLinkAnnotationV0 { uri, rect });
+        annotations.push(PdfLinkAnnotationV0 { target, rect });
         if !link_active_at_line_end {
-            *active_link_uri = None;
+            *active_link_target = None;
         }
     } else if !link_active_at_line_end {
-        *active_link_uri = None;
+        *active_link_target = None;
     }
 
     Some(annotations)
@@ -1313,6 +1365,7 @@ fn split_body_and_metadata_lines_v0(pages: &[PagePlanV0]) -> (Vec<Vec<LinePlanV0
                 || has_toc_entry_line_prefix_v0(&line.glyphs)
                 || has_label_line_prefix_v0(&line.glyphs)
                 || has_ref_line_prefix_v0(&line.glyphs)
+                || has_ref_anchor_link_line_prefix_v0(&line.glyphs)
                 || has_bibitem_line_prefix_v0(&line.glyphs)
                 || has_cite_line_prefix_v0(&line.glyphs)
             {
@@ -1339,11 +1392,11 @@ fn parse_metadata_lines_v0(
     metadata_lines: &[LinePlanV0],
 ) -> Option<(
     BTreeMap<u32, Vec<Vec<GlyphPlanV0>>>,
-    BTreeMap<u32, Vec<u8>>,
+    BTreeMap<u32, PdfLinkTargetV0>,
     Vec<TocEntryMetadataV0>,
 )> {
     let mut footnote_defs_by_id = BTreeMap::<u32, Vec<Vec<GlyphPlanV0>>>::new();
-    let mut href_url_by_id = BTreeMap::<u32, Vec<u8>>::new();
+    let mut link_targets_by_id = BTreeMap::<u32, PdfLinkTargetV0>::new();
     let mut toc_entries = Vec::<TocEntryMetadataV0>::new();
     let mut current_footnote_id = None::<u32>;
     for line in metadata_lines {
@@ -1356,7 +1409,20 @@ fn parse_metadata_lines_v0(
             continue;
         }
         if let Some((href_id, href_url)) = parse_href_url_line_v0(&line.glyphs) {
-            if href_url_by_id.insert(href_id, href_url).is_some() {
+            if link_targets_by_id
+                .insert(href_id, PdfLinkTargetV0::Uri(href_url))
+                .is_some()
+            {
+                return None;
+            }
+            current_footnote_id = None;
+            continue;
+        }
+        if let Some(ref_link) = parse_ref_anchor_link_line_v0(&line.glyphs) {
+            if link_targets_by_id
+                .insert(ref_link.link_id, PdfLinkTargetV0::Anchor(ref_link.anchor_id))
+                .is_some()
+            {
                 return None;
             }
             current_footnote_id = None;
@@ -1399,15 +1465,18 @@ fn parse_metadata_lines_v0(
         footnote_defs_by_id.get_mut(&footnote_id)?.push(line.glyphs.clone());
     }
     toc_entries.sort_by_key(|entry| entry.anchor_id);
-    Some((footnote_defs_by_id, href_url_by_id, toc_entries))
+    Some((footnote_defs_by_id, link_targets_by_id, toc_entries))
 }
 
 fn build_page_content_stream_v0(
     lines: &[LinePlanV0],
     footnote_defs_by_id: &BTreeMap<u32, Vec<Vec<GlyphPlanV0>>>,
-    href_url_by_id: &BTreeMap<u32, Vec<u8>>,
+    link_targets_by_id: &BTreeMap<u32, PdfLinkTargetV0>,
     toc_entries: &[TocEntryMetadataV0],
     next_link_id: &mut u32,
+    page_index: usize,
+    next_anchor_id: &mut u32,
+    anchor_destinations: &mut BTreeMap<u32, AnchorDestinationV0>,
     allow_title_block: bool,
 ) -> Option<PageRenderV0> {
     let mut out = Vec::new();
@@ -1444,7 +1513,7 @@ fn build_page_content_stream_v0(
     let mut style_stack = Vec::<PdfTextStyleV0>::new();
     let mut current_style = PdfTextStyleV0::Regular;
     let mut link_active = false;
-    let mut active_link_uri = None::<Vec<u8>>;
+    let mut active_link_target = None::<PdfLinkTargetV0>;
     let mut line_index = 0usize;
     while line_index < lines.len() {
         let line = &lines[line_index];
@@ -1468,6 +1537,20 @@ fn build_page_content_stream_v0(
             continue;
         }
         if line_index >= title_block_len && has_figure_box_prefix_v0(&line.glyphs) {
+            let figure_anchor_id = *next_anchor_id;
+            *next_anchor_id = next_anchor_id.checked_add(1)?;
+            if anchor_destinations
+                .insert(
+                    figure_anchor_id,
+                    AnchorDestinationV0 {
+                        page_index,
+                        y_pt: y,
+                    },
+                )
+                .is_some()
+            {
+                return None;
+            }
             let mut cursor = line_index + 1;
             let mut image_path: Option<Vec<u8>> = None;
             if let Some(image_line) = lines.get(cursor) {
@@ -1639,6 +1722,22 @@ fn build_page_content_stream_v0(
             } else {
                 MARGIN_PT_V0
             };
+            if heading_kind.is_some() {
+                let heading_anchor_id = *next_anchor_id;
+                *next_anchor_id = next_anchor_id.checked_add(1)?;
+                if anchor_destinations
+                    .insert(
+                        heading_anchor_id,
+                        AnchorDestinationV0 {
+                            page_index,
+                            y_pt: y,
+                        },
+                    )
+                    .is_some()
+                {
+                    return None;
+                }
+            }
             if let Some(prefix) = list_prefix {
                 let display_prefix_glyphs = &render_glyphs_base
                     [prefix.display_start..prefix.display_start + prefix.display_len];
@@ -1659,9 +1758,9 @@ fn build_page_content_stream_v0(
                 line_x,
                 y,
                 font_size_pt,
-                href_url_by_id,
+                link_targets_by_id,
                 next_link_id,
-                &mut active_link_uri,
+                &mut active_link_target,
                 link_active,
             )?;
             annotations.append(&mut line_annotations);
@@ -1695,7 +1794,7 @@ fn build_page_content_stream_v0(
     if !style_stack.is_empty() || link_active {
         return None;
     }
-    if active_link_uri.is_some() {
+    if active_link_target.is_some() {
         return None;
     }
 
@@ -1744,25 +1843,39 @@ fn build_page_content_stream_v0(
 
 fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
     let (body_pages, metadata_lines) = split_body_and_metadata_lines_v0(pages);
-    let Some((footnote_defs_by_id, href_url_by_id, toc_entries)) = parse_metadata_lines_v0(&metadata_lines) else {
+    let Some((footnote_defs_by_id, link_targets_by_id, toc_entries)) =
+        parse_metadata_lines_v0(&metadata_lines)
+    else {
         return Vec::new();
     };
 
     let mut next_link_id = 1u32;
+    let mut next_anchor_id = 1u32;
+    let mut anchor_destinations = BTreeMap::<u32, AnchorDestinationV0>::new();
     let mut page_renders = Vec::<PageRenderV0>::with_capacity(body_pages.len());
     for (page_index, body_lines) in body_pages.iter().enumerate() {
         let Some(rendered) = build_page_content_stream_v0(
             body_lines,
             &footnote_defs_by_id,
-            &href_url_by_id,
+            &link_targets_by_id,
             &toc_entries,
             &mut next_link_id,
+            page_index,
+            &mut next_anchor_id,
+            &mut anchor_destinations,
             page_index == 0,
         ) else { return Vec::new(); };
         page_renders.push(rendered);
     }
-    if usize::try_from(next_link_id.saturating_sub(1)).ok() != Some(href_url_by_id.len()) {
+    if usize::try_from(next_link_id.saturating_sub(1)).ok() != Some(link_targets_by_id.len()) {
         return Vec::new();
+    }
+    for target in link_targets_by_id.values() {
+        if let PdfLinkTargetV0::Anchor(anchor_id) = target {
+            if !anchor_destinations.contains_key(anchor_id) {
+                return Vec::new();
+            }
+        }
     }
 
     // Object numbering:
@@ -1778,11 +1891,16 @@ fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
         .iter()
         .map(|page| u32::try_from(page.annotations.len()).unwrap_or(0))
         .sum::<u32>();
+    let total_uri_annotations = page_renders
+        .iter()
+        .flat_map(|page| page.annotations.iter())
+        .filter(|annotation| matches!(annotation.target, PdfLinkTargetV0::Uri(_)))
+        .count() as u32;
     let first_page_id = 3u32;
     let first_stream_id = first_page_id + page_count;
     let first_annotation_id = first_stream_id + page_count;
     let first_action_id = first_annotation_id + total_annotations;
-    let font_regular_id = first_action_id + total_annotations;
+    let font_regular_id = first_action_id + total_uri_annotations;
     let font_italic_id = font_regular_id + 1;
     let font_bold_id = font_regular_id + 2;
     let pages_id = 2u32;
@@ -1856,25 +1974,53 @@ fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
     }
 
     let mut annotation_counter = 0u32;
+    let mut action_counter = 0u32;
     for page in &page_renders {
         for annotation in &page.annotations {
             let annotation_id = first_annotation_id + annotation_counter;
-            let action_id = first_action_id + annotation_counter;
-            let annot_body = format!(
-                "<< /Type /Annot /Subtype /Link /Rect [{:.2} {:.2} {:.2} {:.2}] /Border [0 0 0] /A {action_id} 0 R >>",
-                annotation.rect[0],
-                annotation.rect[1],
-                annotation.rect[2],
-                annotation.rect[3],
-            );
-            offsets.push(write_pdf_obj(&mut out, annotation_id, annot_body.as_bytes()));
-            let mut action_body = Vec::<u8>::new();
-            action_body.extend_from_slice(b"<< /S /URI /URI (");
-            action_body.extend_from_slice(&escape_pdf_string_bytes(&annotation.uri));
-            action_body.extend_from_slice(b") >>");
-            offsets.push(write_pdf_obj(&mut out, action_id, &action_body));
+            match &annotation.target {
+                PdfLinkTargetV0::Uri(uri) => {
+                    let action_id = first_action_id + action_counter;
+                    action_counter += 1;
+                    let annot_body = format!(
+                        "<< /Type /Annot /Subtype /Link /Rect [{:.2} {:.2} {:.2} {:.2}] /Border [0 0 0] /A {action_id} 0 R >>",
+                        annotation.rect[0],
+                        annotation.rect[1],
+                        annotation.rect[2],
+                        annotation.rect[3],
+                    );
+                    offsets.push(write_pdf_obj(&mut out, annotation_id, annot_body.as_bytes()));
+                    let mut action_body = Vec::<u8>::new();
+                    action_body.extend_from_slice(b"<< /S /URI /URI (");
+                    action_body.extend_from_slice(&escape_pdf_string_bytes(uri));
+                    action_body.extend_from_slice(b") >>");
+                    offsets.push(write_pdf_obj(&mut out, action_id, &action_body));
+                }
+                PdfLinkTargetV0::Anchor(anchor_id) => {
+                    let Some(destination) = anchor_destinations.get(anchor_id).copied() else {
+                        return Vec::new();
+                    };
+                    let destination_page_id = first_page_id + u32::try_from(destination.page_index).unwrap_or(0);
+                    if destination_page_id >= first_stream_id {
+                        return Vec::new();
+                    }
+                    let annot_body = format!(
+                        "<< /Type /Annot /Subtype /Link /Rect [{:.2} {:.2} {:.2} {:.2}] /Border [0 0 0] /Dest [{destination_page_id} 0 R /XYZ {:.2} {:.2} null] >>",
+                        annotation.rect[0],
+                        annotation.rect[1],
+                        annotation.rect[2],
+                        annotation.rect[3],
+                        MARGIN_PT_V0,
+                        destination.y_pt,
+                    );
+                    offsets.push(write_pdf_obj(&mut out, annotation_id, annot_body.as_bytes()));
+                }
+            }
             annotation_counter += 1;
         }
+    }
+    if action_counter != total_uri_annotations {
+        return Vec::new();
     }
 
     // Fonts

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -684,6 +684,16 @@ fn parse_pdf_annotation_action_id_v0(body: &str) -> Option<u32> {
     fields[0].parse::<u32>().ok()
 }
 
+fn parse_pdf_annotation_dest_page_id_v0(body: &str) -> Option<u32> {
+    let marker = "/Dest [";
+    let start = body.find(marker)? + marker.len();
+    let fields = body[start..].split_whitespace().collect::<Vec<_>>();
+    if fields.len() < 3 || fields[1] != "0" || fields[2] != "R" {
+        return None;
+    }
+    fields[0].parse::<u32>().ok()
+}
+
 fn parse_pdf_action_uri_v0(body: &str) -> Option<String> {
     let marker = "/URI (";
     let start = body.find(marker)? + marker.len();
@@ -2172,6 +2182,56 @@ fn pdf_renderer_emits_link_annotation_with_in_bounds_rect_v0() {
     assert!(rect[3] > rect[1], "rect height must be positive: {rect:?}");
     assert!((0.0..=612.0).contains(&rect[0]) && (0.0..=612.0).contains(&rect[2]));
     assert!((0.0..=792.0).contains(&rect[1]) && (0.0..=792.0).contains(&rect[3]));
+}
+
+#[test]
+fn pdf_renderer_emits_internal_ref_and_external_href_annotations_v0() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"Prelude.\n\n@S {Intro}\n\nSee <1> and <{Example}>.\n\n!l sec:intro 1 heading 1 Intro\n!r sec:intro 5 1\n!ra 1 1\n!u 2 https://example.com",
+    )
+    .expect("writer should accept cross-ref marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let page_one = parse_pdf_object_body_v0(&pdf, 3).expect("page object");
+    let annots = parse_pdf_ref_ids_v0(&page_one, "/Annots");
+    assert_eq!(annots.len(), 2, "expected one ref annot and one href annot");
+
+    let first_annot = parse_pdf_object_body_v0(&pdf, annots[0]).expect("first annotation");
+    let second_annot = parse_pdf_object_body_v0(&pdf, annots[1]).expect("second annotation");
+    assert!(
+        first_annot.contains("/Dest ["),
+        "first annotation should use internal destination: {first_annot}"
+    );
+    assert!(
+        !first_annot.contains("/A "),
+        "internal destination annotation must not use URI action: {first_annot}"
+    );
+    assert_eq!(
+        parse_pdf_annotation_dest_page_id_v0(&first_annot),
+        Some(3),
+        "internal ref should target first page"
+    );
+
+    let action_id = parse_pdf_annotation_action_id_v0(&second_annot).expect("href action id");
+    let action_body = parse_pdf_object_body_v0(&pdf, action_id).expect("href action body");
+    assert_eq!(
+        parse_pdf_action_uri_v0(&action_body).as_deref(),
+        Some("https://example.com"),
+        "href annotation should keep URI target"
+    );
+}
+
+#[test]
+fn pdf_renderer_rejects_ref_annotation_target_with_missing_anchor_v0() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"See <1> only.\n\n!r sec:intro 1 1\n!ra 1 1",
+    )
+    .expect("writer should accept marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed when ref target anchor is missing"
+    );
 }
 
 #[test]

--- a/scripts/wasm_typeset_minimal_v0_emit_pdf.mjs
+++ b/scripts/wasm_typeset_minimal_v0_emit_pdf.mjs
@@ -51,6 +51,13 @@ function parsePdfAnnotationActionIdV0(body) {
   return Number.isFinite(id) ? id : null;
 }
 
+function parsePdfAnnotationDestPageIdV0(body) {
+  const match = body.match(/\/Dest \[(\d+)\s+0\s+R\s+\/XYZ/);
+  if (!match) return null;
+  const id = Number.parseInt(match[1], 10);
+  return Number.isFinite(id) ? id : null;
+}
+
 function parsePdfActionUriV0(body) {
   const match = body.match(/\/URI \(([^)]*)\)/);
   return match ? match[1] : null;
@@ -322,18 +329,24 @@ async function run() {
   }
 
   const pageOneUris = [];
+  const pageOneDestPageIds = [];
   for (const annotId of pageOneAnnotIds) {
     const annotBody = objectById.get(annotId);
     if (!annotBody || !annotBody.includes('/Subtype /Link')) {
       throw new Error(`page 1 annotation ${annotId} missing /Subtype /Link`);
     }
     const actionId = parsePdfAnnotationActionIdV0(annotBody);
-    if (!actionId) throw new Error(`page 1 annotation ${annotId} missing action`);
-    const actionBody = objectById.get(actionId);
-    if (!actionBody) throw new Error(`page 1 action ${actionId} missing`);
-    const uri = parsePdfActionUriV0(actionBody);
-    if (!uri) throw new Error(`page 1 action ${actionId} missing URI`);
-    pageOneUris.push(uri);
+    if (actionId) {
+      const actionBody = objectById.get(actionId);
+      if (!actionBody) throw new Error(`page 1 action ${actionId} missing`);
+      const uri = parsePdfActionUriV0(actionBody);
+      if (!uri) throw new Error(`page 1 action ${actionId} missing URI`);
+      pageOneUris.push(uri);
+    } else {
+      const destPageId = parsePdfAnnotationDestPageIdV0(annotBody);
+      if (!destPageId) throw new Error(`page 1 annotation ${annotId} missing URI action and /Dest`);
+      pageOneDestPageIds.push(destPageId);
+    }
     const rect = parsePdfAnnotationRectV0(annotBody);
     if (!rect) throw new Error(`page 1 annotation ${annotId} missing rect`);
     if (
@@ -349,18 +362,24 @@ async function run() {
   }
 
   const pageTwoUris = [];
+  const pageTwoDestPageIds = [];
   for (const annotId of pageTwoAnnotIds) {
     const annotBody = objectById.get(annotId);
     if (!annotBody || !annotBody.includes('/Subtype /Link')) {
       throw new Error(`page 2 annotation ${annotId} missing /Subtype /Link`);
     }
     const actionId = parsePdfAnnotationActionIdV0(annotBody);
-    if (!actionId) throw new Error(`page 2 annotation ${annotId} missing action`);
-    const actionBody = objectById.get(actionId);
-    if (!actionBody) throw new Error(`page 2 action ${actionId} missing`);
-    const uri = parsePdfActionUriV0(actionBody);
-    if (!uri) throw new Error(`page 2 action ${actionId} missing URI`);
-    pageTwoUris.push(uri);
+    if (actionId) {
+      const actionBody = objectById.get(actionId);
+      if (!actionBody) throw new Error(`page 2 action ${actionId} missing`);
+      const uri = parsePdfActionUriV0(actionBody);
+      if (!uri) throw new Error(`page 2 action ${actionId} missing URI`);
+      pageTwoUris.push(uri);
+    } else {
+      const destPageId = parsePdfAnnotationDestPageIdV0(annotBody);
+      if (!destPageId) throw new Error(`page 2 annotation ${annotId} missing URI action and /Dest`);
+      pageTwoDestPageIds.push(destPageId);
+    }
     const rect = parsePdfAnnotationRectV0(annotBody);
     if (!rect) throw new Error(`page 2 annotation ${annotId} missing rect`);
     if (
@@ -374,11 +393,20 @@ async function run() {
       throw new Error(`page 2 annotation ${annotId} has invalid rect`);
     }
   }
+  if (pageOneUris.length === 0 || pageTwoUris.length === 0) {
+    throw new Error('expected at least one external URI annotation on page 1 and page 2');
+  }
   if (!pageOneUris.every((uri) => uri === 'https://example.com/page1')) {
     throw new Error(`expected page 1 URIs to be page1 links, got ${JSON.stringify(pageOneUris)}`);
   }
   if (!pageTwoUris.every((uri) => uri === 'https://example.com/page2')) {
     throw new Error(`expected page 2 URIs to be page2 links, got ${JSON.stringify(pageTwoUris)}`);
+  }
+  if (pageOneDestPageIds.some((id) => id < pageIds[0] || id > pageIds[pageIds.length - 1])) {
+    throw new Error(`page 1 internal link destination out of bounds: ${JSON.stringify(pageOneDestPageIds)}`);
+  }
+  if (pageTwoDestPageIds.some((id) => id < pageIds[0] || id > pageIds[pageIds.length - 1])) {
+    throw new Error(`page 2 internal link destination out of bounds: ${JSON.stringify(pageTwoDestPageIds)}`);
   }
 
   const streamOneId = parsePageContentStreamIdV0(pageOneBody);


### PR DESCRIPTION
## Summary\n- implement cross-ref pass v1 using typed artifacts for  resolution\n- wire internal reference link metadata into PDF annotation emission\n- add engine/xdv tests and keep wasm proofs green\n\nRefs: #388\n\n## Proof\n- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests\n- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml\n- ./scripts/proof_wasm_typeset_minimal_v0.sh out\n- ./scripts/proof_wasm_fixture_gallery_v0.sh out