### PR TITLE
typeset_minimal: TOC hyperlinks v1

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -366,7 +366,13 @@ fn consume_simple_bracket_non_empty(tokens: &[TokenV0], index: usize) -> Option<
     let mut saw_non_space = false;
     while let Some(token) = tokens.get(cursor) {
         match token {
-            TokenV0::Char(b']') => return if saw_non_space { Some(cursor + 1) } else { None },
+            TokenV0::Char(b']') => {
+                return if saw_non_space {
+                    Some(cursor + 1)
+                } else {
+                    None
+                }
+            }
             TokenV0::Char(_) => saw_non_space = true,
             TokenV0::Space => {}
             _ => return None,
@@ -465,8 +471,7 @@ fn is_safe_math_payload_char_v0(byte: u8) -> bool {
     (0x20..=0x7e).contains(&byte)
         && !matches!(
             byte,
-            b'$'
-                | b'\\'
+            b'$' | b'\\'
                 | ITALIC_START_MARKER_V0
                 | ITALIC_END_MARKER_V0
                 | BOLD_START_MARKER_V0
@@ -476,7 +481,11 @@ fn is_safe_math_payload_char_v0(byte: u8) -> bool {
         )
 }
 
-fn consume_inline_math_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+fn consume_inline_math_command_v0(
+    tokens: &[TokenV0],
+    index: usize,
+    out: &mut Vec<u8>,
+) -> Option<usize> {
     if !matches!(tokens.get(index), Some(TokenV0::Char(b'$'))) {
         return None;
     }
@@ -509,7 +518,11 @@ fn consume_inline_math_command_v0(tokens: &[TokenV0], index: usize, out: &mut Ve
     }
 }
 
-fn consume_display_math_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+fn consume_display_math_command_v0(
+    tokens: &[TokenV0],
+    index: usize,
+    out: &mut Vec<u8>,
+) -> Option<usize> {
     if !matches!(
         tokens.get(index),
         Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"["
@@ -845,7 +858,9 @@ fn consume_fragment_token_v0(
             out.extend_from_slice(REF_MARKER_SUFFIX_V0);
             Some(next)
         }
-        TokenV0::ControlSeq(name) if name.as_slice() == b"protect" || name.as_slice() == b"relax" => {
+        TokenV0::ControlSeq(name)
+            if name.as_slice() == b"protect" || name.as_slice() == b"relax" =>
+        {
             Some(index + 1)
         }
         TokenV0::ControlSeq(name) if name.as_slice() == b"emph" || name.as_slice() == b"textbf" => {
@@ -856,7 +871,14 @@ fn consume_fragment_token_v0(
             };
             let (group_start, group_end, next) = consume_group_bounds(tokens, index + 1)?;
             out.push(style_markers.0);
-            consume_fragment_range_v0(tokens, group_start, group_end, out, allow_and, allow_hard_break)?;
+            consume_fragment_range_v0(
+                tokens,
+                group_start,
+                group_end,
+                out,
+                allow_and,
+                allow_hard_break,
+            )?;
             out.push(style_markers.1);
             Some(next)
         }
@@ -1071,7 +1093,11 @@ fn consume_includegraphics_path_v0(tokens: &[TokenV0], index: usize) -> Option<(
     Some((normalized, next))
 }
 
-fn consume_tabular_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+fn consume_tabular_environment_v0(
+    tokens: &[TokenV0],
+    index: usize,
+    out: &mut Vec<u8>,
+) -> Option<usize> {
     let (env_name, mut cursor) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
     if env_name.as_slice() != TABULAR_ENV_V0 {
         return None;
@@ -1122,7 +1148,9 @@ fn consume_tabular_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Ve
                     row.push(core::mem::take(&mut cell));
                     cursor += 1;
                 }
-                Some(TokenV0::ControlSeq(name)) if is_hard_line_break_control_v0(name.as_slice()) => {
+                Some(TokenV0::ControlSeq(name))
+                    if is_hard_line_break_control_v0(name.as_slice()) =>
+                {
                     trim_trailing_spaces(&mut cell);
                     if cell.windows(2).any(|window| window == b"||") {
                         return None;
@@ -1201,7 +1229,14 @@ fn consume_figure_environment_v0(
                 }
                 let (group_start, group_end, next) = consume_group_bounds(tokens, cursor + 1)?;
                 let mut value = Vec::<u8>::new();
-                consume_fragment_range_v0(tokens, group_start, group_end, &mut value, false, false)?;
+                consume_fragment_range_v0(
+                    tokens,
+                    group_start,
+                    group_end,
+                    &mut value,
+                    false,
+                    false,
+                )?;
                 trim_trailing_spaces(&mut value);
                 if value.is_empty() {
                     return None;
@@ -1289,7 +1324,9 @@ fn consume_list_environment_with_depth_v0(
 
                 loop {
                     match tokens.get(cursor) {
-                        Some(TokenV0::ControlSeq(name)) if name.as_slice() == ITEM_CONTROL_V0 => break,
+                        Some(TokenV0::ControlSeq(name)) if name.as_slice() == ITEM_CONTROL_V0 => {
+                            break
+                        }
                         Some(TokenV0::ControlSeq(name)) if name.as_slice() == BEGIN_CONTROL_V0 => {
                             let (nested_env, _) =
                                 consume_env_name_command_v0(tokens, cursor, BEGIN_CONTROL_V0)?;
@@ -1298,7 +1335,12 @@ fn consume_list_environment_with_depth_v0(
                             {
                                 return None;
                             }
-                            cursor = consume_list_environment_with_depth_v0(tokens, cursor, out, depth + 1)?;
+                            cursor = consume_list_environment_with_depth_v0(
+                                tokens,
+                                cursor,
+                                out,
+                                depth + 1,
+                            )?;
                         }
                         Some(TokenV0::ControlSeq(name)) if name.as_slice() == END_CONTROL_V0 => {
                             let (end_env, next) =
@@ -1331,7 +1373,11 @@ fn consume_list_environment_with_depth_v0(
     }
 }
 
-fn consume_list_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+fn consume_list_environment_v0(
+    tokens: &[TokenV0],
+    index: usize,
+    out: &mut Vec<u8>,
+) -> Option<usize> {
     consume_list_environment_with_depth_v0(tokens, index, out, 0)
 }
 
@@ -1389,7 +1435,11 @@ fn prefix_right_lines_v0(content: &[u8]) -> Vec<u8> {
     out
 }
 
-fn consume_quote_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+fn consume_quote_environment_v0(
+    tokens: &[TokenV0],
+    index: usize,
+    out: &mut Vec<u8>,
+) -> Option<usize> {
     let (env_name, mut cursor) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
     if env_name.as_slice() != QUOTE_ENV_V0 {
         return None;
@@ -1425,7 +1475,11 @@ fn consume_quote_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<
     }
 }
 
-fn consume_center_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+fn consume_center_environment_v0(
+    tokens: &[TokenV0],
+    index: usize,
+    out: &mut Vec<u8>,
+) -> Option<usize> {
     let (env_name, mut cursor) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
     if env_name.as_slice() != CENTER_ENV_V0 {
         return None;
@@ -1461,7 +1515,11 @@ fn consume_center_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec
     }
 }
 
-fn consume_centerline_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+fn consume_centerline_command_v0(
+    tokens: &[TokenV0],
+    index: usize,
+    out: &mut Vec<u8>,
+) -> Option<usize> {
     if !matches!(
         tokens.get(index),
         Some(TokenV0::ControlSeq(name)) if name.as_slice() == CENTERLINE_CONTROL_V0
@@ -1519,14 +1577,19 @@ fn consume_flushright_environment_v0(
                 cursor += 1;
             }
             Some(_) => {
-                cursor = consume_fragment_token_v0(tokens, cursor, &mut right_aligned, false, true)?;
+                cursor =
+                    consume_fragment_token_v0(tokens, cursor, &mut right_aligned, false, true)?;
             }
             None => return None,
         }
     }
 }
 
-fn consume_rightline_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+fn consume_rightline_command_v0(
+    tokens: &[TokenV0],
+    index: usize,
+    out: &mut Vec<u8>,
+) -> Option<usize> {
     if !matches!(
         tokens.get(index),
         Some(TokenV0::ControlSeq(name)) if name.as_slice() == RIGHTLINE_CONTROL_V0
@@ -1535,7 +1598,14 @@ fn consume_rightline_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<
     }
     let (group_start, group_end, next) = consume_group_bounds(tokens, index + 1)?;
     let mut right_aligned = Vec::new();
-    consume_fragment_range_v0(tokens, group_start, group_end, &mut right_aligned, false, true)?;
+    consume_fragment_range_v0(
+        tokens,
+        group_start,
+        group_end,
+        &mut right_aligned,
+        false,
+        true,
+    )?;
     trim_trailing_spaces(&mut right_aligned);
     if right_aligned.is_empty() {
         return None;
@@ -1551,7 +1621,11 @@ fn consume_rightline_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<
     Some(next)
 }
 
-fn consume_body_environment_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+fn consume_body_environment_v0(
+    tokens: &[TokenV0],
+    index: usize,
+    out: &mut Vec<u8>,
+) -> Option<usize> {
     let (env_name, _) = consume_env_name_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
     if env_name.as_slice() == ITEMIZE_ENV_V0 || env_name.as_slice() == ENUMERATE_ENV_V0 {
         return consume_list_environment_v0(tokens, index, out);
@@ -1616,8 +1690,7 @@ fn is_safe_href_url_byte_v0(byte: u8) -> bool {
     byte.is_ascii_alphanumeric()
         || matches!(
             byte,
-            b':'
-                | b'/'
+            b':' | b'/'
                 | b'?'
                 | b'#'
                 | b'['
@@ -1660,7 +1733,11 @@ fn normalize_bib_resource_name_v0(raw_path: &[u8]) -> Option<Vec<u8>> {
     if raw_path.contains(&b'\\') || raw_path.contains(&b':') {
         return None;
     }
-    if !raw_path.iter().copied().all(is_safe_bib_resource_path_byte_v0) {
+    if !raw_path
+        .iter()
+        .copied()
+        .all(is_safe_bib_resource_path_byte_v0)
+    {
         return None;
     }
 
@@ -1778,10 +1855,9 @@ fn consume_package_declaration_noop_v0(tokens: &[TokenV0], index: usize) -> Opti
         if package.is_empty()
             || package.starts_with(b"/")
             || package.windows(2).any(|window| window == b"..")
-            || !package
-                .iter()
-                .copied()
-                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b'.' | b'_' | b'-'))
+            || !package.iter().copied().all(|byte| {
+                byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b'.' | b'_' | b'-')
+            })
         {
             return None;
         }
@@ -1897,9 +1973,7 @@ fn extract_bib_title_field_v0(entry_body: &[u8]) -> Option<Vec<u8>> {
     None
 }
 
-pub(crate) fn parse_minimal_bib_entries_v0(
-    bib_bytes: &[u8],
-) -> Option<BTreeMap<Vec<u8>, Vec<u8>>> {
+pub(crate) fn parse_minimal_bib_entries_v0(bib_bytes: &[u8]) -> Option<BTreeMap<Vec<u8>, Vec<u8>>> {
     let mut entries = BTreeMap::<Vec<u8>, Vec<u8>>::new();
     let mut index = 0usize;
 
@@ -2067,7 +2141,10 @@ fn apply_crossref_pass_v1(
                 return None;
             }
             let key = body[key_start..key_end].to_vec();
-            let resolved_anchor_id = artifacts.labels_by_key.get(&key).map(|entry| entry.anchor_id);
+            let resolved_anchor_id = artifacts
+                .labels_by_key
+                .get(&key)
+                .map(|entry| entry.anchor_id);
             if let Some(anchor_id) = resolved_anchor_id {
                 if let Some(label) = artifacts.labels_by_key.get(&key) {
                     if matches!(label.kind, LabelKindV0::Heading)
@@ -2316,7 +2393,8 @@ fn consume_thebibliography_environment_v0(
         return None;
     }
 
-    let (width_group_start, width_group_end, width_group_next) = consume_group_bounds(tokens, cursor)?;
+    let (width_group_start, width_group_end, width_group_next) =
+        consume_group_bounds(tokens, cursor)?;
     let width_hint = parse_char_space_group_trimmed_v0(tokens, width_group_start, width_group_end)?;
     if width_hint.is_empty() {
         return None;
@@ -2346,7 +2424,9 @@ fn consume_thebibliography_environment_v0(
         }
 
         let (key, next_after_key) = parse_label_or_ref_key_group_v0(tokens, cursor)?;
-        if local_items.iter().any(|item| item.key == key) || bibitems.iter().any(|item| item.key == key) {
+        if local_items.iter().any(|item| item.key == key)
+            || bibitems.iter().any(|item| item.key == key)
+        {
             return None;
         }
         cursor = next_after_key;
@@ -2356,9 +2436,12 @@ fn consume_thebibliography_environment_v0(
             match tokens.get(cursor) {
                 Some(TokenV0::ControlSeq(name)) if name.as_slice() == BIBITEM_CONTROL_V0 => break,
                 Some(TokenV0::ControlSeq(name)) if name.as_slice() == END_CONTROL_V0 => break,
-                Some(TokenV0::ControlSeq(name)) if name.as_slice() == BEGIN_CONTROL_V0 => return None,
+                Some(TokenV0::ControlSeq(name)) if name.as_slice() == BEGIN_CONTROL_V0 => {
+                    return None
+                }
                 Some(_) => {
-                    cursor = consume_fragment_token_v0(tokens, cursor, &mut item_text, false, true)?;
+                    cursor =
+                        consume_fragment_token_v0(tokens, cursor, &mut item_text, false, true)?;
                 }
                 None => return None,
             }
@@ -2516,7 +2599,9 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
                 index = consume_document_env_command_v0(tokens, index, BEGIN_CONTROL_V0)?;
                 break;
             }
-            Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"protect" || name.as_slice() == b"relax" => {
+            Some(TokenV0::ControlSeq(name))
+                if name.as_slice() == b"protect" || name.as_slice() == b"relax" =>
+            {
                 index += 1;
             }
             Some(TokenV0::Space) => index += 1,
@@ -2612,13 +2697,19 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == FOOTNOTE_CONTROL_V0 => {
                 saw_body_content_after_maketitle = true;
-                maybe_emit_pending_noindent_prefix_v0(&mut body, &mut pending_noindent_after_heading);
+                maybe_emit_pending_noindent_prefix_v0(
+                    &mut body,
+                    &mut pending_noindent_after_heading,
+                );
                 pending_label_target = None;
                 index = consume_footnote_command_v0(tokens, index, &mut body, &mut footnotes)?;
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == HREF_CONTROL_V0 => {
                 saw_body_content_after_maketitle = true;
-                maybe_emit_pending_noindent_prefix_v0(&mut body, &mut pending_noindent_after_heading);
+                maybe_emit_pending_noindent_prefix_v0(
+                    &mut body,
+                    &mut pending_noindent_after_heading,
+                );
                 pending_label_target = None;
                 index = consume_href_command_v0(tokens, index, &mut body, &mut href_urls)?;
             }
@@ -2633,13 +2724,19 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == REF_CONTROL_V0 => {
                 saw_body_content_after_maketitle = true;
-                maybe_emit_pending_noindent_prefix_v0(&mut body, &mut pending_noindent_after_heading);
+                maybe_emit_pending_noindent_prefix_v0(
+                    &mut body,
+                    &mut pending_noindent_after_heading,
+                );
                 pending_label_target = None;
                 index = consume_ref_command_v0(tokens, index, &mut body)?;
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == CITE_CONTROL_V0 => {
                 saw_body_content_after_maketitle = true;
-                maybe_emit_pending_noindent_prefix_v0(&mut body, &mut pending_noindent_after_heading);
+                maybe_emit_pending_noindent_prefix_v0(
+                    &mut body,
+                    &mut pending_noindent_after_heading,
+                );
                 pending_label_target = None;
                 index = consume_cite_command_v0(tokens, index, &mut body)?;
             }
@@ -2648,7 +2745,10 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
                     || name.as_slice() == BIBLIOGRAPHY_CONTROL_V0 =>
             {
                 saw_body_content_after_maketitle = true;
-                maybe_emit_pending_noindent_prefix_v0(&mut body, &mut pending_noindent_after_heading);
+                maybe_emit_pending_noindent_prefix_v0(
+                    &mut body,
+                    &mut pending_noindent_after_heading,
+                );
                 pending_label_target = None;
                 if name.as_slice() == BIBLIOGRAPHY_CONTROL_V0 {
                     bibliography_render_requested = true;
@@ -2658,14 +2758,15 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == PRINTBIBLIOGRAPHY_CONTROL_V0 => {
                 saw_body_content_after_maketitle = true;
-                maybe_emit_pending_noindent_prefix_v0(&mut body, &mut pending_noindent_after_heading);
+                maybe_emit_pending_noindent_prefix_v0(
+                    &mut body,
+                    &mut pending_noindent_after_heading,
+                );
                 pending_label_target = None;
                 bibliography_render_requested = true;
                 index += 1;
             }
-            Some(TokenV0::ControlSeq(name))
-                if name.as_slice() == BIBLIOGRAPHYSTYLE_CONTROL_V0 =>
-            {
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == BIBLIOGRAPHYSTYLE_CONTROL_V0 => {
                 saw_body_content_after_maketitle = true;
                 pending_label_target = None;
                 index = consume_bibliographystyle_command_v0(tokens, index)?;
@@ -2698,7 +2799,10 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
             }
             Some(_) => {
                 saw_body_content_after_maketitle = true;
-                maybe_emit_pending_noindent_prefix_v0(&mut body, &mut pending_noindent_after_heading);
+                maybe_emit_pending_noindent_prefix_v0(
+                    &mut body,
+                    &mut pending_noindent_after_heading,
+                );
                 pending_label_target = None;
                 index = consume_fragment_token_v0(tokens, index, &mut body, false, true)?;
             }
@@ -2720,11 +2824,8 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
     body = normalize_tex_ellipsis_v0(&body);
     body = normalize_bracket_spacing_v0(&body);
     body = normalize_wrapper_marker_spacing_v0(&body);
-    let crossref_artifacts = build_crossref_artifacts_v1(
-        &labels_by_key,
-        &toc_entries,
-        !href_urls.is_empty(),
-    )?;
+    let crossref_artifacts =
+        build_crossref_artifacts_v1(&labels_by_key, &toc_entries, !href_urls.is_empty())?;
     body = apply_crossref_pass_v1(
         &body,
         &crossref_artifacts,
@@ -2757,7 +2858,10 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
         }
     }
     for item in &bibitems {
-        if bibliography_entries_by_key.insert(item.key.clone(), item.clone()).is_some() {
+        if bibliography_entries_by_key
+            .insert(item.key.clone(), item.clone())
+            .is_some()
+        {
             return None;
         }
     }
@@ -2807,7 +2911,13 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
             body.push(b' ');
             body.extend_from_slice(entry.anchor_id.to_string().as_bytes());
             body.push(b' ');
-            body.extend_from_slice(&entry.title);
+            if crossref_artifacts.hyperref_enabled {
+                body.push(LINK_START_MARKER_V0);
+                body.extend_from_slice(&entry.title);
+                body.push(LINK_END_MARKER_V0);
+            } else {
+                body.extend_from_slice(&entry.title);
+            }
             push_newline(&mut body);
         }
     }

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -20,7 +20,9 @@ fn compile_typeset_with_files(
         .add_file(b"main.tex", main)
         .expect("main.tex should mount");
     for (path, bytes) in extra_files {
-        mount.add_file(path, bytes).expect("extra file should mount");
+        mount
+            .add_file(path, bytes)
+            .expect("extra file should mount");
     }
     compile_main_typeset_minimal_v0(&mut mount)
 }
@@ -116,7 +118,10 @@ fn typeset_minimal_toc_after_maketitle_emits_placeholder_and_entries() {
     let main = b"\\documentclass{article}\\title{T}\\author{A}\\date{D}\\begin{document}\\maketitle\\tableofcontents\\section{Intro}\\subsection{Detail}\\end{document}";
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
-    assert!(text.contains("\n\n!toc\n\n@S {Intro}\n\n@s {Detail}"), "body={text:?}");
+    assert!(
+        text.contains("\n\n!toc\n\n@S {Intro}\n\n@s {Detail}"),
+        "body={text:?}"
+    );
     assert!(text.contains("!toc 1 1 Intro"), "body={text:?}");
     assert!(text.contains("!toc 2 2 Detail"), "body={text:?}");
 }
@@ -211,13 +216,26 @@ fn typeset_minimal_toc_metadata_coexists_with_footnotes_and_links() {
     let main = b"\\documentclass{article}\\title{T}\\author{A}\\date{D}\\begin{document}\\maketitle\\tableofcontents\\section{Intro}Body\\footnote{Note one} and \\href{https://example.com}{Link}.\\end{document}";
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
-    assert!(text.contains("!toc 1 1 Intro"), "body={text:?}");
+    assert!(text.contains("!toc 1 1 <Intro>"), "body={text:?}");
     assert!(text.contains("!f 1 Note one"), "body={text:?}");
     assert!(text.contains("!u 1 https://example.com"), "body={text:?}");
-    let toc_pos = text.find("!toc 1 1 Intro").expect("toc marker");
+    let toc_pos = text.find("!toc 1 1 <Intro>").expect("toc marker");
     let footnote_pos = text.find("!f 1 Note one").expect("footnote marker");
     let href_pos = text.find("!u 1 https://example.com").expect("href marker");
-    assert!(footnote_pos < href_pos && href_pos < toc_pos, "body={text:?}");
+    assert!(
+        footnote_pos < href_pos && href_pos < toc_pos,
+        "body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_toc_entries_are_link_wrapped_when_hyperref_is_enabled() {
+    let main = b"\\documentclass{article}\\title{T}\\author{A}\\date{D}\\begin{document}\\maketitle\\tableofcontents\\section{Intro}\\subsection{Detail}\\href{https://example.com}{Link}.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("!toc 1 1 <Intro>"), "body={text:?}");
+    assert!(text.contains("!toc 2 2 <Detail>"), "body={text:?}");
+    assert!(text.contains("!u 1 https://example.com"), "body={text:?}");
 }
 
 #[test]
@@ -252,8 +270,12 @@ fn typeset_minimal_toc_placeholder_precedes_rendered_headings() {
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
     let toc_placeholder = text.find("!toc").expect("toc placeholder should exist");
-    let first_heading = text.find("@S {First}").expect("section heading should exist");
-    let second_heading = text.find("@s {Second}").expect("subsection heading should exist");
+    let first_heading = text
+        .find("@S {First}")
+        .expect("section heading should exist");
+    let second_heading = text
+        .find("@s {Second}")
+        .expect("subsection heading should exist");
     assert!(
         toc_placeholder < first_heading && first_heading < second_heading,
         "toc placeholder and headings should preserve deterministic order: body={text:?}"
@@ -290,7 +312,10 @@ fn typeset_minimal_labels_and_refs_emit_metadata_and_resolve_inline_values() {
     let text = String::from_utf8(body).expect("body should be valid utf8");
     assert!(text.contains("See 1 and ??."), "body={text:?}");
     assert!(text.contains("Figure 2."), "body={text:?}");
-    assert!(text.contains("!l sec:intro 1 heading 1 Intro"), "body={text:?}");
+    assert!(
+        text.contains("!l sec:intro 1 heading 1 Intro"),
+        "body={text:?}"
+    );
     assert!(text.contains("!l fig:cap 2 figure 0 -"), "body={text:?}");
     assert!(text.contains("!r sec:intro "), "body={text:?}");
     assert!(text.contains("!r sec:missing "), "body={text:?}");
@@ -333,7 +358,10 @@ fn typeset_minimal_bibliography_and_cites_emit_block_and_metadata() {
     let main = b"\\documentclass{article}\\begin{document}See \\cite{ref:b} and \\cite{ref:a} then again \\cite{ref:b}.\\begin{thebibliography}{9}\\bibitem{ref:a}Alpha source text.\\bibitem{ref:b}Beta source text.\\end{thebibliography}\\end{document}";
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
-    assert!(text.contains("See [1] and [2] then again [1]."), "body={text:?}");
+    assert!(
+        text.contains("See [1] and [2] then again [1]."),
+        "body={text:?}"
+    );
     assert!(text.contains("@S {References}"), "body={text:?}");
     assert!(text.contains("[1] Beta source text."), "body={text:?}");
     assert!(text.contains("[2] Alpha source text."), "body={text:?}");
@@ -365,7 +393,12 @@ fn typeset_minimal_resolves_cites_via_bibliography_resource_file() {
     let lines = layout.pages[0]
         .lines
         .iter()
-        .map(|line| line.glyphs.iter().map(|glyph| glyph.byte).collect::<Vec<u8>>())
+        .map(|line| {
+            line.glyphs
+                .iter()
+                .map(|glyph| glyph.byte)
+                .collect::<Vec<u8>>()
+        })
         .collect::<Vec<Vec<u8>>>();
     let text = lines
         .iter()
@@ -395,7 +428,8 @@ fn typeset_minimal_rejects_thebibliography_without_bibitem() {
 
 #[test]
 fn typeset_minimal_rejects_label_with_unsafe_key_bytes() {
-    let main = b"\\documentclass{article}\\begin{document}\\section{A}\\label{../bad}\\end{document}";
+    let main =
+        b"\\documentclass{article}\\begin{document}\\section{A}\\label{../bad}\\end{document}";
     let result = compile_typeset(main);
     assert_eq!(result.status, CompileStatus::NotImplemented);
     assert!(result.main_xdv_bytes.is_empty());
@@ -407,7 +441,10 @@ fn typeset_minimal_heading_at_start_has_no_leading_blank_lines() {
         b"\\documentclass{article}\\begin{document}\\paragraph{Lead in}Body text.\\end{document}";
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
-    assert!(text.starts_with("@s {Lead in}\n\n~ Body text."), "body={text:?}");
+    assert!(
+        text.starts_with("@s {Lead in}\n\n~ Body text."),
+        "body={text:?}"
+    );
 }
 
 #[test]
@@ -519,7 +556,9 @@ fn typeset_minimal_center_environment_prefixes_each_line() {
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
     assert!(
-        text.contains("Before.\n\n^ Centered one\n^ Centered two\n\n^ Centered paragraph\n\nAfter."),
+        text.contains(
+            "Before.\n\n^ Centered one\n^ Centered two\n\n^ Centered paragraph\n\nAfter."
+        ),
         "body={text:?}"
     );
 }
@@ -529,13 +568,15 @@ fn typeset_minimal_centerline_emits_single_centered_line() {
     let main = b"\\documentclass{article}\\begin{document}Before.\\centerline{A \\emph{B}}After.\\end{document}";
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
-    assert!(text.contains("Before.\n\n^ A [B]\n\nAfter."), "body={text:?}");
+    assert!(
+        text.contains("Before.\n\n^ A [B]\n\nAfter."),
+        "body={text:?}"
+    );
 }
 
 #[test]
 fn typeset_minimal_centerline_rejects_multiline_content() {
-    let main =
-        b"\\documentclass{article}\\begin{document}\\centerline{A\\\\B}\\end{document}";
+    let main = b"\\documentclass{article}\\begin{document}\\centerline{A\\\\B}\\end{document}";
     let result = compile_typeset(main);
     assert_eq!(result.status, CompileStatus::NotImplemented);
     assert!(result.main_xdv_bytes.is_empty());
@@ -557,7 +598,10 @@ fn typeset_minimal_rightline_emits_single_right_aligned_line() {
     let main = b"\\documentclass{article}\\begin{document}Before.\\rightline{A \\textbf{B}}After.\\end{document}";
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
-    assert!(text.contains("Before.\n\n| A {B}\n\nAfter."), "body={text:?}");
+    assert!(
+        text.contains("Before.\n\n| A {B}\n\nAfter."),
+        "body={text:?}"
+    );
 }
 
 #[test]
@@ -622,10 +666,7 @@ fn typeset_minimal_figure_stub_accepts_includegraphics_without_extension_by_norm
     let main = b"\\documentclass{article}\\begin{document}\\begin{figure}\\includegraphics{figs/demo}\\caption{No ext}\\end{figure}\\end{document}";
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
-    assert!(
-        text.contains("!gimg 1 figs/demo.png"),
-        "body={text:?}"
-    );
+    assert!(text.contains("!gimg 1 figs/demo.png"), "body={text:?}");
 }
 
 #[test]
@@ -646,7 +687,8 @@ fn typeset_minimal_rejects_figure_includegraphics_unsafe_path() {
 
 #[test]
 fn typeset_minimal_rejects_figure_without_caption() {
-    let main = b"\\documentclass{article}\\begin{document}\\begin{figure}\\end{figure}\\end{document}";
+    let main =
+        b"\\documentclass{article}\\begin{document}\\begin{figure}\\end{figure}\\end{document}";
     let result = compile_typeset(main);
     assert_eq!(result.status, CompileStatus::NotImplemented);
     assert!(result.main_xdv_bytes.is_empty());
@@ -686,7 +728,8 @@ fn typeset_minimal_rejects_href_with_unsupported_url_tokens() {
 
 #[test]
 fn typeset_minimal_rejects_malformed_href_missing_text_group() {
-    let main = b"\\documentclass{article}\\begin{document}\\href{https://example.com}\\end{document}";
+    let main =
+        b"\\documentclass{article}\\begin{document}\\href{https://example.com}\\end{document}";
     let result = compile_typeset(main);
     assert_eq!(result.status, CompileStatus::NotImplemented);
     assert!(result.main_xdv_bytes.is_empty());
@@ -719,7 +762,12 @@ fn typeset_minimal_long_paragraph_wraps_to_multiple_lines() {
     let layout =
         parse_dvi_v2_text_page_to_layout_v0(&result.main_xdv_bytes, 917_504).expect("layout parse");
     assert!(
-        layout.pages.first().map(|page| page.lines.len()).unwrap_or(0) >= 2,
+        layout
+            .pages
+            .first()
+            .map(|page| page.lines.len())
+            .unwrap_or(0)
+            >= 2,
         "expected wrapped output with multiple lines"
     );
 }
@@ -733,8 +781,7 @@ fn typeset_minimal_single_newline_collapses_to_space() {
 
 #[test]
 fn typeset_minimal_punctuation_does_not_cross_paragraph_break() {
-    let main =
-        b"\\documentclass{article}\n\\begin{document}\nHello,\n\nworld.\n\\end{document}\n";
+    let main = b"\\documentclass{article}\n\\begin{document}\nHello,\n\nworld.\n\\end{document}\n";
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
     assert!(text.contains("Hello,\n\nworld."), "body={text:?}");
@@ -755,7 +802,10 @@ fn typeset_minimal_punctuation_removes_spaces_before_markers_and_punctuation() {
     let main = b"\\documentclass{article}\\begin{document}lead\\emph{core} , trail and lead\\textbf{core} ! done.\\end{document}";
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
-    assert!(text.contains("lead[core], trail and lead{core}! done."), "body={text:?}");
+    assert!(
+        text.contains("lead[core], trail and lead{core}! done."),
+        "body={text:?}"
+    );
     assert!(!text.contains("[core] ,"), "body={text:?}");
     assert!(!text.contains("{core} !"), "body={text:?}");
 }
@@ -831,7 +881,10 @@ fn typeset_minimal_nested_wrapper_boundary_spacing_is_stable() {
     let main = b"\\documentclass{article}\\begin{document}word\\emph{\\textbf{ mid }}word and word\\textbf{\\emph{ core }} ,trail\\end{document}";
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
-    assert!(text.contains("word[{mid}]word and word{[core]},trail"), "body={text:?}");
+    assert!(
+        text.contains("word[{mid}]word and word{[core]},trail"),
+        "body={text:?}"
+    );
     assert!(!text.contains("word [{mid}]word"), "body={text:?}");
     assert!(!text.contains("} ,trail"), "body={text:?}");
 }
@@ -849,16 +902,25 @@ fn typeset_minimal_brackets_and_braces_do_not_strip_across_hard_newline() {
 fn typeset_minimal_double_backslash_emits_hard_newline() {
     let main = b"\\documentclass{article}\\begin{document}Hello\\\\world.\\end{document}";
     let lines = layout_lines_bytes(main);
-    assert!(lines.len() >= 2, "expected at least two lines, got {:?}", lines);
+    assert!(
+        lines.len() >= 2,
+        "expected at least two lines, got {:?}",
+        lines
+    );
     assert_eq!(lines[0], b"Hello");
     assert_eq!(lines[1], b"world.");
 }
 
 #[test]
 fn typeset_minimal_newline_alias_emits_hard_newline() {
-    let main = b"\\documentclass{article}\n\\begin{document}\nHello\\newline world.\n\\end{document}\n";
+    let main =
+        b"\\documentclass{article}\n\\begin{document}\nHello\\newline world.\n\\end{document}\n";
     let lines = layout_lines_bytes(main);
-    assert!(lines.len() >= 2, "expected at least two lines, got {:?}", lines);
+    assert!(
+        lines.len() >= 2,
+        "expected at least two lines, got {:?}",
+        lines
+    );
     assert_eq!(lines[0], b"Hello");
     assert_eq!(lines[1], b"world.");
 }
@@ -867,7 +929,11 @@ fn typeset_minimal_newline_alias_emits_hard_newline() {
 fn typeset_minimal_linebreak_alias_emits_hard_newline() {
     let main = b"\\documentclass{article}\\begin{document}Hello\\linebreak world.\\end{document}";
     let lines = layout_lines_bytes(main);
-    assert!(lines.len() >= 2, "expected at least two lines, got {:?}", lines);
+    assert!(
+        lines.len() >= 2,
+        "expected at least two lines, got {:?}",
+        lines
+    );
     assert_eq!(lines[0], b"Hello");
     assert_eq!(lines[1], b"world.");
 }
@@ -904,8 +970,7 @@ fn typeset_minimal_inline_math_emits_placeholder_text() {
 
 #[test]
 fn typeset_minimal_display_math_emits_centered_placeholder_block() {
-    let main =
-        b"\\documentclass{article}\\begin{document}Before.\\[x+y\\]After.\\end{document}";
+    let main = b"\\documentclass{article}\\begin{document}Before.\\[x+y\\]After.\\end{document}";
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
     assert!(

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -1,4 +1,7 @@
-use crate::{parse_dvi_v2_text_page_to_layout_v0, GlyphPlanV0, LinePlanV0, PagePlanV0, DEFAULT_LINE_ADVANCE_SP_V0};
+use crate::{
+    parse_dvi_v2_text_page_to_layout_v0, GlyphPlanV0, LinePlanV0, PagePlanV0,
+    DEFAULT_LINE_ADVANCE_SP_V0,
+};
 use std::collections::BTreeMap;
 
 const PDF_VERSION: &[u8] = b"%PDF-1.4\n";
@@ -291,7 +294,9 @@ fn split_superscript_segments_v0(segments: &[PdfStyledSegmentV0]) -> Vec<PdfRend
                 continue;
             }
             let mut marker_end = cursor + 2;
-            while marker_end < segment.glyphs.len() && segment.glyphs[marker_end].byte.is_ascii_digit() {
+            while marker_end < segment.glyphs.len()
+                && segment.glyphs[marker_end].byte.is_ascii_digit()
+            {
                 marker_end += 1;
             }
             if cursor > normal_start {
@@ -381,7 +386,10 @@ fn detect_list_prefix_v0(glyphs: &[GlyphPlanV0]) -> Option<ListPrefixV0> {
         .map(|glyph| (glyph.advance_sp as f32) / 65_536.0)
         .sum();
 
-    if glyphs.len() >= leading + 2 && glyphs[leading].byte == b'-' && glyphs[leading + 1].byte == b' ' {
+    if glyphs.len() >= leading + 2
+        && glyphs[leading].byte == b'-'
+        && glyphs[leading + 1].byte == b' '
+    {
         return Some(ListPrefixV0 {
             kind: ListPrefixKindV0::Itemize,
             prefix_len: leading + 2,
@@ -533,7 +541,8 @@ fn parse_table_row_cells_v0(glyphs: &[GlyphPlanV0]) -> Option<Vec<Vec<GlyphPlanV
     let mut current = Vec::<GlyphPlanV0>::new();
     let mut index = TABLE_ROW_PREFIX_MARKER_V0.len();
     while index < glyphs.len() {
-        if index + 1 < glyphs.len() && glyphs[index].byte == b'|' && glyphs[index + 1].byte == b'|' {
+        if index + 1 < glyphs.len() && glyphs[index].byte == b'|' && glyphs[index + 1].byte == b'|'
+        {
             cells.push(trim_space_glyph_edges_v0(&current));
             current.clear();
             index += 2;
@@ -647,10 +656,16 @@ fn emit_table_block_v0(
         for (col_index, cell_glyphs) in cells.iter().enumerate() {
             let segments = parse_styled_segments_v0(cell_glyphs)?;
             let render_segments = split_superscript_segments_v0(&segments);
-            if render_segments.iter().any(|segment| segment.superscript || segment.is_link) {
+            if render_segments
+                .iter()
+                .any(|segment| segment.superscript || segment.is_link)
+            {
                 return None;
             }
-            let width_pt = render_segments.iter().map(|segment| segment.advance_pt).sum::<f32>();
+            let width_pt = render_segments
+                .iter()
+                .map(|segment| segment.advance_pt)
+                .sum::<f32>();
             col_max_width_pt[col_index] = col_max_width_pt[col_index].max(width_pt);
             parsed_cells.push(render_segments);
         }
@@ -660,7 +675,9 @@ fn emit_table_block_v0(
     let table_width_pt = col_max_width_pt
         .iter()
         .copied()
-        .fold(0.0f32, |acc, width_pt| acc + width_pt + (TABLE_CELL_PADDING_PT_V0 * 2.0));
+        .fold(0.0f32, |acc, width_pt| {
+            acc + width_pt + (TABLE_CELL_PADDING_PT_V0 * 2.0)
+        });
     let max_content_width_pt = PAGE_WIDTH_PT_V0 - (2.0 * MARGIN_PT_V0);
     if table_width_pt > max_content_width_pt {
         return None;
@@ -732,10 +749,7 @@ fn emit_table_block_v0(
         out.extend_from_slice(
             format!(
                 "{:.2} {:.2} m {:.2} {:.2} l S\n",
-                table_left_x_pt,
-                y_pt,
-                table_right_x_pt,
-                y_pt,
+                table_left_x_pt, y_pt, table_right_x_pt, y_pt,
             )
             .as_bytes(),
         );
@@ -745,10 +759,7 @@ fn emit_table_block_v0(
         out.extend_from_slice(
             format!(
                 "{:.2} {:.2} m {:.2} {:.2} l S\n",
-                x_pt,
-                table_top_y_pt,
-                x_pt,
-                table_bottom_y_pt,
+                x_pt, table_top_y_pt, x_pt, table_bottom_y_pt,
             )
             .as_bytes(),
         );
@@ -819,6 +830,7 @@ fn emit_toc_block_v0(
     toc_entries: &[TocEntryMetadataV0],
     y: &mut f32,
     min_body_y_pt: f32,
+    annotations: &mut Vec<PdfLinkAnnotationV0>,
 ) -> Option<()> {
     if *y < min_body_y_pt {
         return None;
@@ -841,7 +853,13 @@ fn emit_toc_block_v0(
         glyphs: title_glyphs,
         is_link: false,
     }];
-    emit_styled_segments_v0(out, &title_segments, MARGIN_PT_V0, *y, TOC_TITLE_FONT_SIZE_PT_V0);
+    emit_styled_segments_v0(
+        out,
+        &title_segments,
+        MARGIN_PT_V0,
+        *y,
+        TOC_TITLE_FONT_SIZE_PT_V0,
+    );
     out.extend_from_slice(b"\n");
     *y -= LEADING_PT_V0;
 
@@ -851,14 +869,19 @@ fn emit_toc_block_v0(
         }
         let base_segments = parse_styled_segments_v0(&entry.title_glyphs)?;
         let render_segments = split_superscript_segments_v0(&base_segments);
-        if render_segments
-            .iter()
-            .any(|segment| segment.superscript || segment.is_link)
-        {
+        if render_segments.iter().any(|segment| segment.superscript) {
             return None;
         }
         let indent_steps = f32::from(entry.level.saturating_sub(1));
         let x_pt = MARGIN_PT_V0 + (indent_steps * TOC_ENTRY_INDENT_STEP_PT_V0);
+        let mut toc_annotations = collect_toc_anchor_annotations_for_line_v0(
+            &render_segments,
+            x_pt,
+            *y,
+            FONT_SIZE_PT_V0,
+            entry.anchor_id,
+        )?;
+        annotations.append(&mut toc_annotations);
         emit_render_segments_with_superscript_v0(out, &render_segments, x_pt, *y, FONT_SIZE_PT_V0);
         out.extend_from_slice(b"\n");
         *y -= LEADING_PT_V0;
@@ -959,8 +982,7 @@ fn is_safe_link_uri_byte_v0(byte: u8) -> bool {
     byte.is_ascii_alphanumeric()
         || matches!(
             byte,
-            b':'
-                | b'/'
+            b':' | b'/'
                 | b'?'
                 | b'#'
                 | b'['
@@ -1381,6 +1403,69 @@ fn collect_link_annotations_for_line_v0(
     Some(annotations)
 }
 
+fn collect_toc_anchor_annotations_for_line_v0(
+    segments: &[PdfRenderSegmentV0],
+    line_x_pt: f32,
+    line_y_pt: f32,
+    font_size_pt: f32,
+    anchor_id: u32,
+) -> Option<Vec<PdfLinkAnnotationV0>> {
+    let mut annotations = Vec::<PdfLinkAnnotationV0>::new();
+    let mut cursor_x = line_x_pt;
+    let mut run_start_x = None::<f32>;
+    let mut run_end_x = line_x_pt;
+
+    for segment in segments {
+        let start_x = cursor_x;
+        let end_x = cursor_x + segment.advance_pt;
+        if segment.is_link {
+            if run_start_x.is_none() {
+                run_start_x = Some(start_x);
+            }
+            run_end_x = end_x;
+        } else if let Some(run_x) = run_start_x.take() {
+            if run_end_x <= run_x {
+                return None;
+            }
+            let rect = [
+                run_x.clamp(0.0, PAGE_WIDTH_PT_V0),
+                (line_y_pt - font_size_pt * 0.30).clamp(0.0, PAGE_HEIGHT_PT_V0),
+                run_end_x.clamp(0.0, PAGE_WIDTH_PT_V0),
+                (line_y_pt + font_size_pt * 0.85).clamp(0.0, PAGE_HEIGHT_PT_V0),
+            ];
+            if rect[2] <= rect[0] || rect[3] <= rect[1] {
+                return None;
+            }
+            annotations.push(PdfLinkAnnotationV0 {
+                target: PdfLinkTargetV0::Anchor(anchor_id),
+                rect,
+            });
+        }
+        cursor_x = end_x;
+    }
+
+    if let Some(run_x) = run_start_x {
+        if run_end_x <= run_x {
+            return None;
+        }
+        let rect = [
+            run_x.clamp(0.0, PAGE_WIDTH_PT_V0),
+            (line_y_pt - font_size_pt * 0.30).clamp(0.0, PAGE_HEIGHT_PT_V0),
+            run_end_x.clamp(0.0, PAGE_WIDTH_PT_V0),
+            (line_y_pt + font_size_pt * 0.85).clamp(0.0, PAGE_HEIGHT_PT_V0),
+        ];
+        if rect[2] <= rect[0] || rect[3] <= rect[1] {
+            return None;
+        }
+        annotations.push(PdfLinkAnnotationV0 {
+            target: PdfLinkTargetV0::Anchor(anchor_id),
+            rect,
+        });
+    }
+
+    Some(annotations)
+}
+
 fn collect_footnote_marker_ids_from_glyphs_v0(
     glyphs: &[GlyphPlanV0],
     marker_ids: &mut Vec<u32>,
@@ -1417,7 +1502,9 @@ fn collect_page_footnote_marker_ids_v0(lines: &[LinePlanV0]) -> Option<Vec<u32>>
     Some(marker_ids)
 }
 
-fn split_body_and_metadata_lines_v0(pages: &[PagePlanV0]) -> (Vec<Vec<LinePlanV0>>, Vec<LinePlanV0>) {
+fn split_body_and_metadata_lines_v0(
+    pages: &[PagePlanV0],
+) -> (Vec<Vec<LinePlanV0>>, Vec<LinePlanV0>) {
     let mut body_pages = vec![Vec::<LinePlanV0>::new(); pages.len()];
     let mut metadata_lines = Vec::<LinePlanV0>::new();
     let mut in_metadata = false;
@@ -1442,13 +1529,69 @@ fn split_body_and_metadata_lines_v0(pages: &[PagePlanV0]) -> (Vec<Vec<LinePlanV0
         }
     }
     while body_pages.len() > 1 {
-        let should_pop = body_pages.last().map(|lines| lines.is_empty()).unwrap_or(false);
+        let should_pop = body_pages
+            .last()
+            .map(|lines| lines.is_empty())
+            .unwrap_or(false);
         if !should_pop {
             break;
         }
         body_pages.pop();
     }
     (body_pages, metadata_lines)
+}
+
+fn collect_nominal_anchor_destinations_v0(
+    body_pages: &[Vec<LinePlanV0>],
+) -> Option<BTreeMap<u32, AnchorDestinationV0>> {
+    let mut anchor_destinations = BTreeMap::<u32, AnchorDestinationV0>::new();
+    let mut next_anchor_id = 1u32;
+    for (page_index, lines) in body_pages.iter().enumerate() {
+        let title_block_len = if page_index == 0 {
+            detect_title_block_len_v0(lines)
+        } else {
+            0
+        };
+        let mut y = PAGE_HEIGHT_PT_V0 - MARGIN_PT_V0 - TITLE_FONT_SIZE_PT_V0;
+        for (line_index, line) in lines.iter().enumerate() {
+            if line_index >= title_block_len && has_figure_box_prefix_v0(&line.glyphs) {
+                if anchor_destinations
+                    .insert(
+                        next_anchor_id,
+                        AnchorDestinationV0 {
+                            page_index,
+                            y_pt: y,
+                        },
+                    )
+                    .is_some()
+                {
+                    return None;
+                }
+                next_anchor_id = next_anchor_id.checked_add(1)?;
+            } else if line_index >= title_block_len
+                && detect_heading_prefix_v0(&line.glyphs).is_some()
+            {
+                if anchor_destinations
+                    .insert(
+                        next_anchor_id,
+                        AnchorDestinationV0 {
+                            page_index,
+                            y_pt: y,
+                        },
+                    )
+                    .is_some()
+                {
+                    return None;
+                }
+                next_anchor_id = next_anchor_id.checked_add(1)?;
+            }
+            y -= LEADING_PT_V0;
+            if title_block_len > 0 && line_index + 1 == title_block_len {
+                y -= TITLE_EXTRA_GAP_PT_V0;
+            }
+        }
+    }
+    Some(anchor_destinations)
 }
 
 fn parse_metadata_lines_v0(
@@ -1463,7 +1606,8 @@ fn parse_metadata_lines_v0(
     let mut toc_entries = Vec::<TocEntryMetadataV0>::new();
     let mut current_footnote_id = None::<u32>;
     for line in metadata_lines {
-        if let Some((footnote_id, footnote_line)) = parse_footnote_definition_line_v0(&line.glyphs) {
+        if let Some((footnote_id, footnote_line)) = parse_footnote_definition_line_v0(&line.glyphs)
+        {
             if footnote_defs_by_id.contains_key(&footnote_id) {
                 return None;
             }
@@ -1483,7 +1627,10 @@ fn parse_metadata_lines_v0(
         }
         if let Some(ref_link) = parse_ref_anchor_link_line_v0(&line.glyphs) {
             if link_targets_by_id
-                .insert(ref_link.link_id, PdfLinkTargetV0::Anchor(ref_link.anchor_id))
+                .insert(
+                    ref_link.link_id,
+                    PdfLinkTargetV0::Anchor(ref_link.anchor_id),
+                )
                 .is_some()
             {
                 return None;
@@ -1525,7 +1672,9 @@ fn parse_metadata_lines_v0(
             continue;
         }
         let footnote_id = current_footnote_id?;
-        footnote_defs_by_id.get_mut(&footnote_id)?.push(line.glyphs.clone());
+        footnote_defs_by_id
+            .get_mut(&footnote_id)?
+            .push(line.glyphs.clone());
     }
     toc_entries.sort_by_key(|entry| entry.anchor_id);
     Some((footnote_defs_by_id, link_targets_by_id, toc_entries))
@@ -1549,7 +1698,9 @@ fn build_page_content_stream_v0(
     let page_footnote_ids = collect_page_footnote_marker_ids_v0(lines)?;
     let mut footnote_line_count = 0usize;
     for footnote_id in &page_footnote_ids {
-        let Some(footnote_lines) = footnote_defs_by_id.get(footnote_id) else { return None; };
+        let Some(footnote_lines) = footnote_defs_by_id.get(footnote_id) else {
+            return None;
+        };
         footnote_line_count = footnote_line_count.checked_add(footnote_lines.len())?;
     }
     let footnote_reserved_height_pt = if footnote_line_count == 0 {
@@ -1591,7 +1742,12 @@ fn build_page_content_stream_v0(
             while table_end < lines.len() && has_table_row_prefix_v0(&lines[table_end].glyphs) {
                 table_end += 1;
             }
-            emit_table_block_v0(&mut out, &lines[line_index..table_end], &mut y, min_body_y_pt)?;
+            emit_table_block_v0(
+                &mut out,
+                &lines[line_index..table_end],
+                &mut y,
+                min_body_y_pt,
+            )?;
             previous_rendered_line_was_empty = false;
             skip_indent_after_title_block = false;
             active_hang_indent_pt = 0.0;
@@ -1646,7 +1802,13 @@ fn build_page_content_stream_v0(
             return None;
         }
         if line_index >= title_block_len && has_toc_placeholder_line_v0(&line.glyphs) {
-            emit_toc_block_v0(&mut out, toc_entries, &mut y, min_body_y_pt)?;
+            emit_toc_block_v0(
+                &mut out,
+                toc_entries,
+                &mut y,
+                min_body_y_pt,
+                &mut annotations,
+            )?;
             previous_rendered_line_was_empty = false;
             skip_indent_after_title_block = false;
             active_hang_indent_pt = 0.0;
@@ -1721,7 +1883,9 @@ fn build_page_content_stream_v0(
             &mut style_stack,
             &mut current_style,
             &mut link_active,
-        ) else { return None; };
+        ) else {
+            return None;
+        };
         let render_segments = split_superscript_segments_v0(&segments);
         let line_is_empty = render_segments.is_empty();
         let in_title_block = title_block_len > 0 && line_index < title_block_len;
@@ -1749,7 +1913,10 @@ fn build_page_content_stream_v0(
             && next_raw_line_is_empty
             && is_heading_line_segments_v0(&segments);
         if !line_is_empty {
-            let line_width_pt: f32 = render_segments.iter().map(|segment| segment.advance_pt).sum();
+            let line_width_pt: f32 = render_segments
+                .iter()
+                .map(|segment| segment.advance_pt)
+                .sum();
             let line_x = if in_title_block {
                 centered_line_x_v0(line_width_pt)
             } else if heading_kind.is_some() || heading_centered {
@@ -1804,7 +1971,8 @@ fn build_page_content_stream_v0(
             if let Some(prefix) = list_prefix {
                 let display_prefix_glyphs = &render_glyphs_base
                     [prefix.display_start..prefix.display_start + prefix.display_len];
-                let Some(display_prefix_segments) = parse_styled_segments_v0(display_prefix_glyphs) else {
+                let Some(display_prefix_segments) = parse_styled_segments_v0(display_prefix_glyphs)
+                else {
                     return None;
                 };
                 let prefix_width_pt = glyphs_advance_pt_v0(display_prefix_glyphs);
@@ -1814,7 +1982,13 @@ fn build_page_content_stream_v0(
                         ENUM_NUMBER_COLUMN_RIGHT_PT_V0 + prefix.leading_advance_pt - prefix_width_pt
                     }
                 };
-                emit_styled_segments_v0(&mut out, &display_prefix_segments, prefix_x, y, font_size_pt);
+                emit_styled_segments_v0(
+                    &mut out,
+                    &display_prefix_segments,
+                    prefix_x,
+                    y,
+                    font_size_pt,
+                );
             }
             let mut line_annotations = collect_link_annotations_for_line_v0(
                 &render_segments,
@@ -1862,14 +2036,15 @@ fn build_page_content_stream_v0(
     }
 
     if footnote_line_count > 0 {
-        let mut footnote_y =
-            MARGIN_PT_V0 + footnote_reserved_height_pt - FOOTNOTE_LEADING_PT_V0;
+        let mut footnote_y = MARGIN_PT_V0 + footnote_reserved_height_pt - FOOTNOTE_LEADING_PT_V0;
         for footnote_id in &page_footnote_ids {
             for footnote_line in footnote_defs_by_id.get(footnote_id)? {
                 if footnote_y < MARGIN_PT_V0 {
                     return None;
                 }
-                let Some(segments) = parse_styled_segments_v0(footnote_line) else { return None; };
+                let Some(segments) = parse_styled_segments_v0(footnote_line) else {
+                    return None;
+                };
                 if !segments.is_empty() {
                     let render_segments = split_superscript_segments_v0(&segments);
                     let has_superscript = render_segments.iter().any(|segment| segment.superscript);
@@ -1911,6 +2086,10 @@ fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
     else {
         return Vec::new();
     };
+    let Some(nominal_anchor_destinations) = collect_nominal_anchor_destinations_v0(&body_pages)
+    else {
+        return Vec::new();
+    };
 
     let mut next_link_id = 1u32;
     let mut next_anchor_id = 1u32;
@@ -1927,8 +2106,13 @@ fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
             &mut next_anchor_id,
             &mut anchor_destinations,
             page_index == 0,
-        ) else { return Vec::new(); };
+        ) else {
+            return Vec::new();
+        };
         page_renders.push(rendered);
+    }
+    for (anchor_id, destination) in nominal_anchor_destinations {
+        anchor_destinations.entry(anchor_id).or_insert(destination);
     }
     if usize::try_from(next_link_id.saturating_sub(1)).ok() != Some(link_targets_by_id.len()) {
         return Vec::new();
@@ -2052,7 +2236,11 @@ fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
                         annotation.rect[2],
                         annotation.rect[3],
                     );
-                    offsets.push(write_pdf_obj(&mut out, annotation_id, annot_body.as_bytes()));
+                    offsets.push(write_pdf_obj(
+                        &mut out,
+                        annotation_id,
+                        annot_body.as_bytes(),
+                    ));
                     let mut action_body = Vec::<u8>::new();
                     action_body.extend_from_slice(b"<< /S /URI /URI (");
                     action_body.extend_from_slice(&escape_pdf_string_bytes(uri));
@@ -2063,7 +2251,8 @@ fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
                     let Some(destination) = anchor_destinations.get(anchor_id).copied() else {
                         return Vec::new();
                     };
-                    let destination_page_id = first_page_id + u32::try_from(destination.page_index).unwrap_or(0);
+                    let destination_page_id =
+                        first_page_id + u32::try_from(destination.page_index).unwrap_or(0);
                     if destination_page_id >= first_stream_id {
                         return Vec::new();
                     }
@@ -2076,7 +2265,11 @@ fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
                         MARGIN_PT_V0,
                         destination.y_pt,
                     );
-                    offsets.push(write_pdf_obj(&mut out, annotation_id, annot_body.as_bytes()));
+                    offsets.push(write_pdf_obj(
+                        &mut out,
+                        annotation_id,
+                        annot_body.as_bytes(),
+                    ));
                 }
             }
             annotation_counter += 1;

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -1,17 +1,14 @@
 use super::{
     count_dvi_v2_text_movements_v0, count_dvi_v2_text_pages_v0,
-    count_dvi_v2_text_pages_with_advance_v0, validate_dvi_v2_empty_page_v0,
-    LinePlanV0,
-    parse_dvi_v2_text_page_to_layout_v0, plan_layout_v0, plan_layout_width_v0,
-    recompute_line_width_sp_v0,
-    render_dvi_v2_text_page_to_pdf_v0,
-    sum_dvi_v2_positive_right3_amounts_with_layout_v0, validate_dvi_v2_text_page_matches_layout_v0,
-    validate_dvi_v2_text_page_v0, validate_dvi_v2_text_page_with_layout_v0,
-    write_dvi_v2_empty_page_v0, write_dvi_v2_text_page_v0,
-    write_dvi_v2_text_page_from_layout_v0,
+    count_dvi_v2_text_pages_with_advance_v0, parse_dvi_v2_text_page_to_layout_v0, plan_layout_v0,
+    plan_layout_width_v0, recompute_line_width_sp_v0, render_dvi_v2_text_page_to_pdf_v0,
+    sum_dvi_v2_positive_right3_amounts_with_layout_v0, validate_dvi_v2_empty_page_v0,
+    validate_dvi_v2_text_page_matches_layout_v0, validate_dvi_v2_text_page_v0,
+    validate_dvi_v2_text_page_with_layout_v0, write_dvi_v2_empty_page_v0,
+    write_dvi_v2_text_page_from_layout_v0, write_dvi_v2_text_page_v0,
     write_dvi_v2_text_page_with_advance_v0, write_dvi_v2_text_page_with_layout_and_wrap_v0,
     write_dvi_v2_text_page_with_layout_v0, write_dvi_v2_text_page_with_layout_wrap_and_paging_v0,
-    DVI_DOWN3, DVI_EOP, DVI_FNT_DEF1, DVI_PRE, DVI_RIGHT3, DVI_TRAILER_BYTE,
+    LinePlanV0, DVI_DOWN3, DVI_EOP, DVI_FNT_DEF1, DVI_PRE, DVI_RIGHT3, DVI_TRAILER_BYTE,
 };
 
 #[test]
@@ -87,8 +84,9 @@ fn text_writer_uses_per_glyph_metrics_for_right3_amounts() {
     assert!(validate_dvi_v2_text_page_v0(&bytes));
     let movement = count_dvi_v2_text_movements_v0(&bytes).expect("movement summary should parse");
     assert_eq!(movement, (3, 0, 0, 0, 1));
-    let total = sum_dvi_v2_positive_right3_amounts_with_layout_v0(&bytes, glyph_advance_sp, 786_432)
-        .expect("sum parser should parse");
+    let total =
+        sum_dvi_v2_positive_right3_amounts_with_layout_v0(&bytes, glyph_advance_sp, 786_432)
+            .expect("sum parser should parse");
     assert_eq!(total, (65_536 * 5 / 2) as u32);
 }
 
@@ -115,7 +113,8 @@ fn planner_wrap_and_paging_shape_is_deterministic() {
 
 #[test]
 fn planner_forced_pagebreak_and_wrap_interaction_shape() {
-    let plan = plan_layout_v0(b"ABCDEFGH\x0cIJKLMNOP", 65_536, 786_432, 4, 10).expect("layout plan");
+    let plan =
+        plan_layout_v0(b"ABCDEFGH\x0cIJKLMNOP", 65_536, 786_432, 4, 10).expect("layout plan");
     assert_eq!(plan.pages.len(), 2);
     assert_eq!(plan.pages[0].lines.len(), 2);
     assert_eq!(plan.pages[1].lines.len(), 2);
@@ -139,8 +138,8 @@ fn planner_propagates_wi_dot_glyph_advances_and_line_width() {
 
 #[test]
 fn planner_space_and_punctuation_advances_are_stable_v0() {
-    let plan = plan_layout_width_v0(b"A ,.!? B", 65_536, 786_432, 10_000_000, 200)
-        .expect("layout plan");
+    let plan =
+        plan_layout_width_v0(b"A ,.!? B", 65_536, 786_432, 10_000_000, 200).expect("layout plan");
     assert_eq!(plan.pages.len(), 1);
     assert_eq!(plan.pages[0].lines.len(), 1);
     let line = &plan.pages[0].lines[0];
@@ -162,8 +161,8 @@ fn planner_space_and_punctuation_advances_are_stable_v0() {
 
 #[test]
 fn planner_variable_width_ratio_categories_are_stable_v0() {
-    let plan = plan_layout_width_v0(b"Wm i|.M", 65_536, 786_432, 10_000_000, 200)
-        .expect("layout plan");
+    let plan =
+        plan_layout_width_v0(b"Wm i|.M", 65_536, 786_432, 10_000_000, 200).expect("layout plan");
     assert_eq!(plan.pages.len(), 1);
     assert_eq!(plan.pages[0].lines.len(), 1);
     let line = &plan.pages[0].lines[0];
@@ -179,8 +178,8 @@ fn planner_variable_width_ratio_categories_are_stable_v0() {
 
 #[test]
 fn planner_width_wraps_long_line_at_spaces() {
-    let plan =
-        plan_layout_width_v0(b"aaaa bbbb cccc", 65_536, 786_432, 327_680, 200).expect("layout plan");
+    let plan = plan_layout_width_v0(b"aaaa bbbb cccc", 65_536, 786_432, 327_680, 200)
+        .expect("layout plan");
     assert_eq!(plan.pages.len(), 1);
     assert_eq!(plan.pages[0].lines.len(), 3);
     assert_eq!(
@@ -211,8 +210,7 @@ fn planner_width_wraps_long_line_at_spaces() {
 
 #[test]
 fn planner_width_uses_variable_space_width_v0() {
-    let plan =
-        plan_layout_width_v0(b"A A", 100, 786_432, 250, 200).expect("layout plan");
+    let plan = plan_layout_width_v0(b"A A", 100, 786_432, 250, 200).expect("layout plan");
     assert_eq!(plan.pages.len(), 1);
     assert_eq!(plan.pages[0].lines.len(), 1);
     assert_eq!(
@@ -227,8 +225,8 @@ fn planner_width_uses_variable_space_width_v0() {
 
 #[test]
 fn style_markers_have_zero_advance_and_roundtrip_v0() {
-    let layout = plan_layout_width_v0(b"A [B] {C}", 65_536, 786_432, 10_000_000, 200)
-        .expect("layout plan");
+    let layout =
+        plan_layout_width_v0(b"A [B] {C}", 65_536, 786_432, 10_000_000, 200).expect("layout plan");
     assert_eq!(layout.pages.len(), 1);
     assert_eq!(layout.pages[0].lines.len(), 1);
     let line = &layout.pages[0].lines[0];
@@ -261,7 +259,9 @@ fn pdf_renderer_keeps_multi_space_line_unwrapped_under_width_limit_v0() {
 
     let xdv = write_dvi_v2_text_page_from_layout_v0(&layout, 786_432).expect("xdv bytes");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
-    assert!(pdf.windows(b"(A     B) Tj".len()).any(|w| w == b"(A     B) Tj"));
+    assert!(pdf
+        .windows(b"(A     B) Tj".len())
+        .any(|w| w == b"(A     B) Tj"));
 }
 
 fn max_tm_gap_pt_for_line_containing_v0(pdf: &[u8], needle: &str) -> Option<f32> {
@@ -423,7 +423,11 @@ fn parse_tm_positions_in_line_v0(line: &str) -> Vec<(usize, f32, f32)> {
     positions
 }
 
-fn tm_x_for_segment_substring_v0(pdf: &[u8], line_needle: &str, segment_substring: &str) -> Option<f32> {
+fn tm_x_for_segment_substring_v0(
+    pdf: &[u8],
+    line_needle: &str,
+    segment_substring: &str,
+) -> Option<f32> {
     let text = String::from_utf8_lossy(pdf);
     for line in text.lines() {
         if !line.contains(line_needle) || !line.contains(segment_substring) {
@@ -781,7 +785,10 @@ fn width_sp_for_prefixed_rendered_line_v0(line: &LinePlanV0, prefix: [u8; 2]) ->
     Some(width_sp)
 }
 
-fn layout_line_width_for_exact_bytes_v0(layout: &super::LayoutPlanV0, target: &[u8]) -> Option<u32> {
+fn layout_line_width_for_exact_bytes_v0(
+    layout: &super::LayoutPlanV0,
+    target: &[u8],
+) -> Option<u32> {
     for page in &layout.pages {
         for line in &page.lines {
             let bytes: Vec<u8> = line.glyphs.iter().map(|glyph| glyph.byte).collect();
@@ -808,9 +815,8 @@ fn pdf_renderer_caps_segment_tm_gap_for_styled_line_v0() {
 
 #[test]
 fn pdf_renderer_inline_wrapper_spacing_invariants_v0() {
-    let xdv =
-        write_dvi_v2_text_page_v0(b"word[mid]word word [lead] trail,{bold}!")
-            .expect("writer should accept styled text");
+    let xdv = write_dvi_v2_text_page_v0(b"word[mid]word word [lead] trail,{bold}!")
+        .expect("writer should accept styled text");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
     let rendered = rendered_text_for_line_containing_segment_v0(&pdf, "word")
         .expect("styled line should decode");
@@ -818,11 +824,11 @@ fn pdf_renderer_inline_wrapper_spacing_invariants_v0() {
 
     let word_x = tm_xs_for_segment_text_v0(&pdf, "word")[0];
     let mid_x = tm_xs_for_segment_text_v0(&pdf, "mid")[0];
-    let trailing_word_x = tm_x_for_segment_substring_v0(&pdf, "(word)", "(word word )")
-        .expect("word word segment x");
+    let trailing_word_x =
+        tm_x_for_segment_substring_v0(&pdf, "(word)", "(word word )").expect("word word segment x");
     let lead_x = tm_xs_for_segment_text_v0(&pdf, "lead")[0];
-    let trail_x = tm_x_for_segment_substring_v0(&pdf, "(word)", "( trail,)")
-        .expect("trail segment x");
+    let trail_x =
+        tm_x_for_segment_substring_v0(&pdf, "(word)", "( trail,)").expect("trail segment x");
     let bold_x = tm_xs_for_segment_text_v0(&pdf, "bold")[0];
 
     let epsilon_pt = 0.02f32;
@@ -941,8 +947,8 @@ fn pdf_renderer_centers_title_block_lines_within_epsilon_v0() {
     let expected_date_x = expected_center_x_pt_v0(layout.pages[0].lines[2].width_sp);
 
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
-    let title_x = tm_x_for_line_containing_text_v0(&pdf, "(Centering Accuracy Title)")
-        .expect("title line x");
+    let title_x =
+        tm_x_for_line_containing_text_v0(&pdf, "(Centering Accuracy Title)").expect("title line x");
     let author_x = tm_x_for_line_containing_text_v0(&pdf, "(Alice Bob)").expect("author line x");
     let date_x = tm_x_for_line_containing_text_v0(&pdf, "(2026-03-05)").expect("date line x");
 
@@ -964,7 +970,8 @@ fn pdf_renderer_centers_title_block_lines_within_epsilon_v0() {
 #[test]
 fn pdf_renderer_centers_section_headings_within_epsilon_v0() {
     let demo_text = b"Title\nAuthor\n2026-03-05\n\nPrelude paragraph.\n\n{Centered Section Heading}\n\n~ Body after centered heading.";
-    let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept centered heading text");
+    let xdv =
+        write_dvi_v2_text_page_v0(demo_text).expect("writer should accept centered heading text");
     let layout = parse_dvi_v2_text_page_to_layout_v0(&xdv, 786_432).expect("layout parse");
     assert_eq!(layout.pages.len(), 1);
     let heading_line = layout.pages[0]
@@ -996,7 +1003,8 @@ fn pdf_renderer_centers_section_headings_within_epsilon_v0() {
 #[test]
 fn pdf_renderer_title_and_heading_centering_per_line_width_v0() {
     let demo_text = b"Centered Title Line\nAlice Bob\n2026-03-05\n\nPrelude paragraph.\n\n{Heading Alpha}\n\n~ Body alpha paragraph.\n\n{Heading Beta}\n\n~ Body beta paragraph.";
-    let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept title+heading demo");
+    let xdv =
+        write_dvi_v2_text_page_v0(demo_text).expect("writer should accept title+heading demo");
     let layout = parse_dvi_v2_text_page_to_layout_v0(&xdv, 786_432).expect("layout parse");
     let title_width = layout_line_width_for_exact_bytes_v0(&layout, b"Centered Title Line")
         .expect("title line width");
@@ -1010,12 +1018,11 @@ fn pdf_renderer_title_and_heading_centering_per_line_width_v0() {
     let expected_heading_beta_x = expected_center_x_pt_v0(heading_beta_width);
 
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
-    let title_x = tm_x_for_line_containing_text_v0(&pdf, "(Centered Title Line)")
-        .expect("title x");
-    let heading_alpha_x = tm_x_for_line_containing_text_v0(&pdf, "(Heading Alpha)")
-        .expect("heading alpha x");
-    let heading_beta_x = tm_x_for_line_containing_text_v0(&pdf, "(Heading Beta)")
-        .expect("heading beta x");
+    let title_x = tm_x_for_line_containing_text_v0(&pdf, "(Centered Title Line)").expect("title x");
+    let heading_alpha_x =
+        tm_x_for_line_containing_text_v0(&pdf, "(Heading Alpha)").expect("heading alpha x");
+    let heading_beta_x =
+        tm_x_for_line_containing_text_v0(&pdf, "(Heading Beta)").expect("heading beta x");
 
     let epsilon_pt = 0.02f32;
     assert!(
@@ -1057,13 +1064,22 @@ fn pdf_renderer_heading_font_hierarchy_invariants_v0() {
     let subsection_size = subsection_sizes[0];
     let body_size = body_sizes[0];
 
-    assert!((title_size - 18.0).abs() <= 0.02, "title font size mismatch: {title_size}");
-    assert!((section_size - 16.0).abs() <= 0.02, "section font size mismatch: {section_size}");
+    assert!(
+        (title_size - 18.0).abs() <= 0.02,
+        "title font size mismatch: {title_size}"
+    );
+    assert!(
+        (section_size - 16.0).abs() <= 0.02,
+        "section font size mismatch: {section_size}"
+    );
     assert!(
         (subsection_size - 14.0).abs() <= 0.02,
         "subsection font size mismatch: {subsection_size}"
     );
-    assert!((body_size - 12.0).abs() <= 0.02, "body font size mismatch: {body_size}");
+    assert!(
+        (body_size - 12.0).abs() <= 0.02,
+        "body font size mismatch: {body_size}"
+    );
     assert!(
         title_size > section_size && section_size > subsection_size && subsection_size > body_size,
         "font hierarchy must be strict: title={title_size}, section={section_size}, subsection={subsection_size}, body={body_size}"
@@ -1073,19 +1089,21 @@ fn pdf_renderer_heading_font_hierarchy_invariants_v0() {
 #[test]
 fn pdf_renderer_paragraph_rhythm_and_noindent_invariants_v0() {
     let demo_text = b"Title\nAuthor\n2026-03-05\n\nFirst paragraph line one.\nSecond line same paragraph.\n\nSecond paragraph line.\n\n@S {Heading}\n\n~ After heading noindent line.\n\nIndented paragraph line.";
-    let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept paragraph rhythm demo");
+    let xdv =
+        write_dvi_v2_text_page_v0(demo_text).expect("writer should accept paragraph rhythm demo");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
 
-    let (first_x, first_y) = tm_position_for_line_containing_text_v0(&pdf, "(First paragraph line one.)")
-        .expect("first paragraph line one");
+    let (first_x, first_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(First paragraph line one.)")
+            .expect("first paragraph line one");
     let (same_para_x, same_para_y) =
         tm_position_for_line_containing_text_v0(&pdf, "(Second line same paragraph.)")
             .expect("same paragraph line");
     let (second_para_x, second_para_y) =
         tm_position_for_line_containing_text_v0(&pdf, "(Second paragraph line.)")
             .expect("second paragraph line");
-    let (heading_x, heading_y) = tm_position_for_line_containing_text_v0(&pdf, "(Heading)")
-        .expect("heading line");
+    let (heading_x, heading_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Heading)").expect("heading line");
     let (after_heading_x, after_heading_y) =
         tm_position_for_line_containing_text_v0(&pdf, "(After heading noindent line.)")
             .expect("after heading line");
@@ -1094,12 +1112,18 @@ fn pdf_renderer_paragraph_rhythm_and_noindent_invariants_v0() {
             .expect("indented paragraph line");
 
     let epsilon_pt = 0.02f32;
-    assert!((first_x - 72.0).abs() <= epsilon_pt, "first paragraph x mismatch: {first_x}");
+    assert!(
+        (first_x - 72.0).abs() <= epsilon_pt,
+        "first paragraph x mismatch: {first_x}"
+    );
     assert!(
         (same_para_x - 72.0).abs() <= epsilon_pt,
         "same paragraph line should stay non-indented: {same_para_x}"
     );
-    assert!((second_para_x - 96.0).abs() <= epsilon_pt, "second paragraph indent mismatch: {second_para_x}");
+    assert!(
+        (second_para_x - 96.0).abs() <= epsilon_pt,
+        "second paragraph indent mismatch: {second_para_x}"
+    );
     assert!(
         (after_heading_x - 72.0).abs() <= epsilon_pt,
         "first paragraph after heading should noindent: {after_heading_x}"
@@ -1128,7 +1152,10 @@ fn pdf_renderer_paragraph_rhythm_and_noindent_invariants_v0() {
         (after_heading_y - indented_y - 28.0).abs() <= epsilon_pt,
         "noindent->indented paragraph gap mismatch: after_heading_y={after_heading_y}, indented_y={indented_y}"
     );
-    assert!((heading_x - 72.0).abs() > 0.5, "heading should be centered: {heading_x}");
+    assert!(
+        (heading_x - 72.0).abs() > 0.5,
+        "heading should be centered: {heading_x}"
+    );
 }
 
 #[test]
@@ -1141,20 +1168,15 @@ fn pdf_renderer_list_rhythm_and_wrap_indent_invariants_v0() {
         tm_position_for_line_containing_text_v0(&pdf, "(Paragraph before list.)")
             .expect("before list paragraph");
     let (item_one_bullet_x, item_one_y) =
-        tm_position_for_segment_substring_v0(&pdf, "(-)")
-            .expect("item one bullet position");
+        tm_position_for_segment_substring_v0(&pdf, "(-)").expect("item one bullet position");
     let (item_one_body_x, _) =
-        tm_position_for_segment_substring_v0(&pdf, "(ITEMONE")
-            .expect("item one body position");
+        tm_position_for_segment_substring_v0(&pdf, "(ITEMONE").expect("item one body position");
     let (item_one_wrap_x, _) =
-        tm_position_for_segment_substring_v0(&pdf, "WRAPONE")
-            .expect("item one wrap position");
+        tm_position_for_segment_substring_v0(&pdf, "WRAPONE").expect("item one wrap position");
     let (item_two_bullet_x, item_two_y) =
-        tm_position_for_segment_substring_v0(&pdf, "(ITEMTWO")
-            .expect("item two body position");
+        tm_position_for_segment_substring_v0(&pdf, "(ITEMTWO").expect("item two body position");
     let (item_two_wrap_x, _) =
-        tm_position_for_segment_substring_v0(&pdf, "WRAPTWO")
-            .expect("item two wrap position");
+        tm_position_for_segment_substring_v0(&pdf, "WRAPTWO").expect("item two wrap position");
     let (_, after_list_y) =
         tm_position_for_line_containing_text_v0(&pdf, "(Paragraph after list.)")
             .expect("after list paragraph");
@@ -1192,17 +1214,22 @@ fn pdf_renderer_list_rhythm_and_wrap_indent_invariants_v0() {
 
 #[test]
 fn pdf_renderer_paragraph_indent_and_line_gap_invariants_v0() {
-    let demo_text = b"Title\nAuthor\n2026-03-05\n\nFirst body paragraph line.\n\nSecond paragraph line.";
+    let demo_text =
+        b"Title\nAuthor\n2026-03-05\n\nFirst body paragraph line.\n\nSecond paragraph line.";
     let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept demo text");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
 
-    let (first_x, first_y) = tm_position_for_line_containing_text_v0(&pdf, "(First body paragraph line.)")
-        .expect("first body line position");
+    let (first_x, first_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(First body paragraph line.)")
+            .expect("first body line position");
     let (second_x, second_y) =
         tm_position_for_line_containing_text_v0(&pdf, "(Second paragraph line.)")
             .expect("second paragraph line position");
 
-    assert!((first_x - 72.0).abs() <= 0.02, "first paragraph x mismatch: {first_x}");
+    assert!(
+        (first_x - 72.0).abs() <= 0.02,
+        "first paragraph x mismatch: {first_x}"
+    );
     assert!(
         (second_x - 96.0).abs() <= 0.02,
         "indented paragraph x mismatch: {second_x}"
@@ -1220,14 +1247,13 @@ fn pdf_renderer_section_heading_spacing_invariants_v0() {
     let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept heading text");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
 
-    let (intro_x, intro_y) =
-        tm_position_for_line_containing_text_v0(&pdf, "(Intro paragraph.)").expect("intro position");
+    let (intro_x, intro_y) = tm_position_for_line_containing_text_v0(&pdf, "(Intro paragraph.)")
+        .expect("intro position");
     let (_, heading_y) = tm_position_for_line_containing_text_v0(&pdf, "(Section Heading)")
         .expect("heading position");
-    assert!(
-        !pdf.windows(b"(~ Body after heading.) Tj".len())
-            .any(|w| w == b"(~ Body after heading.) Tj")
-    );
+    assert!(!pdf
+        .windows(b"(~ Body after heading.) Tj".len())
+        .any(|w| w == b"(~ Body after heading.) Tj"));
     let (body_x, body_y) = tm_position_for_line_containing_text_v0(&pdf, "(Body after heading.)")
         .expect("body position");
 
@@ -1239,7 +1265,10 @@ fn pdf_renderer_section_heading_spacing_invariants_v0() {
         (heading_y - body_y - 28.0).abs() <= 0.02,
         "heading->body y-gap mismatch: heading_y={heading_y}, body_y={body_y}"
     );
-    assert!((intro_x - 72.0).abs() <= 0.02, "intro x mismatch: {intro_x}");
+    assert!(
+        (intro_x - 72.0).abs() <= 0.02,
+        "intro x mismatch: {intro_x}"
+    );
     assert!(
         (body_x - 72.0).abs() <= 0.02,
         "first paragraph after heading should not indent: {body_x}"
@@ -1252,12 +1281,13 @@ fn pdf_renderer_heading_list_quote_rhythm_invariants_v0() {
     let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept rhythm text");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
 
-    let (_, prelude_y) =
-        tm_position_for_line_containing_text_v0(&pdf, "(Prelude paragraph.)").expect("prelude position");
+    let (_, prelude_y) = tm_position_for_line_containing_text_v0(&pdf, "(Prelude paragraph.)")
+        .expect("prelude position");
     let (_, heading_y) =
         tm_position_for_line_containing_text_v0(&pdf, "(Heading)").expect("heading position");
-    let (_, after_heading_y) = tm_position_for_line_containing_text_v0(&pdf, "(After heading paragraph.)")
-        .expect("after heading position");
+    let (_, after_heading_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(After heading paragraph.)")
+            .expect("after heading position");
     let (_, list_one_y) =
         tm_position_for_line_containing_text_v0(&pdf, "(First list item)").expect("list one");
     let (_, list_two_y) =
@@ -1305,7 +1335,8 @@ fn pdf_renderer_heading_list_quote_rhythm_invariants_v0() {
 
 #[test]
 fn pdf_renderer_applies_hanging_indent_for_list_continuation_v0() {
-    let xdv = write_dvi_v2_text_page_v0(b"- item\ncontinuation").expect("writer should accept text");
+    let xdv =
+        write_dvi_v2_text_page_v0(b"- item\ncontinuation").expect("writer should accept text");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
 
     let pdf_text = String::from_utf8_lossy(&pdf);
@@ -1322,7 +1353,10 @@ fn pdf_renderer_applies_hanging_indent_for_list_continuation_v0() {
             xs.push(x_pt);
         }
     }
-    assert!(xs.len() >= 2, "expected at least two text lines, got {xs:?}");
+    assert!(
+        xs.len() >= 2,
+        "expected at least two text lines, got {xs:?}"
+    );
     assert!((xs[0] - 72.0).abs() <= 0.02, "first list line x={}", xs[0]);
     assert!(xs[1] > xs[0], "continuation should hang-indent: {xs:?}");
 }
@@ -1333,7 +1367,8 @@ fn pdf_renderer_itemize_bullet_and_body_x_offsets_invariants_v0() {
         .expect("writer should accept list text");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
     assert!(
-        !pdf.windows(b"(- alpha) Tj".len()).any(|w| w == b"(- alpha) Tj"),
+        !pdf.windows(b"(- alpha) Tj".len())
+            .any(|w| w == b"(- alpha) Tj"),
         "prefix should be split from body"
     );
 
@@ -1343,11 +1378,19 @@ fn pdf_renderer_itemize_bullet_and_body_x_offsets_invariants_v0() {
     let continuation_xs = tm_xs_for_segment_text_v0(&pdf, "continuation");
     let continuation_two_xs = tm_xs_for_segment_text_v0(&pdf, "continuationtwo");
 
-    assert_eq!(bullet_xs.len(), 2, "expected two bullet renders: {bullet_xs:?}");
+    assert_eq!(
+        bullet_xs.len(),
+        2,
+        "expected two bullet renders: {bullet_xs:?}"
+    );
     assert_eq!(alpha_xs.len(), 1, "expected alpha render");
     assert_eq!(beta_xs.len(), 1, "expected beta render");
     assert_eq!(continuation_xs.len(), 1, "expected continuation render");
-    assert_eq!(continuation_two_xs.len(), 1, "expected continuationtwo render");
+    assert_eq!(
+        continuation_two_xs.len(),
+        1,
+        "expected continuationtwo render"
+    );
 
     let epsilon_pt = 0.02f32;
     for x in &bullet_xs {
@@ -1369,7 +1412,8 @@ fn pdf_renderer_enumerate_number_column_alignment_invariants_v0() {
         .expect("writer should accept enumerate text");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
     assert!(
-        !pdf.windows(b"(9. nine) Tj".len()).any(|w| w == b"(9. nine) Tj"),
+        !pdf.windows(b"(9. nine) Tj".len())
+            .any(|w| w == b"(9. nine) Tj"),
         "prefix should be split from body"
     );
 
@@ -1472,7 +1516,10 @@ fn pdf_renderer_nested_list_indentation_and_wrap_invariants_v0() {
     assert_eq!(nested_wrap_x.len(), 1, "expected nested wrap render");
 
     let epsilon_pt = 0.02f32;
-    assert!((bullet_xs[0] - 72.0).abs() <= epsilon_pt, "outer bullet x mismatch");
+    assert!(
+        (bullet_xs[0] - 72.0).abs() <= epsilon_pt,
+        "outer bullet x mismatch"
+    );
     assert!(
         bullet_xs[1] > bullet_xs[0],
         "nested bullet should shift right: {bullet_xs:?}"
@@ -1507,14 +1554,12 @@ fn pdf_renderer_applies_quote_indent_and_hides_prefix_v0() {
     let xdv = write_dvi_v2_text_page_v0(b"\n> quoted line\ncontinuation line")
         .expect("writer should accept text");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
-    assert!(
-        !pdf.windows(b"(> quoted line) Tj".len())
-            .any(|w| w == b"(> quoted line) Tj")
-    );
-    assert!(
-        pdf.windows(b"(quoted line) Tj".len())
-            .any(|w| w == b"(quoted line) Tj")
-    );
+    assert!(!pdf
+        .windows(b"(> quoted line) Tj".len())
+        .any(|w| w == b"(> quoted line) Tj"));
+    assert!(pdf
+        .windows(b"(quoted line) Tj".len())
+        .any(|w| w == b"(quoted line) Tj"));
 
     let pdf_text = String::from_utf8_lossy(&pdf);
     let mut xs = Vec::<f32>::new();
@@ -1530,9 +1575,15 @@ fn pdf_renderer_applies_quote_indent_and_hides_prefix_v0() {
             xs.push(x_pt);
         }
     }
-    assert!(xs.len() >= 2, "expected at least two rendered lines, got {xs:?}");
+    assert!(
+        xs.len() >= 2,
+        "expected at least two rendered lines, got {xs:?}"
+    );
     assert!(xs[0] > 72.0, "quote line should be indented: {xs:?}");
-    assert!((xs[0] - xs[1]).abs() <= 0.02, "quote continuation should keep indent: {xs:?}");
+    assert!(
+        (xs[0] - xs[1]).abs() <= 0.02,
+        "quote continuation should keep indent: {xs:?}"
+    );
 }
 
 #[test]
@@ -1557,21 +1608,36 @@ fn pdf_renderer_quote_indent_and_paragraph_break_invariants_v0() {
         tm_position_for_line_containing_text_v0(&pdf, "(second continuation)").expect("line 4");
 
     let epsilon_pt = 0.02f32;
-    assert!((x1 - x2).abs() <= epsilon_pt, "quote line x drift: {x1} vs {x2}");
-    assert!((x1 - x3).abs() <= epsilon_pt, "quote paragraph x drift: {x1} vs {x3}");
-    assert!((x1 - x4).abs() <= epsilon_pt, "quote line x drift: {x1} vs {x4}");
-    assert!((y1 - y2 - 14.0).abs() <= epsilon_pt, "quote line gap mismatch");
+    assert!(
+        (x1 - x2).abs() <= epsilon_pt,
+        "quote line x drift: {x1} vs {x2}"
+    );
+    assert!(
+        (x1 - x3).abs() <= epsilon_pt,
+        "quote paragraph x drift: {x1} vs {x3}"
+    );
+    assert!(
+        (x1 - x4).abs() <= epsilon_pt,
+        "quote line x drift: {x1} vs {x4}"
+    );
+    assert!(
+        (y1 - y2 - 14.0).abs() <= epsilon_pt,
+        "quote line gap mismatch"
+    );
     assert!(
         (y2 - y3 - 28.0).abs() <= epsilon_pt,
         "quote paragraph gap mismatch"
     );
-    assert!((y3 - y4 - 14.0).abs() <= epsilon_pt, "quote line gap mismatch");
+    assert!(
+        (y3 - y4 - 14.0).abs() <= epsilon_pt,
+        "quote line gap mismatch"
+    );
 }
 
 #[test]
 fn pdf_renderer_hides_center_prefix_and_centers_line_v0() {
-    let xdv =
-        write_dvi_v2_text_page_v0(b"\n^ centered line").expect("writer should accept centered text");
+    let xdv = write_dvi_v2_text_page_v0(b"\n^ centered line")
+        .expect("writer should accept centered text");
     let layout = parse_dvi_v2_text_page_to_layout_v0(&xdv, 786_432).expect("layout parse");
     let centered_line = layout.pages[0]
         .lines
@@ -1579,19 +1645,18 @@ fn pdf_renderer_hides_center_prefix_and_centers_line_v0() {
         .find(|line| width_sp_for_prefixed_rendered_line_v0(line, [b'^', b' ']).is_some())
         .expect("center-prefixed line");
     let expected_x = expected_center_x_pt_v0(
-        width_sp_for_prefixed_rendered_line_v0(centered_line, [b'^', b' ']).expect("prefixed width"),
+        width_sp_for_prefixed_rendered_line_v0(centered_line, [b'^', b' '])
+            .expect("prefixed width"),
     );
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
-    assert!(
-        !pdf.windows(b"(^ centered line) Tj".len())
-            .any(|w| w == b"(^ centered line) Tj")
-    );
-    assert!(
-        pdf.windows(b"(centered line) Tj".len())
-            .any(|w| w == b"(centered line) Tj")
-    );
-    let x_pt = tm_x_for_line_containing_text_v0(&pdf, "(centered line)")
-        .expect("centered Tm position");
+    assert!(!pdf
+        .windows(b"(^ centered line) Tj".len())
+        .any(|w| w == b"(^ centered line) Tj"));
+    assert!(pdf
+        .windows(b"(centered line) Tj".len())
+        .any(|w| w == b"(centered line) Tj"));
+    let x_pt =
+        tm_x_for_line_containing_text_v0(&pdf, "(centered line)").expect("centered Tm position");
     let epsilon_pt = 0.02f32;
     assert!(
         (x_pt - expected_x).abs() <= epsilon_pt,
@@ -1601,8 +1666,8 @@ fn pdf_renderer_hides_center_prefix_and_centers_line_v0() {
 
 #[test]
 fn pdf_renderer_hides_right_prefix_and_right_aligns_line_v0() {
-    let xdv =
-        write_dvi_v2_text_page_v0(b"\n| right aligned line").expect("writer should accept right text");
+    let xdv = write_dvi_v2_text_page_v0(b"\n| right aligned line")
+        .expect("writer should accept right text");
     let layout = parse_dvi_v2_text_page_to_layout_v0(&xdv, 786_432).expect("layout parse");
     let right_line = layout.pages[0]
         .lines
@@ -1613,14 +1678,12 @@ fn pdf_renderer_hides_right_prefix_and_right_aligns_line_v0() {
         width_sp_for_prefixed_rendered_line_v0(right_line, [b'|', b' ']).expect("prefixed width"),
     );
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
-    assert!(
-        !pdf.windows(b"(| right aligned line) Tj".len())
-            .any(|w| w == b"(| right aligned line) Tj")
-    );
-    assert!(
-        pdf.windows(b"(right aligned line) Tj".len())
-            .any(|w| w == b"(right aligned line) Tj")
-    );
+    assert!(!pdf
+        .windows(b"(| right aligned line) Tj".len())
+        .any(|w| w == b"(| right aligned line) Tj"));
+    assert!(pdf
+        .windows(b"(right aligned line) Tj".len())
+        .any(|w| w == b"(right aligned line) Tj"));
     let x_pt = tm_x_for_line_containing_text_v0(&pdf, "(right aligned line)")
         .expect("right-aligned Tm position");
     let epsilon_pt = 0.02f32;
@@ -1639,14 +1702,22 @@ fn pdf_renderer_applies_center_alignment_per_line_width_v0() {
         .lines
         .iter()
         .find(|line| {
-            line.glyphs.iter().map(|glyph| glyph.byte).collect::<Vec<_>>() == b"^ center one"
+            line.glyphs
+                .iter()
+                .map(|glyph| glyph.byte)
+                .collect::<Vec<_>>()
+                == b"^ center one"
         })
         .expect("center line one");
     let line_two = layout.pages[0]
         .lines
         .iter()
         .find(|line| {
-            line.glyphs.iter().map(|glyph| glyph.byte).collect::<Vec<_>>() == b"^ center line two"
+            line.glyphs
+                .iter()
+                .map(|glyph| glyph.byte)
+                .collect::<Vec<_>>()
+                == b"^ center line two"
         })
         .expect("center line two");
 
@@ -1675,14 +1746,22 @@ fn pdf_renderer_applies_right_alignment_per_line_width_v0() {
         .lines
         .iter()
         .find(|line| {
-            line.glyphs.iter().map(|glyph| glyph.byte).collect::<Vec<_>>() == b"| right one"
+            line.glyphs
+                .iter()
+                .map(|glyph| glyph.byte)
+                .collect::<Vec<_>>()
+                == b"| right one"
         })
         .expect("right line one");
     let line_two = layout.pages[0]
         .lines
         .iter()
         .find(|line| {
-            line.glyphs.iter().map(|glyph| glyph.byte).collect::<Vec<_>>() == b"| right line two"
+            line.glyphs
+                .iter()
+                .map(|glyph| glyph.byte)
+                .collect::<Vec<_>>()
+                == b"| right line two"
         })
         .expect("right line two");
 
@@ -1711,7 +1790,10 @@ fn pdf_renderer_center_alignment_handles_styled_segments_without_drift_v0() {
         .lines
         .iter()
         .find(|line| {
-            line.glyphs.iter().map(|glyph| glyph.byte).collect::<Vec<_>>()
+            line.glyphs
+                .iter()
+                .map(|glyph| glyph.byte)
+                .collect::<Vec<_>>()
                 == b"^ alpha[mid],gamma"
         })
         .expect("center styled line one");
@@ -1719,7 +1801,11 @@ fn pdf_renderer_center_alignment_handles_styled_segments_without_drift_v0() {
         .lines
         .iter()
         .find(|line| {
-            line.glyphs.iter().map(|glyph| glyph.byte).collect::<Vec<_>>() == b"^ short{bold}."
+            line.glyphs
+                .iter()
+                .map(|glyph| glyph.byte)
+                .collect::<Vec<_>>()
+                == b"^ short{bold}."
         })
         .expect("center styled line two");
 
@@ -1745,8 +1831,8 @@ fn pdf_renderer_center_alignment_handles_styled_segments_without_drift_v0() {
 
     let alpha_x = tm_xs_for_segment_text_v0(&pdf, "alpha")[0];
     let mid_x = tm_xs_for_segment_text_v0(&pdf, "mid")[0];
-    let gamma_x = tm_x_for_segment_substring_v0(&pdf, "(alpha)", "(,gamma)")
-        .expect("gamma segment x");
+    let gamma_x =
+        tm_x_for_segment_substring_v0(&pdf, "(alpha)", "(,gamma)").expect("gamma segment x");
     assert!(
         ((mid_x - alpha_x) - segment_width_pt_v0(b"alpha")).abs() <= epsilon_pt,
         "alpha->mid spacing drift: alpha_x={alpha_x}, mid_x={mid_x}"
@@ -1766,7 +1852,10 @@ fn pdf_renderer_right_alignment_handles_styled_segments_without_drift_v0() {
         .lines
         .iter()
         .find(|line| {
-            line.glyphs.iter().map(|glyph| glyph.byte).collect::<Vec<_>>()
+            line.glyphs
+                .iter()
+                .map(|glyph| glyph.byte)
+                .collect::<Vec<_>>()
                 == b"| edge, [core] trail"
         })
         .expect("right styled line one");
@@ -1774,7 +1863,11 @@ fn pdf_renderer_right_alignment_handles_styled_segments_without_drift_v0() {
         .lines
         .iter()
         .find(|line| {
-            line.glyphs.iter().map(|glyph| glyph.byte).collect::<Vec<_>>() == b"| alpha{beta}."
+            line.glyphs
+                .iter()
+                .map(|glyph| glyph.byte)
+                .collect::<Vec<_>>()
+                == b"| alpha{beta}."
         })
         .expect("right styled line two");
 
@@ -1798,11 +1891,11 @@ fn pdf_renderer_right_alignment_handles_styled_segments_without_drift_v0() {
         "line two right drift: actual={line_two_x}, expected={expected_two}"
     );
 
-    let edge_x = tm_x_for_segment_substring_v0(&pdf, "(edge, )", "(edge, )")
-        .expect("edge segment x");
+    let edge_x =
+        tm_x_for_segment_substring_v0(&pdf, "(edge, )", "(edge, )").expect("edge segment x");
     let core_x = tm_xs_for_segment_text_v0(&pdf, "core")[0];
-    let trail_x = tm_x_for_segment_substring_v0(&pdf, "(edge, )", "( trail)")
-        .expect("trail segment x");
+    let trail_x =
+        tm_x_for_segment_substring_v0(&pdf, "(edge, )", "( trail)").expect("trail segment x");
     assert!(
         ((core_x - edge_x) - segment_width_pt_v0(b"edge, ")).abs() <= epsilon_pt,
         "edge->core spacing drift: edge_x={edge_x}, core_x={core_x}"
@@ -1821,7 +1914,9 @@ fn parse_roundtrips_writer_layout_for_wrap_and_paging() {
         .expect("writer output");
     let parsed = parse_dvi_v2_text_page_to_layout_v0(&bytes, 786_432).expect("parsed layout");
     assert_eq!(parsed, layout);
-    assert!(validate_dvi_v2_text_page_matches_layout_v0(&bytes, &layout, 786_432));
+    assert!(validate_dvi_v2_text_page_matches_layout_v0(
+        &bytes, &layout, 786_432
+    ));
 }
 
 #[test]
@@ -1915,14 +2010,12 @@ fn pdf_renderer_uses_helvetica_base_fonts_v0() {
     let bytes = write_dvi_v2_text_page_v0(b"A [B] {C}").expect("writer should accept text");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&bytes).expect("pdf render");
     assert!(pdf.windows(b"/Helvetica".len()).any(|w| w == b"/Helvetica"));
-    assert!(
-        pdf.windows(b"/Helvetica-Oblique".len())
-            .any(|w| w == b"/Helvetica-Oblique")
-    );
-    assert!(
-        pdf.windows(b"/Helvetica-Bold".len())
-            .any(|w| w == b"/Helvetica-Bold")
-    );
+    assert!(pdf
+        .windows(b"/Helvetica-Oblique".len())
+        .any(|w| w == b"/Helvetica-Oblique"));
+    assert!(pdf
+        .windows(b"/Helvetica-Bold".len())
+        .any(|w| w == b"/Helvetica-Bold"));
 }
 
 #[test]
@@ -2029,11 +2122,10 @@ fn pdf_renderer_footnote_block_renders_at_page_bottom_with_small_font_v0() {
         "internal footnote prefix should be hidden in pdf output: {pdf_text}"
     );
 
-    let body_pos = tm_position_for_segment_substring_v0(&pdf, "(Body")
-        .expect("body segment position");
-    let footnote_pos =
-        tm_position_for_line_containing_text_v0(&pdf, "(1 Footnote text with ")
-            .expect("footnote line position");
+    let body_pos =
+        tm_position_for_segment_substring_v0(&pdf, "(Body").expect("body segment position");
+    let footnote_pos = tm_position_for_line_containing_text_v0(&pdf, "(1 Footnote text with ")
+        .expect("footnote line position");
     assert!(
         footnote_pos.1 < body_pos.1,
         "footnote should render below body line: body_y={} footnote_y={}",
@@ -2101,8 +2193,7 @@ fn pdf_renderer_link_style_near_punctuation_stays_single_matrix_v0() {
 
     let see_x = tm_xs_for_segment_text_v0(&pdf, "See,")[0];
     let example_x = tm_xs_for_segment_text_v0(&pdf, "Example")[0];
-    let tail_x = tm_x_for_segment_substring_v0(&pdf, "(See,)", "(. Tail)")
-        .expect("tail segment x");
+    let tail_x = tm_x_for_segment_substring_v0(&pdf, "(See,)", "(. Tail)").expect("tail segment x");
     let epsilon_pt = 0.02f32;
     assert!(
         ((example_x - see_x) - segment_width_pt_v0(b"See,")).abs() <= epsilon_pt,
@@ -2125,7 +2216,10 @@ fn pdf_renderer_inline_math_placeholder_keeps_single_text_matrix_v0() {
         "inline math placeholder line should render: {pdf_text}"
     );
     let tm_count = tm_count_for_line_containing_v0(&pdf, "(Before MATH after.)");
-    assert_eq!(tm_count, 1, "inline placeholder line should use a single Tm");
+    assert_eq!(
+        tm_count, 1,
+        "inline placeholder line should use a single Tm"
+    );
 }
 
 #[test]
@@ -2137,9 +2231,7 @@ fn pdf_renderer_display_math_placeholder_line_is_centered_v0() {
         .lines
         .iter()
         .find(|line| {
-            line.glyphs.len() >= 2
-                && line.glyphs[0].byte == b'^'
-                && line.glyphs[1].byte == b' '
+            line.glyphs.len() >= 2 && line.glyphs[0].byte == b'^' && line.glyphs[1].byte == b' '
         })
         .expect("display line with center prefix should exist");
     let display_width_pt: f32 = display_line.glyphs[2..]
@@ -2164,9 +2256,8 @@ fn pdf_renderer_display_math_placeholder_line_is_centered_v0() {
 
 #[test]
 fn pdf_renderer_emits_link_annotation_with_in_bounds_rect_v0() {
-    let xdv =
-        write_dvi_v2_text_page_v0(b"Visit <{Example link}> now.\n\n!u 1 https://example.com")
-            .expect("writer should accept href marker lines");
+    let xdv = write_dvi_v2_text_page_v0(b"Visit <{Example link}> now.\n\n!u 1 https://example.com")
+        .expect("writer should accept href marker lines");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
     let pdf_text = String::from_utf8_lossy(&pdf);
     assert!(
@@ -2223,10 +2314,8 @@ fn pdf_renderer_emits_internal_ref_and_external_href_annotations_v0() {
 
 #[test]
 fn pdf_renderer_rejects_ref_annotation_target_with_missing_anchor_v0() {
-    let xdv = write_dvi_v2_text_page_v0(
-        b"See <1> only.\n\n!r sec:intro 1 1\n!ra 1 1",
-    )
-    .expect("writer should accept marker lines");
+    let xdv = write_dvi_v2_text_page_v0(b"See <1> only.\n\n!r sec:intro 1 1\n!ra 1 1")
+        .expect("writer should accept marker lines");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
     assert!(
         pdf.is_none(),
@@ -2268,23 +2357,39 @@ fn pdf_renderer_multipage_footnotes_and_annots_associate_per_page_v0() {
     )
     .expect("writer should accept multipage marker data");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
-    assert_eq!(count_pdf_page_objects_v0(&pdf), 2, "expected two page objects");
+    assert_eq!(
+        count_pdf_page_objects_v0(&pdf),
+        2,
+        "expected two page objects"
+    );
 
     let page_one = parse_pdf_object_body_v0(&pdf, 3).expect("page 1 object");
     let page_two = parse_pdf_object_body_v0(&pdf, 4).expect("page 2 object");
     let page_one_annots = parse_pdf_ref_ids_v0(&page_one, "/Annots");
     let page_two_annots = parse_pdf_ref_ids_v0(&page_two, "/Annots");
-    assert_eq!(page_one_annots.len(), 1, "page 1 should have one annotation");
-    assert_eq!(page_two_annots.len(), 1, "page 2 should have one annotation");
+    assert_eq!(
+        page_one_annots.len(),
+        1,
+        "page 1 should have one annotation"
+    );
+    assert_eq!(
+        page_two_annots.len(),
+        1,
+        "page 2 should have one annotation"
+    );
     assert_ne!(
         page_one_annots[0], page_two_annots[0],
         "each page should reference its own annotation object"
     );
 
-    let annotation_one = parse_pdf_object_body_v0(&pdf, page_one_annots[0]).expect("annotation one");
-    let annotation_two = parse_pdf_object_body_v0(&pdf, page_two_annots[0]).expect("annotation two");
-    let action_one = parse_pdf_annotation_action_id_v0(&annotation_one).expect("annotation one action");
-    let action_two = parse_pdf_annotation_action_id_v0(&annotation_two).expect("annotation two action");
+    let annotation_one =
+        parse_pdf_object_body_v0(&pdf, page_one_annots[0]).expect("annotation one");
+    let annotation_two =
+        parse_pdf_object_body_v0(&pdf, page_two_annots[0]).expect("annotation two");
+    let action_one =
+        parse_pdf_annotation_action_id_v0(&annotation_one).expect("annotation one action");
+    let action_two =
+        parse_pdf_annotation_action_id_v0(&annotation_two).expect("annotation two action");
     let action_one_body = parse_pdf_object_body_v0(&pdf, action_one).expect("action one body");
     let action_two_body = parse_pdf_object_body_v0(&pdf, action_two).expect("action two body");
     assert_eq!(
@@ -2302,8 +2407,14 @@ fn pdf_renderer_multipage_footnotes_and_annots_associate_per_page_v0() {
         parse_pdf_annotation_rect_v0(&annotation_one).expect("annotation one rect"),
         parse_pdf_annotation_rect_v0(&annotation_two).expect("annotation two rect"),
     ] {
-        assert!(rect[2] > rect[0], "annotation width must be positive: {rect:?}");
-        assert!(rect[3] > rect[1], "annotation height must be positive: {rect:?}");
+        assert!(
+            rect[2] > rect[0],
+            "annotation width must be positive: {rect:?}"
+        );
+        assert!(
+            rect[3] > rect[1],
+            "annotation height must be positive: {rect:?}"
+        );
         assert!(
             rect[0] >= 0.0 && rect[1] >= 0.0 && rect[2] <= 612.0 && rect[3] <= 792.0,
             "annotation rect must stay within page bounds: {rect:?}"
@@ -2312,14 +2423,12 @@ fn pdf_renderer_multipage_footnotes_and_annots_associate_per_page_v0() {
 
     let stream_one = parse_pdf_object_body_v0(&pdf, 5).expect("stream one body");
     let stream_two = parse_pdf_object_body_v0(&pdf, 6).expect("stream two body");
-    let page_one_footnote_y =
-        tm_position_for_line_containing_text_in_body_v0(&stream_one, "(1")
-            .expect("page one footnote line")
-            .1;
-    let page_two_footnote_y =
-        tm_position_for_line_containing_text_in_body_v0(&stream_two, "(2")
-            .expect("page two footnote line")
-            .1;
+    let page_one_footnote_y = tm_position_for_line_containing_text_in_body_v0(&stream_one, "(1")
+        .expect("page one footnote line")
+        .1;
+    let page_two_footnote_y = tm_position_for_line_containing_text_in_body_v0(&stream_two, "(2")
+        .expect("page two footnote line")
+        .1;
     assert!(
         (72.0..=140.0).contains(&page_one_footnote_y),
         "page 1 footnote should render near bottom: y={page_one_footnote_y}"
@@ -2416,7 +2525,10 @@ fn pdf_renderer_table_rows_use_stable_column_x_offsets_v0() {
         (gamma_x - zeta_x).abs() <= 3.0,
         "column 3 x drift too large: {gamma_x} vs {zeta_x}"
     );
-    assert!(alpha_x < beta_x && beta_x < gamma_x, "column order mismatch");
+    assert!(
+        alpha_x < beta_x && beta_x < gamma_x,
+        "column order mismatch"
+    );
 }
 
 #[test]
@@ -2445,7 +2557,9 @@ fn pdf_renderer_table_cells_stay_within_column_bounds_v1() {
         .first()
         .expect("WideMiddle x");
     let b_x = *tm_xs_for_segment_text_v0(&pdf, "B").first().expect("B x");
-    let nine_x = *tm_xs_for_segment_text_v0(&pdf, "9.9").first().expect("9.9 x");
+    let nine_x = *tm_xs_for_segment_text_v0(&pdf, "9.9")
+        .first()
+        .expect("9.9 x");
     let one_two_three_x = *tm_xs_for_segment_text_v0(&pdf, "123.45")
         .first()
         .expect("123.45 x");
@@ -2458,8 +2572,8 @@ fn pdf_renderer_table_cells_stay_within_column_bounds_v1() {
         (longleft_x - col1_content_left_pt).abs() <= epsilon_pt,
         "column 1 left-aligned start mismatch: {longleft_x} vs {col1_content_left_pt}"
     );
-    let expected_wide_x = col2_content_left_pt
-        + ((col2_width_pt - segment_width_pt_v0(b"WideMiddle")) * 0.5);
+    let expected_wide_x =
+        col2_content_left_pt + ((col2_width_pt - segment_width_pt_v0(b"WideMiddle")) * 0.5);
     let expected_b_x = col2_content_left_pt + ((col2_width_pt - segment_width_pt_v0(b"B")) * 0.5);
     assert!(
         (wide_x - expected_wide_x).abs() <= epsilon_pt,
@@ -2488,7 +2602,8 @@ fn pdf_renderer_table_cells_stay_within_column_bounds_v1() {
     let nine_right_x = nine_x + segment_width_pt_v0(b"9.9");
     let one_two_three_right_x = one_two_three_x + segment_width_pt_v0(b"123.45");
     assert!(
-        a_x >= col1_content_left_pt - epsilon_pt && a_right_x <= col1_content_left_pt + col1_width_pt + epsilon_pt,
+        a_x >= col1_content_left_pt - epsilon_pt
+            && a_right_x <= col1_content_left_pt + col1_width_pt + epsilon_pt,
         "row 1 col 1 text should remain within column bounds"
     );
     assert!(
@@ -2497,15 +2612,18 @@ fn pdf_renderer_table_cells_stay_within_column_bounds_v1() {
         "row 2 col 1 text should remain within column bounds"
     );
     assert!(
-        wide_x >= col2_content_left_pt - epsilon_pt && wide_right_x <= col2_content_left_pt + col2_width_pt + epsilon_pt,
+        wide_x >= col2_content_left_pt - epsilon_pt
+            && wide_right_x <= col2_content_left_pt + col2_width_pt + epsilon_pt,
         "row 1 col 2 text should remain within column bounds"
     );
     assert!(
-        b_x >= col2_content_left_pt - epsilon_pt && b_right_x <= col2_content_left_pt + col2_width_pt + epsilon_pt,
+        b_x >= col2_content_left_pt - epsilon_pt
+            && b_right_x <= col2_content_left_pt + col2_width_pt + epsilon_pt,
         "row 2 col 2 text should remain within column bounds"
     );
     assert!(
-        nine_x >= col3_content_left_pt - epsilon_pt && nine_right_x <= col3_content_left_pt + col3_width_pt + epsilon_pt,
+        nine_x >= col3_content_left_pt - epsilon_pt
+            && nine_right_x <= col3_content_left_pt + col3_width_pt + epsilon_pt,
         "row 1 col 3 text should remain within column bounds"
     );
     assert!(
@@ -2541,7 +2659,10 @@ fn pdf_renderer_rejects_table_width_overflow_v0() {
     let xdv = write_dvi_v2_text_page_with_layout_and_wrap_v0(&row, 65_536, 786_432, 5_000)
         .expect("writer should accept table marker line");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
-    assert!(pdf.is_none(), "renderer should fail-closed for table overflow");
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed for table overflow"
+    );
 }
 
 #[test]
@@ -2570,11 +2691,9 @@ fn pdf_renderer_figure_block_spacing_invariants_v0() {
     let left_margin_epsilon = 0.5f32;
     let (before_x, before_y) =
         tm_position_for_line_containing_text_v0(&pdf, "(Before paragraph.)").expect("before");
-    let (placeholder_x, placeholder_y) = tm_position_for_line_containing_text_v0(
-        &pdf,
-        "([ Figure placeholder: figures/demo.png ])",
-    )
-    .expect("placeholder");
+    let (placeholder_x, placeholder_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "([ Figure placeholder: figures/demo.png ])")
+            .expect("placeholder");
     let (caption_x, caption_y) =
         tm_position_for_line_containing_text_v0(&pdf, "(Figure caption text.)").expect("caption");
     let (after_x, after_y) =
@@ -2588,11 +2707,26 @@ fn pdf_renderer_figure_block_spacing_invariants_v0() {
         caption_x > left_margin_pt + left_margin_epsilon,
         "caption should be visually offset from body margin"
     );
-    assert!(before_x >= left_margin_pt - epsilon_pt, "before paragraph should stay in body column");
-    assert!(after_x >= left_margin_pt - epsilon_pt, "after paragraph should stay in body column");
-    assert!(before_y > placeholder_y, "placeholder should render below body");
-    assert!(placeholder_y > caption_y, "caption should render below placeholder");
-    assert!(caption_y > after_y, "after paragraph should render below caption");
+    assert!(
+        before_x >= left_margin_pt - epsilon_pt,
+        "before paragraph should stay in body column"
+    );
+    assert!(
+        after_x >= left_margin_pt - epsilon_pt,
+        "after paragraph should stay in body column"
+    );
+    assert!(
+        before_y > placeholder_y,
+        "placeholder should render below body"
+    );
+    assert!(
+        placeholder_y > caption_y,
+        "caption should render below placeholder"
+    );
+    assert!(
+        caption_y > after_y,
+        "after paragraph should render below caption"
+    );
 }
 
 #[test]
@@ -2615,11 +2749,26 @@ fn pdf_renderer_renders_toc_block_with_level_indentation_v0() {
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
     let pdf_text = String::from_utf8_lossy(&pdf);
 
-    assert!(!pdf_text.contains("!toc 1 1"), "toc metadata lines must not be visible");
-    assert!(!pdf_text.contains("!toc 2 2"), "toc metadata lines must not be visible");
-    assert!(pdf_text.contains("(Contents) Tj"), "toc title should render");
-    assert!(pdf_text.contains("(Intro entry) Tj"), "toc level 1 entry should render");
-    assert!(pdf_text.contains("(Detail entry) Tj"), "toc level 2 entry should render");
+    assert!(
+        !pdf_text.contains("!toc 1 1"),
+        "toc metadata lines must not be visible"
+    );
+    assert!(
+        !pdf_text.contains("!toc 2 2"),
+        "toc metadata lines must not be visible"
+    );
+    assert!(
+        pdf_text.contains("(Contents) Tj"),
+        "toc title should render"
+    );
+    assert!(
+        pdf_text.contains("(Intro entry) Tj"),
+        "toc level 1 entry should render"
+    );
+    assert!(
+        pdf_text.contains("(Detail entry) Tj"),
+        "toc level 2 entry should render"
+    );
 
     let intro_x =
         tm_x_for_line_containing_text_v0(&pdf, "(Intro entry)").expect("toc level 1 position");
@@ -2632,11 +2781,77 @@ fn pdf_renderer_renders_toc_block_with_level_indentation_v0() {
 }
 
 #[test]
-fn pdf_renderer_rejects_toc_entries_with_unsupported_level_v0() {
-    let xdv =
-        write_dvi_v2_text_page_v0(b"!toc\n\n!toc 3 1 Too deep").expect("writer should accept bytes");
+fn pdf_renderer_emits_toc_link_annotations_targeting_heading_anchors_v0() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"Prelude.\n\n!toc\n\n@S {Intro section}\n\n@s {Detail section}\n\n!toc 1 1 <Intro section>\n!toc 2 2 <Detail section>",
+    )
+    .expect("writer should accept toc metadata and heading lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    assert!(
+        pdf_text.contains("(Intro section) Tj"),
+        "toc section title should render: {pdf_text}"
+    );
+    assert!(
+        pdf_text.contains("(Detail section) Tj"),
+        "toc subsection title should render: {pdf_text}"
+    );
+
+    let page_one = parse_pdf_object_body_v0(&pdf, 3).expect("page object");
+    let annots = parse_pdf_ref_ids_v0(&page_one, "/Annots");
+    assert_eq!(annots.len(), 2, "toc block should emit two annotations");
+
+    for annotation_id in annots {
+        let annotation = parse_pdf_object_body_v0(&pdf, annotation_id).expect("annotation body");
+        assert!(
+            annotation.contains("/Dest ["),
+            "toc links should use internal destinations: {annotation}"
+        );
+        assert!(
+            !annotation.contains("/A "),
+            "toc links should not use URI actions: {annotation}"
+        );
+        assert_eq!(
+            parse_pdf_annotation_dest_page_id_v0(&annotation),
+            Some(3),
+            "toc links should target page containing heading anchors"
+        );
+        let rect = parse_pdf_annotation_rect_v0(&annotation).expect("annotation rect");
+        assert!(
+            rect[2] > rect[0],
+            "annotation width must be positive: {rect:?}"
+        );
+        assert!(
+            rect[3] > rect[1],
+            "annotation height must be positive: {rect:?}"
+        );
+        assert!(
+            rect[0] >= 0.0 && rect[1] >= 0.0 && rect[2] <= 612.0 && rect[3] <= 792.0,
+            "annotation rect must stay within page bounds: {rect:?}"
+        );
+    }
+}
+
+#[test]
+fn pdf_renderer_rejects_toc_link_annotation_with_missing_anchor_destination_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"Prelude.\n\n!toc\n\n!toc 1 9 <Missing anchor>")
+        .expect("writer bytes");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
-    assert!(pdf.is_none(), "renderer should fail-closed for unsupported toc level");
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed when toc link anchor target is missing"
+    );
+}
+
+#[test]
+fn pdf_renderer_rejects_toc_entries_with_unsupported_level_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"!toc\n\n!toc 3 1 Too deep")
+        .expect("writer should accept bytes");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed for unsupported toc level"
+    );
 }
 
 #[test]
@@ -2657,12 +2872,30 @@ fn pdf_renderer_toc_block_renders_between_surrounding_paragraphs_v0() {
     let (after_x, after_y) =
         tm_position_for_line_containing_text_v0(&pdf, "(After block.)").expect("after");
 
-    assert!(before_y > toc_title_y, "toc block should appear below preceding paragraph");
-    assert!(toc_title_y > toc_intro_y, "toc entries should appear below toc title");
-    assert!(toc_intro_y > toc_detail_y, "toc level 2 line should appear below level 1 line");
-    assert!(toc_detail_y > after_y, "toc block should appear above following paragraph");
-    assert!(toc_title_x >= 72.0, "toc title should remain in printable area");
-    assert!(before_x > 0.0 && after_x > 0.0, "paragraph coordinates must be valid");
+    assert!(
+        before_y > toc_title_y,
+        "toc block should appear below preceding paragraph"
+    );
+    assert!(
+        toc_title_y > toc_intro_y,
+        "toc entries should appear below toc title"
+    );
+    assert!(
+        toc_intro_y > toc_detail_y,
+        "toc level 2 line should appear below level 1 line"
+    );
+    assert!(
+        toc_detail_y > after_y,
+        "toc block should appear above following paragraph"
+    );
+    assert!(
+        toc_title_x >= 72.0,
+        "toc title should remain in printable area"
+    );
+    assert!(
+        before_x > 0.0 && after_x > 0.0,
+        "paragraph coordinates must be valid"
+    );
 }
 
 #[test]
@@ -2671,46 +2904,51 @@ fn pdf_renderer_toc_without_entries_renders_title_only_v0() {
         write_dvi_v2_text_page_v0(b"Intro.\n\n!toc\n\nOutro.").expect("writer should accept bytes");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
     let pdf_text = String::from_utf8_lossy(&pdf);
-    assert!(pdf_text.contains("(Contents) Tj"), "toc title should render");
-    assert!(!pdf_text.contains("!toc"), "toc placeholder should be hidden");
+    assert!(
+        pdf_text.contains("(Contents) Tj"),
+        "toc title should render"
+    );
+    assert!(
+        !pdf_text.contains("!toc"),
+        "toc placeholder should be hidden"
+    );
 }
 
 #[test]
 fn pdf_renderer_rejects_toc_entry_with_non_numeric_anchor_id_v0() {
-    let xdv = write_dvi_v2_text_page_v0(
-        b"!toc\n\n!toc 1 abc Intro",
-    )
-    .expect("writer should accept bytes");
+    let xdv =
+        write_dvi_v2_text_page_v0(b"!toc\n\n!toc 1 abc Intro").expect("writer should accept bytes");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
-    assert!(pdf.is_none(), "renderer should fail-closed on non-numeric toc anchor ids");
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed on non-numeric toc anchor ids"
+    );
 }
 
 #[test]
 fn pdf_renderer_rejects_toc_entry_with_empty_title_v0() {
-    let xdv = write_dvi_v2_text_page_v0(
-        b"!toc\n\n!toc 1 1 ",
-    )
-    .expect("writer should accept bytes");
+    let xdv = write_dvi_v2_text_page_v0(b"!toc\n\n!toc 1 1 ").expect("writer should accept bytes");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
-    assert!(pdf.is_none(), "renderer should fail-closed on empty toc titles");
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed on empty toc titles"
+    );
 }
 
 #[test]
 fn pdf_renderer_rejects_toc_entry_with_zero_anchor_id_v0() {
-    let xdv = write_dvi_v2_text_page_v0(
-        b"!toc\n\n!toc 1 0 Intro",
-    )
-    .expect("writer should accept bytes");
+    let xdv =
+        write_dvi_v2_text_page_v0(b"!toc\n\n!toc 1 0 Intro").expect("writer should accept bytes");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
-    assert!(pdf.is_none(), "renderer should fail-closed on zero toc anchors");
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed on zero toc anchors"
+    );
 }
 
 #[test]
 fn pdf_renderer_rejects_toc_entry_with_unterminated_metadata_shape_v0() {
-    let xdv = write_dvi_v2_text_page_v0(
-        b"!toc\n\n!toc 1",
-    )
-    .expect("writer should accept bytes");
+    let xdv = write_dvi_v2_text_page_v0(b"!toc\n\n!toc 1").expect("writer should accept bytes");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
     assert!(
         pdf.is_none(),
@@ -2720,12 +2958,13 @@ fn pdf_renderer_rejects_toc_entry_with_unterminated_metadata_shape_v0() {
 
 #[test]
 fn pdf_renderer_rejects_duplicate_toc_anchor_ids_v0() {
-    let xdv = write_dvi_v2_text_page_v0(
-        b"!toc\n\n!toc 1 1 Intro\n!toc 2 1 Duplicate anchor",
-    )
-    .expect("writer should accept bytes");
+    let xdv = write_dvi_v2_text_page_v0(b"!toc\n\n!toc 1 1 Intro\n!toc 2 1 Duplicate anchor")
+        .expect("writer should accept bytes");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
-    assert!(pdf.is_none(), "renderer should fail-closed on duplicate toc anchors");
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed on duplicate toc anchors"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Implement TOC hyperlinks v1 for `typeset_minimal_v0`.
- Wrap TOC metadata entries with internal link markers when hyperref is enabled.
- Emit clickable internal PDF annotations for TOC entries and resolve anchor destinations deterministically.
- Add engine/XDV tests for TOC link metadata, annotation emission, and fail-closed missing-anchor behavior.

## Scope
- Locked leaf packet: carreltex#396
- Single PR, non-trivial bundle

## Frozen head
- `4697168648b4ac5401e43588c06a54bf7bc4bfa4`

## Proof tails
### `cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests`
```text
test compile_v0::typeset_minimal_v0_tests::typeset_minimal_toc_metadata_coexists_with_footnotes_and_links ... ok
test compile_v0::typeset_minimal_v0_tests::typeset_minimal_toc_placeholder_precedes_rendered_headings ... ok
test compile_v0::typeset_minimal_v0_tests::typeset_minimal_toc_preserves_duplicate_heading_titles_with_unique_anchors ... ok
test compile_v0::typeset_minimal_v0_tests::typeset_minimal_toc_without_headings_emits_placeholder_only ... ok
test compile_v0::typeset_minimal_v0_tests::typeset_minimal_wrapper_markers_trim_inner_spaces_without_newlines ... ok

test result: ok. 90 passed; 0 failed; 0 ignored; 0 measured; 762 filtered out; finished in 0.01s
```

### `cargo test --manifest-path crates/carreltex-xdv/Cargo.toml`
```text
test tests::write_with_paging_limit_splits_into_multiple_pages ... ok
test tests::writer_output_is_non_empty ... ok
test tests::writer_output_validates ... ok
test tests::write_with_small_wrap_cap_increases_down3_count ... ok

test result: ok. 99 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

### `./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 6`
```text
PASS: xdv_sha256 ed24b7da91fc787a8c39310d6460368cc20d68913cab8cdb111bec3bb7708de0
PASS: pdf_sha256 eb3466143b78701622c8820f36bdcb2f1506d20938c0153473ece4457656fef5
PASS: max_segment_tm_gap_pt 0.00 <= 24.00
PASS: multipage+annots+footnotes pages=3 p1_annots=10 p2_annots=2
PASS: wasm typeset minimal artifacts out/main.{xdv,pdf}
PASS: wasm typeset minimal proof
```

### `./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 12`
```text
PASS: math_v1 sha stable ecf16ee57bdf4a1f1949715f75593da1c612bf844c37b135551992817a0e34ab
PASS: table_v1 sha stable 6555878dad8aa884d53af3c097e5ce440eb888e48418ced7b853e15bb7fcf604
PASS: report typed_artifact_sha256 map present and stable
PASS: report top-level case_artifact_sha256 present
PASS: ondemand run resolved_resources_count 48 -> 50
PASS: ondemand per-case missing_before/missing_after fields and retries verified
PASS: wasm fixture gallery artifacts out
PASS: wasm fixture gallery proof
```
