### PR TITLE
typeset_minimal bib fixedpoint v0

### DIFF
--- a/crates/carreltex-engine/src/compile_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0.rs
@@ -251,6 +251,7 @@ use carreltex_core::{
     build_compile_result_v0, truncate_log_bytes_v0, CompileRequestV0, CompileResultV0,
     CompileStatus, Mount, DEFAULT_COMPILE_MAIN_MAX_LOG_BYTES_V0, MAX_LOG_BYTES_V0,
 };
+use std::collections::BTreeMap;
 use carreltex_xdv::{
     plan_layout_v0, plan_layout_width_v0, validate_dvi_v2_text_page_matches_layout_v0,
     validate_dvi_v2_text_page_with_layout_v0, write_dvi_v2_text_page_from_layout_v0,
@@ -265,14 +266,37 @@ use ok_v0::{
 use stats_v0::build_tex_stats_from_tokens_v0;
 use trace_v0::build_not_implemented_log_v0;
 use typeset_minimal_v0::{
-    extract_typeset_minimal_text_body_v0, normalize_typeset_minimal_tokens_v0,
-    preprocess_typeset_minimal_source_v0,
+    collect_bibliography_resource_names_v0, extract_typeset_minimal_text_body_v0,
+    extract_typeset_minimal_text_body_with_external_bib_v0, normalize_typeset_minimal_tokens_v0,
+    parse_minimal_bib_entries_v0, preprocess_typeset_minimal_source_v0,
 };
 const MISSING_COMPONENTS_V0: &[&str] = &["tex-engine"];
 const EMPTY_TEX_STATS_JSON: &str = "";
 const TYPESET_MINIMAL_GLYPH_ADVANCE_SP_V0: i32 = 471_859;
 const TYPESET_MINIMAL_LINE_ADVANCE_SP_V0: i32 = 917_504;
 const TYPESET_MINIMAL_MAX_LINE_WIDTH_SP_V0: u32 = 30_670_848;
+
+fn build_typeset_minimal_external_bib_entries_v0(
+    mount: &Mount,
+    normalized_typeset_tokens: &[TokenV0],
+) -> Option<BTreeMap<Vec<u8>, Vec<u8>>> {
+    let resource_names = collect_bibliography_resource_names_v0(normalized_typeset_tokens)?;
+    if resource_names.is_empty() {
+        return Some(BTreeMap::new());
+    }
+    let mut entries_by_key = BTreeMap::<Vec<u8>, Vec<u8>>::new();
+    for resource_name in resource_names {
+        let resource_bytes = mount.read_file_by_bytes_v0(&resource_name).ok()??;
+        let parsed_entries = parse_minimal_bib_entries_v0(resource_bytes)?;
+        for (key, value) in parsed_entries {
+            if entries_by_key.insert(key, value).is_some() {
+                return None;
+            }
+        }
+    }
+    Some(entries_by_key)
+}
+
 fn invalid_result_v0(max_log_bytes: u32, reason: InvalidInputReasonV0) -> CompileResultV0 {
     build_compile_result_v0(
         CompileStatus::InvalidInput,
@@ -356,7 +380,17 @@ pub fn compile_main_typeset_minimal_v0(mount: &mut Mount) -> CompileResultV0 {
         return invalid_result_v0(request.max_log_bytes, InvalidInputReasonV0::StatsBuildFailed);
     }
     let normalized_typeset_tokens = normalize_typeset_minimal_tokens_v0(&macro_expanded_tokens);
-    let ok_text_bytes = extract_typeset_minimal_text_body_v0(&normalized_typeset_tokens);
+    let ok_text_bytes = build_typeset_minimal_external_bib_entries_v0(mount, &normalized_typeset_tokens)
+        .and_then(|external_bib_entries| {
+            if external_bib_entries.is_empty() {
+                extract_typeset_minimal_text_body_v0(&normalized_typeset_tokens)
+            } else {
+                extract_typeset_minimal_text_body_with_external_bib_v0(
+                    &normalized_typeset_tokens,
+                    &external_bib_entries,
+                )
+            }
+        });
     if let Some(ok_text_bytes) = ok_text_bytes {
         if ok_text_bytes.len() <= MAX_OK_TEXT_BYTES_V0 {
             let glyph_advance_sp = TYPESET_MINIMAL_GLYPH_ADVANCE_SP_V0;

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -24,6 +24,10 @@ const RIGHTLINE_CONTROL_V0: &[u8] = b"rightline";
 const TABULAR_ENV_V0: &[u8] = b"tabular";
 const FIGURE_ENV_V0: &[u8] = b"figure";
 const THEBIBLIOGRAPHY_ENV_V0: &[u8] = b"thebibliography";
+const USEPACKAGE_CONTROL_V0: &[u8] = b"usepackage";
+const REQUIREPACKAGE_CONTROL_V0: &[u8] = b"RequirePackage";
+const ADDBIBRESOURCE_CONTROL_V0: &[u8] = b"addbibresource";
+const PRINTBIBLIOGRAPHY_CONTROL_V0: &[u8] = b"printbibliography";
 const CAPTION_CONTROL_V0: &[u8] = b"caption";
 const INCLUDEGRAPHICS_CONTROL_V0: &[u8] = b"includegraphics";
 const BIBITEM_CONTROL_V0: &[u8] = b"bibitem";
@@ -125,7 +129,6 @@ struct CrossRefArtifactsV1 {
 #[derive(Clone)]
 struct BibItemMetaV0 {
     key: Vec<u8>,
-    ordinal: u32,
     text: Vec<u8>,
     text_len: u32,
 }
@@ -1643,6 +1646,358 @@ fn is_safe_label_key_byte_v0(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || matches!(byte, b':' | b'-' | b'_' | b'.' | b'/')
 }
 
+fn is_safe_bib_resource_path_byte_v0(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b'.' | b'_' | b'-')
+}
+
+fn normalize_bib_resource_name_v0(raw_path: &[u8]) -> Option<Vec<u8>> {
+    if raw_path.is_empty() {
+        return None;
+    }
+    if raw_path.starts_with(b"/") || raw_path.starts_with(b"\\") {
+        return None;
+    }
+    if raw_path.contains(&b'\\') || raw_path.contains(&b':') {
+        return None;
+    }
+    if !raw_path.iter().copied().all(is_safe_bib_resource_path_byte_v0) {
+        return None;
+    }
+
+    let mut normalized_segments = Vec::<Vec<u8>>::new();
+    for segment in raw_path.split(|byte| *byte == b'/') {
+        if segment.is_empty() || segment == b"." || segment == b".." {
+            return None;
+        }
+        normalized_segments.push(segment.to_vec());
+    }
+    if normalized_segments.is_empty() {
+        return None;
+    }
+
+    let mut normalized = Vec::<u8>::new();
+    for (segment_index, segment) in normalized_segments.iter().enumerate() {
+        if segment_index > 0 {
+            normalized.push(b'/');
+        }
+        normalized.extend_from_slice(segment);
+    }
+    let has_explicit_extension = normalized
+        .rsplit(|byte| *byte == b'/')
+        .next()
+        .map(|last: &[u8]| last.contains(&b'.'))
+        .unwrap_or(false);
+    if has_explicit_extension {
+        if !normalized.ends_with(b".bib") {
+            return None;
+        }
+    } else {
+        normalized.extend_from_slice(b".bib");
+    }
+    Some(normalized)
+}
+
+fn split_bibliography_group_values_v0(raw_group: &[u8]) -> Option<Vec<Vec<u8>>> {
+    let mut values = Vec::<Vec<u8>>::new();
+    let mut segment_start = 0usize;
+    for (index, byte) in raw_group.iter().enumerate() {
+        if *byte == b',' {
+            let raw_segment = trim_horizontal_space_bytes_v0(&raw_group[segment_start..index]);
+            if raw_segment.is_empty() {
+                return None;
+            }
+            values.push(normalize_bib_resource_name_v0(raw_segment)?);
+            segment_start = index + 1;
+        }
+    }
+    let raw_tail = trim_horizontal_space_bytes_v0(&raw_group[segment_start..]);
+    if raw_tail.is_empty() {
+        return None;
+    }
+    values.push(normalize_bib_resource_name_v0(raw_tail)?);
+    Some(values)
+}
+
+fn parse_bibliography_resource_command_v0(
+    tokens: &[TokenV0],
+    index: usize,
+) -> Option<(Vec<Vec<u8>>, usize)> {
+    let command = match tokens.get(index) {
+        Some(TokenV0::ControlSeq(name)) => name.as_slice(),
+        _ => return None,
+    };
+    if command != ADDBIBRESOURCE_CONTROL_V0 && command != BIBLIOGRAPHY_CONTROL_V0 {
+        return None;
+    }
+    let mut cursor = index + 1;
+    if command == ADDBIBRESOURCE_CONTROL_V0 {
+        cursor = consume_simple_bracket_non_empty(tokens, cursor)?;
+    }
+    let (group_start, group_end, next) = consume_group_bounds(tokens, cursor)?;
+    let raw_group = parse_char_space_group_trimmed_v0(tokens, group_start, group_end)?;
+    let resources = if command == ADDBIBRESOURCE_CONTROL_V0 {
+        vec![normalize_bib_resource_name_v0(&raw_group)?]
+    } else {
+        split_bibliography_group_values_v0(&raw_group)?
+    };
+    Some((resources, next))
+}
+
+fn consume_bibliographystyle_command_v0(tokens: &[TokenV0], index: usize) -> Option<usize> {
+    if !matches!(
+        tokens.get(index),
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == BIBLIOGRAPHYSTYLE_CONTROL_V0
+    ) {
+        return None;
+    }
+    let (group_start, group_end, next) = consume_group_bounds(tokens, index + 1)?;
+    let style = parse_char_space_group_trimmed_v0(tokens, group_start, group_end)?;
+    if style.is_empty() {
+        return None;
+    }
+    Some(next)
+}
+
+fn consume_package_declaration_noop_v0(tokens: &[TokenV0], index: usize) -> Option<usize> {
+    if !matches!(
+        tokens.get(index),
+        Some(TokenV0::ControlSeq(name))
+            if name.as_slice() == USEPACKAGE_CONTROL_V0 || name.as_slice() == REQUIREPACKAGE_CONTROL_V0
+    ) {
+        return None;
+    }
+    let mut cursor = consume_simple_bracket_non_empty(tokens, index + 1)?;
+    let (group_start, group_end, next) = consume_group_bounds(tokens, cursor)?;
+    let raw_group = parse_char_space_group_trimmed_v0(tokens, group_start, group_end)?;
+    if raw_group.is_empty() {
+        return None;
+    }
+    let mut saw_package = false;
+    for raw_segment in raw_group.split(|byte| *byte == b',') {
+        let package = trim_horizontal_space_bytes_v0(raw_segment);
+        if package.is_empty()
+            || package.starts_with(b"/")
+            || package.windows(2).any(|window| window == b"..")
+            || !package
+                .iter()
+                .copied()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b'.' | b'_' | b'-'))
+        {
+            return None;
+        }
+        saw_package = true;
+    }
+    if !saw_package {
+        return None;
+    }
+    cursor = next;
+    Some(cursor)
+}
+
+fn skip_horizontal_space_bytes_v0(bytes: &[u8], mut index: usize) -> usize {
+    while index < bytes.len() && is_horizontal_space_v0(bytes[index]) {
+        index += 1;
+    }
+    index
+}
+
+fn normalize_bib_value_text_v0(raw: &[u8]) -> Option<Vec<u8>> {
+    let mut out = Vec::<u8>::new();
+    let mut saw_non_space = false;
+    let mut pending_space = false;
+    for byte in raw {
+        if matches!(*byte, b'{' | b'}' | b'"') {
+            continue;
+        }
+        if byte.is_ascii_whitespace() {
+            pending_space = saw_non_space;
+            continue;
+        }
+        if !byte.is_ascii_graphic() && !byte.is_ascii_alphanumeric() {
+            return None;
+        }
+        if pending_space {
+            out.push(b' ');
+            pending_space = false;
+        }
+        out.push(*byte);
+        saw_non_space = true;
+    }
+    trim_trailing_spaces(&mut out);
+    if out.is_empty() {
+        return None;
+    }
+    Some(out)
+}
+
+fn extract_bib_title_field_v0(entry_body: &[u8]) -> Option<Vec<u8>> {
+    let mut index = 0usize;
+    while index < entry_body.len() {
+        if !entry_body[index].is_ascii_alphabetic() {
+            index += 1;
+            continue;
+        }
+        let field_start = index;
+        while index < entry_body.len() && entry_body[index].is_ascii_alphabetic() {
+            index += 1;
+        }
+        let field_name = entry_body[field_start..index]
+            .iter()
+            .map(u8::to_ascii_lowercase)
+            .collect::<Vec<u8>>();
+        index = skip_horizontal_space_bytes_v0(entry_body, index);
+        if index >= entry_body.len() || entry_body[index] != b'=' {
+            continue;
+        }
+        index += 1;
+        index = skip_horizontal_space_bytes_v0(entry_body, index);
+        if field_name != b"title" {
+            while index < entry_body.len() && entry_body[index] != b',' {
+                index += 1;
+            }
+            continue;
+        }
+        if index >= entry_body.len() {
+            return None;
+        }
+        if entry_body[index] == b'{' {
+            let mut depth = 1usize;
+            let mut cursor = index + 1;
+            while cursor < entry_body.len() {
+                match entry_body[cursor] {
+                    b'{' => depth += 1,
+                    b'}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            return normalize_bib_value_text_v0(&entry_body[index + 1..cursor]);
+                        }
+                    }
+                    _ => {}
+                }
+                cursor += 1;
+            }
+            return None;
+        }
+        if entry_body[index] == b'"' {
+            let mut cursor = index + 1;
+            while cursor < entry_body.len() {
+                if entry_body[cursor] == b'"' && entry_body[cursor.saturating_sub(1)] != b'\\' {
+                    return normalize_bib_value_text_v0(&entry_body[index + 1..cursor]);
+                }
+                cursor += 1;
+            }
+            return None;
+        }
+        let mut cursor = index;
+        while cursor < entry_body.len() && entry_body[cursor] != b',' {
+            cursor += 1;
+        }
+        return normalize_bib_value_text_v0(&entry_body[index..cursor]);
+    }
+    None
+}
+
+pub(crate) fn parse_minimal_bib_entries_v0(
+    bib_bytes: &[u8],
+) -> Option<BTreeMap<Vec<u8>, Vec<u8>>> {
+    let mut entries = BTreeMap::<Vec<u8>, Vec<u8>>::new();
+    let mut index = 0usize;
+
+    while index < bib_bytes.len() {
+        if bib_bytes[index] == b'%' {
+            while index < bib_bytes.len() && bib_bytes[index] != b'\n' {
+                index += 1;
+            }
+            continue;
+        }
+        if bib_bytes[index] != b'@' {
+            index += 1;
+            continue;
+        }
+        index += 1;
+        index = skip_horizontal_space_bytes_v0(bib_bytes, index);
+        let type_start = index;
+        while index < bib_bytes.len() && bib_bytes[index].is_ascii_alphabetic() {
+            index += 1;
+        }
+        if index == type_start {
+            return None;
+        }
+        index = skip_horizontal_space_bytes_v0(bib_bytes, index);
+        if !matches!(bib_bytes.get(index), Some(b'{')) {
+            return None;
+        }
+        index += 1;
+        index = skip_horizontal_space_bytes_v0(bib_bytes, index);
+        let key_start = index;
+        while index < bib_bytes.len() && !matches!(bib_bytes[index], b',' | b'}') {
+            index += 1;
+        }
+        if index == key_start || !matches!(bib_bytes.get(index), Some(b',')) {
+            return None;
+        }
+        let key_raw = trim_horizontal_space_bytes_v0(&bib_bytes[key_start..index]);
+        if key_raw.is_empty()
+            || !key_raw.iter().copied().all(is_safe_label_key_byte_v0)
+            || key_raw.starts_with(b"/")
+            || key_raw.windows(2).any(|window| window == b"..")
+        {
+            return None;
+        }
+        index += 1;
+        let body_start = index;
+        let mut depth = 1usize;
+        while index < bib_bytes.len() {
+            match bib_bytes[index] {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                _ => {}
+            }
+            index += 1;
+        }
+        if depth != 0 {
+            return None;
+        }
+        let entry_body = &bib_bytes[body_start..index];
+        let title = extract_bib_title_field_v0(entry_body).unwrap_or_else(|| key_raw.to_vec());
+        if title.is_empty() {
+            return None;
+        }
+        if entries.insert(key_raw.to_vec(), title).is_some() {
+            return None;
+        }
+        index += 1;
+    }
+
+    Some(entries)
+}
+
+pub(crate) fn collect_bibliography_resource_names_v0(tokens: &[TokenV0]) -> Option<Vec<Vec<u8>>> {
+    let mut resources = BTreeMap::<Vec<u8>, ()>::new();
+    let mut index = 0usize;
+    while index < tokens.len() {
+        match tokens.get(index) {
+            Some(TokenV0::ControlSeq(name))
+                if name.as_slice() == ADDBIBRESOURCE_CONTROL_V0
+                    || name.as_slice() == BIBLIOGRAPHY_CONTROL_V0 =>
+            {
+                let (resource_names, next) = parse_bibliography_resource_command_v0(tokens, index)?;
+                for resource in resource_names {
+                    resources.insert(resource, ());
+                }
+                index = next;
+            }
+            _ => index += 1,
+        }
+    }
+    Some(resources.into_keys().collect())
+}
+
 fn parse_label_or_ref_key_group_v0(tokens: &[TokenV0], index: usize) -> Option<(Vec<u8>, usize)> {
     let (group_start, group_end, next) = consume_group_bounds(tokens, index + 1)?;
     let mut key = Vec::<u8>::new();
@@ -1804,14 +2159,16 @@ fn assign_link_metadata_v1(
     Some((href_links, ref_links))
 }
 
-fn resolve_cite_markers_v0(
+fn resolve_cite_markers_fixedpoint_v0(
     body: &[u8],
-    bibitems_by_key: &BTreeMap<Vec<u8>, u32>,
+    bibliography_entries_by_key: &BTreeMap<Vec<u8>, BibItemMetaV0>,
     cite_occurrences: &mut Vec<CiteOccurrenceMetaV0>,
-) -> Option<Vec<u8>> {
+) -> Option<(Vec<u8>, Vec<BibItemMetaV0>)> {
     let mut out = Vec::<u8>::with_capacity(body.len());
     let mut index = 0usize;
     let mut line_index = 1u32;
+    let mut cite_key_order = Vec::<Vec<u8>>::new();
+    let mut cite_seen = BTreeMap::<Vec<u8>, ()>::new();
 
     while index < body.len() {
         if body[index..].starts_with(CITE_MARKER_PREFIX_V0) {
@@ -1830,20 +2187,26 @@ fn resolve_cite_markers_v0(
                 return None;
             }
             let key = body[key_start..key_end].to_vec();
-            let resolved_ordinal = bibitems_by_key.get(&key).copied();
+            if !cite_seen.contains_key(&key) {
+                cite_seen.insert(key.clone(), ());
+                cite_key_order.push(key.clone());
+            }
+            let position = cite_key_order
+                .iter()
+                .position(|candidate| candidate == &key)?
+                .checked_add(1)?;
+            let resolved_ordinal = u32::try_from(position).ok()?;
+            if !bibliography_entries_by_key.contains_key(&key) {
+                return None;
+            }
             cite_occurrences.push(CiteOccurrenceMetaV0 {
                 key,
                 line_index,
-                resolved_ordinal,
+                resolved_ordinal: Some(resolved_ordinal),
             });
-
-            if let Some(ordinal) = resolved_ordinal {
-                out.push(b'[');
-                out.extend_from_slice(ordinal.to_string().as_bytes());
-                out.push(b']');
-            } else {
-                out.extend_from_slice(b"[?]");
-            }
+            out.push(b'[');
+            out.extend_from_slice(resolved_ordinal.to_string().as_bytes());
+            out.push(b']');
             index = key_end + CITE_MARKER_SUFFIX_V0.len();
             continue;
         }
@@ -1855,7 +2218,17 @@ fn resolve_cite_markers_v0(
         }
         index += 1;
     }
-    Some(out)
+
+    let mut resolved_entries = Vec::<BibItemMetaV0>::new();
+    for key in &cite_key_order {
+        let entry = bibliography_entries_by_key.get(key)?;
+        resolved_entries.push(BibItemMetaV0 {
+            key: key.clone(),
+            text: entry.text.clone(),
+            text_len: entry.text_len,
+        });
+    }
+    Some((out, resolved_entries))
 }
 
 fn consume_label_command_v0(
@@ -1922,9 +2295,10 @@ fn emit_bibliography_block_v0(out: &mut Vec<u8>, items: &[BibItemMetaV0]) {
     out.extend_from_slice(b"References");
     out.push(BOLD_END_MARKER_V0);
     push_paragraph_break(out);
-    for item in items {
+    for (ordinal_index, item) in items.iter().enumerate() {
+        let ordinal = ordinal_index + 1;
         out.push(b'[');
-        out.extend_from_slice(item.ordinal.to_string().as_bytes());
+        out.extend_from_slice(ordinal.to_string().as_bytes());
         out.extend_from_slice(b"] ");
         out.extend_from_slice(&item.text);
         push_newline(out);
@@ -1935,7 +2309,6 @@ fn emit_bibliography_block_v0(out: &mut Vec<u8>, items: &[BibItemMetaV0]) {
 fn consume_thebibliography_environment_v0(
     tokens: &[TokenV0],
     index: usize,
-    out: &mut Vec<u8>,
     bibitems: &mut Vec<BibItemMetaV0>,
 ) -> Option<usize> {
     let (env_name, mut cursor) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
@@ -1961,7 +2334,6 @@ fn consume_thebibliography_environment_v0(
             if end_env.as_slice() != THEBIBLIOGRAPHY_ENV_V0 || local_items.is_empty() {
                 return None;
             }
-            emit_bibliography_block_v0(out, &local_items);
             bibitems.extend(local_items);
             return Some(next);
         }
@@ -1995,17 +2367,9 @@ fn consume_thebibliography_environment_v0(
         if item_text.is_empty() {
             return None;
         }
-        let ordinal = u32::try_from(
-            bibitems
-                .len()
-                .checked_add(local_items.len())?
-                .checked_add(1)?,
-        )
-        .ok()?;
         let text_len = u32::try_from(item_text.len()).ok()?;
         local_items.push(BibItemMetaV0 {
             key,
-            ordinal,
             text: item_text,
             text_len,
         });
@@ -2102,6 +2466,14 @@ fn emit_maketitle_block_v0(out: &mut Vec<u8>, meta: &TitleMetaV0) {
 }
 
 pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option<Vec<u8>> {
+    let empty_external_bib_entries = BTreeMap::<Vec<u8>, Vec<u8>>::new();
+    extract_typeset_minimal_text_body_with_external_bib_v0(tokens, &empty_external_bib_entries)
+}
+
+pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
+    tokens: &[TokenV0],
+    external_bib_entries: &BTreeMap<Vec<u8>, Vec<u8>>,
+) -> Option<Vec<u8>> {
     let mut index = skip_spaces(tokens, 0);
     index = consume_documentclass_v0(tokens, index)?;
 
@@ -2124,6 +2496,22 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
                 meta.date = Some(value);
                 index = next;
             }
+            Some(TokenV0::ControlSeq(name))
+                if name.as_slice() == USEPACKAGE_CONTROL_V0
+                    || name.as_slice() == REQUIREPACKAGE_CONTROL_V0 =>
+            {
+                index = consume_package_declaration_noop_v0(tokens, index)?;
+            }
+            Some(TokenV0::ControlSeq(name))
+                if name.as_slice() == ADDBIBRESOURCE_CONTROL_V0
+                    || name.as_slice() == BIBLIOGRAPHY_CONTROL_V0 =>
+            {
+                let (_, next) = parse_bibliography_resource_command_v0(tokens, index)?;
+                index = next;
+            }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == BIBLIOGRAPHYSTYLE_CONTROL_V0 => {
+                index = consume_bibliographystyle_command_v0(tokens, index)?;
+            }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == BEGIN_CONTROL_V0 => {
                 index = consume_document_env_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
                 break;
@@ -2140,6 +2528,8 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
     let mut footnotes = Vec::<Vec<u8>>::new();
     let mut href_urls = Vec::<Vec<u8>>::new();
     let mut bibitems = Vec::<BibItemMetaV0>::new();
+    let mut bibliography_render_requested = false;
+    let mut saw_thebibliography_env = false;
     let mut toc_entries = Vec::<TocEntryMetaV0>::new();
     let mut labels_by_key = BTreeMap::<Vec<u8>, LabelEntryMetaV0>::new();
     let mut ref_occurrences = Vec::<RefOccurrenceMetaV0>::new();
@@ -2196,7 +2586,8 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
                     });
                 } else if env_name.as_slice() == THEBIBLIOGRAPHY_ENV_V0 {
                     pending_label_target = None;
-                    index = consume_thebibliography_environment_v0(tokens, index, &mut body, &mut bibitems)?;
+                    saw_thebibliography_env = true;
+                    index = consume_thebibliography_environment_v0(tokens, index, &mut bibitems)?;
                 } else {
                     pending_label_target = None;
                     index = consume_body_environment_v0(tokens, index, &mut body)?;
@@ -2253,10 +2644,31 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
                 index = consume_cite_command_v0(tokens, index, &mut body)?;
             }
             Some(TokenV0::ControlSeq(name))
-                if name.as_slice() == BIBLIOGRAPHY_CONTROL_V0
-                    || name.as_slice() == BIBLIOGRAPHYSTYLE_CONTROL_V0 =>
+                if name.as_slice() == ADDBIBRESOURCE_CONTROL_V0
+                    || name.as_slice() == BIBLIOGRAPHY_CONTROL_V0 =>
             {
-                return None;
+                saw_body_content_after_maketitle = true;
+                maybe_emit_pending_noindent_prefix_v0(&mut body, &mut pending_noindent_after_heading);
+                pending_label_target = None;
+                if name.as_slice() == BIBLIOGRAPHY_CONTROL_V0 {
+                    bibliography_render_requested = true;
+                }
+                let (_, next) = parse_bibliography_resource_command_v0(tokens, index)?;
+                index = next;
+            }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == PRINTBIBLIOGRAPHY_CONTROL_V0 => {
+                saw_body_content_after_maketitle = true;
+                maybe_emit_pending_noindent_prefix_v0(&mut body, &mut pending_noindent_after_heading);
+                pending_label_target = None;
+                bibliography_render_requested = true;
+                index += 1;
+            }
+            Some(TokenV0::ControlSeq(name))
+                if name.as_slice() == BIBLIOGRAPHYSTYLE_CONTROL_V0 =>
+            {
+                saw_body_content_after_maketitle = true;
+                pending_label_target = None;
+                index = consume_bibliographystyle_command_v0(tokens, index)?;
             }
             Some(TokenV0::ControlSeq(name)) if is_heading_control_v0(name.as_slice()) => {
                 saw_body_content_after_maketitle = true;
@@ -2321,11 +2733,50 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
     )?;
     let (href_links, ref_anchor_links) =
         assign_link_metadata_v1(&body, &href_urls, &ref_link_anchor_ids)?;
-    let bibitems_by_key = bibitems
-        .iter()
-        .map(|item| (item.key.clone(), item.ordinal))
-        .collect::<BTreeMap<Vec<u8>, u32>>();
-    body = resolve_cite_markers_v0(&body, &bibitems_by_key, &mut cite_occurrences)?;
+    if saw_thebibliography_env && bibliography_render_requested {
+        return None;
+    }
+    let mut bibliography_entries_by_key = BTreeMap::<Vec<u8>, BibItemMetaV0>::new();
+    for (key, text) in external_bib_entries {
+        if text.is_empty() {
+            return None;
+        }
+        let text_len = u32::try_from(text.len()).ok()?;
+        if bibliography_entries_by_key
+            .insert(
+                key.clone(),
+                BibItemMetaV0 {
+                    key: key.clone(),
+                    text: text.clone(),
+                    text_len,
+                },
+            )
+            .is_some()
+        {
+            return None;
+        }
+    }
+    for item in &bibitems {
+        if bibliography_entries_by_key.insert(item.key.clone(), item.clone()).is_some() {
+            return None;
+        }
+    }
+    let (resolved_body, resolved_bibliography_entries) = resolve_cite_markers_fixedpoint_v0(
+        &body,
+        &bibliography_entries_by_key,
+        &mut cite_occurrences,
+    )?;
+    body = resolved_body;
+
+    if !cite_occurrences.is_empty() && resolved_bibliography_entries.is_empty() {
+        return None;
+    }
+    if saw_thebibliography_env || bibliography_render_requested {
+        if resolved_bibliography_entries.is_empty() {
+            return None;
+        }
+        emit_bibliography_block_v0(&mut body, &resolved_bibliography_entries);
+    }
 
     if !footnotes.is_empty() {
         push_paragraph_break(&mut body);
@@ -2411,13 +2862,14 @@ pub(crate) fn extract_typeset_minimal_text_body_v0(tokens: &[TokenV0]) -> Option
             push_newline(&mut body);
         }
     }
-    if !bibitems.is_empty() {
+    if !resolved_bibliography_entries.is_empty() {
         push_paragraph_break(&mut body);
-        for item in &bibitems {
+        for (ordinal_index, item) in resolved_bibliography_entries.iter().enumerate() {
+            let ordinal = u32::try_from(ordinal_index.checked_add(1)?).ok()?;
             body.extend_from_slice(BIBITEM_LINE_PREFIX_MARKER_V0);
             body.extend_from_slice(&item.key);
             body.push(b' ');
-            body.extend_from_slice(item.ordinal.to_string().as_bytes());
+            body.extend_from_slice(ordinal.to_string().as_bytes());
             body.push(b' ');
             body.extend_from_slice(item.text_len.to_string().as_bytes());
             push_newline(&mut body);

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -8,10 +8,20 @@ use carreltex_core::{CompileStatus, Mount};
 use carreltex_xdv::parse_dvi_v2_text_page_to_layout_v0;
 
 fn compile_typeset(main: &[u8]) -> carreltex_core::CompileResultV0 {
+    compile_typeset_with_files(main, &[])
+}
+
+fn compile_typeset_with_files(
+    main: &[u8],
+    extra_files: &[(&[u8], &[u8])],
+) -> carreltex_core::CompileResultV0 {
     let mut mount = Mount::default();
     mount
         .add_file(b"main.tex", main)
         .expect("main.tex should mount");
+    for (path, bytes) in extra_files {
+        mount.add_file(path, bytes).expect("extra file should mount");
+    }
     compile_main_typeset_minimal_v0(&mut mount)
 }
 
@@ -320,28 +330,56 @@ fn typeset_minimal_rejects_duplicate_label_keys() {
 
 #[test]
 fn typeset_minimal_bibliography_and_cites_emit_block_and_metadata() {
-    let main = b"\\documentclass{article}\\begin{document}See \\cite{ref:a} and \\cite{missing}.\\begin{thebibliography}{9}\\bibitem{ref:a}Alpha source text.\\end{thebibliography}\\end{document}";
+    let main = b"\\documentclass{article}\\begin{document}See \\cite{ref:b} and \\cite{ref:a} then again \\cite{ref:b}.\\begin{thebibliography}{9}\\bibitem{ref:a}Alpha source text.\\bibitem{ref:b}Beta source text.\\end{thebibliography}\\end{document}";
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
-    assert!(text.contains("See [1] and [?]."), "body={text:?}");
+    assert!(text.contains("See [1] and [2] then again [1]."), "body={text:?}");
     assert!(text.contains("@S {References}"), "body={text:?}");
-    assert!(text.contains("[1] Alpha source text."), "body={text:?}");
-    assert!(text.contains("!b ref:a 1 18"), "body={text:?}");
+    assert!(text.contains("[1] Beta source text."), "body={text:?}");
+    assert!(text.contains("[2] Alpha source text."), "body={text:?}");
+    assert!(text.contains("!b ref:b 1 17"), "body={text:?}");
+    assert!(text.contains("!b ref:a 2 18"), "body={text:?}");
+    assert!(text.contains("!c ref:b "), "body={text:?}");
     assert!(text.contains("!c ref:a "), "body={text:?}");
-    assert!(text.contains("!c missing "), "body={text:?}");
 }
 
 #[test]
-fn typeset_minimal_rejects_bibliography_command_stub() {
-    let main = b"\\documentclass{article}\\begin{document}\\bibliography{refs}\\end{document}";
+fn typeset_minimal_rejects_missing_cite_key_in_bibliography_fixedpoint() {
+    let main = b"\\documentclass{article}\\begin{document}See \\cite{ref:missing}.\\begin{thebibliography}{9}\\bibitem{ref:a}Alpha source text.\\end{thebibliography}\\end{document}";
     let result = compile_typeset(main);
     assert_eq!(result.status, CompileStatus::NotImplemented);
     assert!(result.main_xdv_bytes.is_empty());
 }
 
 #[test]
-fn typeset_minimal_rejects_bibliographystyle_command_stub() {
-    let main = b"\\documentclass{article}\\begin{document}\\bibliographystyle{plain}\\end{document}";
+fn typeset_minimal_resolves_cites_via_bibliography_resource_file() {
+    let main = b"\\documentclass{article}\\begin{document}See \\cite{ref:alpha} and \\cite{ref:beta}.\\bibliography{refs}\\end{document}";
+    let bib = br#"
+@article{ref:alpha, title={Alpha from local bib}}
+@book{ref:beta, title={Beta from local bib}}
+"#;
+    let result = compile_typeset_with_files(main, &[(b"refs.bib", bib)]);
+    assert_eq!(result.status, CompileStatus::Ok);
+    let layout =
+        parse_dvi_v2_text_page_to_layout_v0(&result.main_xdv_bytes, 917_504).expect("layout parse");
+    let lines = layout.pages[0]
+        .lines
+        .iter()
+        .map(|line| line.glyphs.iter().map(|glyph| glyph.byte).collect::<Vec<u8>>())
+        .collect::<Vec<Vec<u8>>>();
+    let text = lines
+        .iter()
+        .map(|line| String::from_utf8_lossy(line).to_string())
+        .collect::<Vec<String>>()
+        .join("\n");
+    assert!(text.contains("See [1] and [2]."), "text={text:?}");
+    assert!(text.contains("[1] Alpha from local bib"), "text={text:?}");
+    assert!(text.contains("[2] Beta from local bib"), "text={text:?}");
+}
+
+#[test]
+fn typeset_minimal_rejects_missing_bibliography_resource_file() {
+    let main = b"\\documentclass{article}\\begin{document}See \\cite{ref:alpha}.\\bibliography{missing_refs}\\end{document}";
     let result = compile_typeset(main);
     assert_eq!(result.status, CompileStatus::NotImplemented);
     assert!(result.main_xdv_bytes.is_empty());

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -108,7 +108,7 @@ Flushright punctuation stress: edge,\emph{core} trail and edge \textbf{core}!
 \rightline{Punctuated \emph{right},line and \textbf{bold} end.}
 
 \subsection{Bibliography}
-This paragraph cites one known source \cite{ref:alpha} and one unresolved source \cite{ref:missing} to keep cite rendering deterministic.
+This paragraph cites one known source \cite{ref:alpha} and a second known source \cite{ref:beta} to keep cite rendering deterministic.
 
 \begin{thebibliography}{9}
 \bibitem{ref:alpha}Alpha bibliography entry text for deterministic cite rendering.


### PR DESCRIPTION
## Summary
- add deterministic bibliography fixedpoint resolution for cite markers against bibliography entries
- support bibliography resources loaded from mounted `.bib` files in the typeset minimal compile path
- enforce fail-closed behavior for missing cite keys and keep bibliography/cite metadata deterministic
- update the minimal fixture cite keys so strict cite resolution keeps the wasm typeset proof green

Refs: #390

## Proof
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml
- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 6
- ./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 18
