### PR TITLE
typeset_minimal: equation numbering v1 + eqref via ref

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -43,6 +43,7 @@ const HREF_URL_LINE_PREFIX_MARKER_V0: &[u8] = b"!u ";
 const LABEL_LINE_PREFIX_MARKER_V0: &[u8] = b"!l ";
 const REF_LINE_PREFIX_MARKER_V0: &[u8] = b"!r ";
 const REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0: &[u8] = b"!ra ";
+const EQUATION_LINE_PREFIX_MARKER_V0: &[u8] = b"!eq ";
 const BIBITEM_LINE_PREFIX_MARKER_V0: &[u8] = b"!b ";
 const CITE_LINE_PREFIX_MARKER_V0: &[u8] = b"!c ";
 const TABLE_ROW_PREFIX_MARKER_V0: &[u8] = b"!t ";
@@ -83,6 +84,7 @@ struct TocEntryMetaV0 {
 enum LabelKindV0 {
     Heading,
     Figure,
+    Equation,
 }
 
 #[derive(Clone)]
@@ -91,6 +93,7 @@ struct LabelEntryMetaV0 {
     kind: LabelKindV0,
     level: Option<u8>,
     figure_ordinal: Option<u32>,
+    equation_ordinal: Option<u32>,
     title: Option<Vec<u8>>,
 }
 
@@ -100,6 +103,7 @@ struct PendingLabelTargetV0 {
     kind: LabelKindV0,
     level: Option<u8>,
     figure_ordinal: Option<u32>,
+    equation_ordinal: Option<u32>,
     title: Option<Vec<u8>>,
 }
 
@@ -120,6 +124,12 @@ struct HrefLinkMetaV0 {
 struct RefAnchorLinkMetaV0 {
     link_id: u32,
     anchor_id: u32,
+}
+
+#[derive(Clone)]
+struct EquationMetaV0 {
+    anchor_id: u32,
+    ordinal: u32,
 }
 
 struct CrossRefArtifactsV1 {
@@ -2152,6 +2162,7 @@ fn apply_crossref_pass_v1(
             let resolved_value = resolved_label.and_then(|entry| match entry.kind {
                 LabelKindV0::Heading => Some(entry.anchor_id),
                 LabelKindV0::Figure => entry.figure_ordinal,
+                LabelKindV0::Equation => entry.equation_ordinal,
             });
             if resolved_anchor_id.is_some() != resolved_value.is_some() {
                 return None;
@@ -2164,6 +2175,9 @@ fn apply_crossref_pass_v1(
                     return None;
                 }
                 if matches!(label.kind, LabelKindV0::Figure) && label.figure_ordinal.is_none() {
+                    return None;
+                }
+                if matches!(label.kind, LabelKindV0::Equation) && label.equation_ordinal.is_none() {
                     return None;
                 }
             }
@@ -2338,6 +2352,9 @@ fn consume_label_command_v0(
     if matches!(target.kind, LabelKindV0::Figure) && target.figure_ordinal.is_none() {
         return None;
     }
+    if matches!(target.kind, LabelKindV0::Equation) && target.equation_ordinal.is_none() {
+        return None;
+    }
     let (key, next) = parse_label_or_ref_key_group_v0(tokens, index)?;
     if labels_by_key.contains_key(&key) {
         return None;
@@ -2349,6 +2366,7 @@ fn consume_label_command_v0(
             kind: target.kind,
             level: target.level,
             figure_ordinal: target.figure_ordinal,
+            equation_ordinal: target.equation_ordinal,
             title: target.title,
         },
     );
@@ -2640,10 +2658,12 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
     let mut cite_occurrences = Vec::<CiteOccurrenceMetaV0>::new();
     let mut next_anchor_id = 1u32;
     let mut next_figure_ordinal = 1u32;
+    let mut next_equation_ordinal = 1u32;
     let mut saw_maketitle = false;
     let mut saw_body_content_after_maketitle = false;
     let mut toc_requested = false;
     let mut pending_noindent_after_heading = false;
+    let mut equations = Vec::<EquationMetaV0>::new();
     let mut pending_label_target = None::<PendingLabelTargetV0>;
     loop {
         match tokens.get(index) {
@@ -2695,6 +2715,7 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
                         kind: LabelKindV0::Figure,
                         level: None,
                         figure_ordinal: Some(figure_ordinal),
+                        equation_ordinal: None,
                         title: None,
                     });
                 } else if env_name.as_slice() == THEBIBLIOGRAPHY_ENV_V0 {
@@ -2740,6 +2761,30 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
                 );
                 pending_label_target = None;
                 index = consume_href_command_v0(tokens, index, &mut body, &mut href_urls)?;
+            }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"[" => {
+                saw_body_content_after_maketitle = true;
+                maybe_emit_pending_noindent_prefix_v0(
+                    &mut body,
+                    &mut pending_noindent_after_heading,
+                );
+                let anchor_id = next_anchor_id;
+                next_anchor_id = next_anchor_id.checked_add(1)?;
+                let equation_ordinal = next_equation_ordinal;
+                next_equation_ordinal = next_equation_ordinal.checked_add(1)?;
+                index = consume_display_math_command_v0(tokens, index, &mut body)?;
+                equations.push(EquationMetaV0 {
+                    anchor_id,
+                    ordinal: equation_ordinal,
+                });
+                pending_label_target = Some(PendingLabelTargetV0 {
+                    anchor_id,
+                    kind: LabelKindV0::Equation,
+                    level: None,
+                    figure_ordinal: None,
+                    equation_ordinal: Some(equation_ordinal),
+                    title: None,
+                });
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == LABEL_CONTROL_V0 => {
                 saw_body_content_after_maketitle = true;
@@ -2819,6 +2864,7 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
                         kind: LabelKindV0::Heading,
                         level: Some(level),
                         figure_ordinal: None,
+                        equation_ordinal: None,
                         title: Some(title),
                     });
                 } else {
@@ -2950,6 +2996,16 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
             push_newline(&mut body);
         }
     }
+    if !equations.is_empty() {
+        push_paragraph_break(&mut body);
+        for equation in &equations {
+            body.extend_from_slice(EQUATION_LINE_PREFIX_MARKER_V0);
+            body.extend_from_slice(equation.anchor_id.to_string().as_bytes());
+            body.push(b' ');
+            body.extend_from_slice(equation.ordinal.to_string().as_bytes());
+            push_newline(&mut body);
+        }
+    }
     if !labels_by_key.is_empty() {
         push_paragraph_break(&mut body);
         for (key, entry) in &labels_by_key {
@@ -2961,13 +3017,15 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
             body.extend_from_slice(match entry.kind {
                 LabelKindV0::Heading => b"heading",
                 LabelKindV0::Figure => b"figure",
+                LabelKindV0::Equation => b"equation",
             });
             body.push(b' ');
-            let level_or_figure = match entry.kind {
+            let level_or_ordinal = match entry.kind {
                 LabelKindV0::Heading => u32::from(entry.level.unwrap_or(0)),
                 LabelKindV0::Figure => entry.figure_ordinal.unwrap_or(0),
+                LabelKindV0::Equation => entry.equation_ordinal.unwrap_or(0),
             };
-            body.extend_from_slice(level_or_figure.to_string().as_bytes());
+            body.extend_from_slice(level_or_ordinal.to_string().as_bytes());
             body.push(b' ');
             if let Some(title) = &entry.title {
                 body.extend_from_slice(title);

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -1013,6 +1013,29 @@ fn typeset_minimal_display_math_emits_centered_placeholder_block() {
 }
 
 #[test]
+fn typeset_minimal_display_math_emits_equation_metadata_and_ref_resolution_v1() {
+    let main = b"\\documentclass{article}\\begin{document}\\[x+y\\]\\label{eq:first}\\[a+b\\]\\label{eq:second}Refs: \\ref{eq:first}, \\ref{eq:second}.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("^ MATH DISPLAY"), "body={text:?}");
+    assert!(text.contains("Refs: 1, 2."), "body={text:?}");
+    assert!(text.contains("!eq 1 1"), "body={text:?}");
+    assert!(text.contains("!eq 2 2"), "body={text:?}");
+    assert!(text.contains("!l eq:first 1 equation 1 -"), "body={text:?}");
+    assert!(text.contains("!l eq:second 2 equation 2 -"), "body={text:?}");
+}
+
+#[test]
+fn typeset_minimal_equation_refs_with_hyperref_emit_anchor_links_v1() {
+    let main = b"\\documentclass{article}\\begin{document}\\[x+y\\]\\label{eq:first}Refs: \\ref{eq:first}.\\href{https://example.com}{link}\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("Refs: <1>."), "body={text:?}");
+    assert!(text.contains("!ra 1 1"), "body={text:?}");
+    assert!(text.contains("!u 2 https://example.com"), "body={text:?}");
+}
+
+#[test]
 fn typeset_minimal_rejects_inline_math_with_control_sequence_payload() {
     let main = b"\\documentclass{article}\\begin{document}$\\alpha$\\end{document}";
     let result = compile_typeset(main);

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -29,6 +29,7 @@ const HREF_URL_LINE_PREFIX_MARKER_V0: &[u8] = b"!u ";
 const LABEL_LINE_PREFIX_MARKER_V0: &[u8] = b"!l ";
 const REF_LINE_PREFIX_MARKER_V0: &[u8] = b"!r ";
 const REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0: &[u8] = b"!ra ";
+const EQUATION_LINE_PREFIX_MARKER_V0: &[u8] = b"!eq ";
 const BIBITEM_LINE_PREFIX_MARKER_V0: &[u8] = b"!b ";
 const CITE_LINE_PREFIX_MARKER_V0: &[u8] = b"!c ";
 const NOINDENT_PREFIX_MARKER_V0: u8 = b'~';
@@ -55,6 +56,7 @@ const TOC_TITLE_FONT_SIZE_PT_V0: f32 = 14.0;
 const TOC_ENTRY_INDENT_STEP_PT_V0: f32 = 18.0;
 const SECTION_HEADING_PREFIX_MARKER_V0: &[u8] = b"@S ";
 const SUBSECTION_HEADING_PREFIX_MARKER_V0: &[u8] = b"@s ";
+const DISPLAY_MATH_PLACEHOLDER_V0: &[u8] = b"MATH DISPLAY";
 const ITALIC_START_MARKER_V0: u8 = b'[';
 const ITALIC_END_MARKER_V0: u8 = b']';
 const BOLD_START_MARKER_V0: u8 = b'{';
@@ -178,6 +180,12 @@ struct TocEntryMetadataV0 {
     level: u8,
     anchor_id: u32,
     title_glyphs: Vec<GlyphPlanV0>,
+}
+
+#[derive(Clone, Copy)]
+struct EquationMetadataV0 {
+    anchor_id: u32,
+    ordinal: u32,
 }
 
 #[derive(Clone)]
@@ -428,6 +436,14 @@ fn detect_quote_prefix_advance_pt_v0(glyphs: &[GlyphPlanV0]) -> Option<f32> {
 
 fn has_center_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
     glyphs.len() >= 2 && glyphs[0].byte == b'^' && glyphs[1].byte == b' '
+}
+
+fn is_display_math_placeholder_line_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    has_center_prefix_v0(glyphs)
+        && glyphs[2..]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .eq(DISPLAY_MATH_PLACEHOLDER_V0.iter().copied())
 }
 
 fn has_right_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
@@ -1075,6 +1091,14 @@ fn has_ref_anchor_link_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
             .eq(REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0.iter().copied())
 }
 
+fn has_equation_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() >= EQUATION_LINE_PREFIX_MARKER_V0.len()
+        && glyphs[..EQUATION_LINE_PREFIX_MARKER_V0.len()]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .eq(EQUATION_LINE_PREFIX_MARKER_V0.iter().copied())
+}
+
 fn has_bibitem_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
     glyphs.len() >= BIBITEM_LINE_PREFIX_MARKER_V0.len()
         && glyphs[..BIBITEM_LINE_PREFIX_MARKER_V0.len()]
@@ -1159,19 +1183,41 @@ fn parse_label_line_v0(glyphs: &[GlyphPlanV0]) -> Option<()> {
     if key.is_empty() || anchor_id == 0 {
         return None;
     }
-    if kind != "heading" && kind != "figure" {
+    if kind != "heading" && kind != "figure" && kind != "equation" {
         return None;
     }
     if kind == "heading" && !(1..=2).contains(&level) {
         return None;
     }
-    if kind == "figure" && level == 0 {
+    if (kind == "figure" || kind == "equation") && level == 0 {
         return None;
     }
     if title.is_empty() {
         return None;
     }
     Some(())
+}
+
+fn parse_equation_line_v0(glyphs: &[GlyphPlanV0]) -> Option<EquationMetadataV0> {
+    if glyphs.len() < EQUATION_LINE_PREFIX_MARKER_V0.len() {
+        return None;
+    }
+    let bytes: Vec<u8> = glyphs.iter().map(|glyph| glyph.byte).collect();
+    if !bytes.starts_with(EQUATION_LINE_PREFIX_MARKER_V0) {
+        return None;
+    }
+    let line = String::from_utf8(bytes).ok()?;
+    let mut parts = line.splitn(3, ' ');
+    let prefix = parts.next()?;
+    if prefix != "!eq" {
+        return None;
+    }
+    let anchor_id = parts.next()?.trim().parse::<u32>().ok()?;
+    let ordinal = parts.next()?.trim().parse::<u32>().ok()?;
+    if anchor_id == 0 || ordinal == 0 {
+        return None;
+    }
+    Some(EquationMetadataV0 { anchor_id, ordinal })
 }
 
 fn parse_ref_line_v0(glyphs: &[GlyphPlanV0]) -> Option<()> {
@@ -1516,6 +1562,7 @@ fn split_body_and_metadata_lines_v0(
                 || has_label_line_prefix_v0(&line.glyphs)
                 || has_ref_line_prefix_v0(&line.glyphs)
                 || has_ref_anchor_link_line_prefix_v0(&line.glyphs)
+                || has_equation_line_prefix_v0(&line.glyphs)
                 || has_bibitem_line_prefix_v0(&line.glyphs)
                 || has_cite_line_prefix_v0(&line.glyphs)
             {
@@ -1569,6 +1616,22 @@ fn collect_nominal_anchor_destinations_v0(
                 }
                 next_anchor_id = next_anchor_id.checked_add(1)?;
             } else if line_index >= title_block_len
+                && is_display_math_placeholder_line_v0(&line.glyphs)
+            {
+                if anchor_destinations
+                    .insert(
+                        next_anchor_id,
+                        AnchorDestinationV0 {
+                            page_index,
+                            y_pt: y,
+                        },
+                    )
+                    .is_some()
+                {
+                    return None;
+                }
+                next_anchor_id = next_anchor_id.checked_add(1)?;
+            } else if line_index >= title_block_len
                 && detect_heading_prefix_v0(&line.glyphs).is_some()
             {
                 if anchor_destinations
@@ -1600,10 +1663,12 @@ fn parse_metadata_lines_v0(
     BTreeMap<u32, Vec<Vec<GlyphPlanV0>>>,
     BTreeMap<u32, PdfLinkTargetV0>,
     Vec<TocEntryMetadataV0>,
+    BTreeMap<u32, u32>,
 )> {
     let mut footnote_defs_by_id = BTreeMap::<u32, Vec<Vec<GlyphPlanV0>>>::new();
     let mut link_targets_by_id = BTreeMap::<u32, PdfLinkTargetV0>::new();
     let mut toc_entries = Vec::<TocEntryMetadataV0>::new();
+    let mut equation_ordinals_by_anchor_id = BTreeMap::<u32, u32>::new();
     let mut current_footnote_id = None::<u32>;
     for line in metadata_lines {
         if let Some((footnote_id, footnote_line)) = parse_footnote_definition_line_v0(&line.glyphs)
@@ -1631,6 +1696,16 @@ fn parse_metadata_lines_v0(
                     ref_link.link_id,
                     PdfLinkTargetV0::Anchor(ref_link.anchor_id),
                 )
+                .is_some()
+            {
+                return None;
+            }
+            current_footnote_id = None;
+            continue;
+        }
+        if let Some(equation) = parse_equation_line_v0(&line.glyphs) {
+            if equation_ordinals_by_anchor_id
+                .insert(equation.anchor_id, equation.ordinal)
                 .is_some()
             {
                 return None;
@@ -1677,7 +1752,12 @@ fn parse_metadata_lines_v0(
             .push(line.glyphs.clone());
     }
     toc_entries.sort_by_key(|entry| entry.anchor_id);
-    Some((footnote_defs_by_id, link_targets_by_id, toc_entries))
+    Some((
+        footnote_defs_by_id,
+        link_targets_by_id,
+        toc_entries,
+        equation_ordinals_by_anchor_id,
+    ))
 }
 
 fn build_page_content_stream_v0(
@@ -1685,6 +1765,7 @@ fn build_page_content_stream_v0(
     footnote_defs_by_id: &BTreeMap<u32, Vec<Vec<GlyphPlanV0>>>,
     link_targets_by_id: &BTreeMap<u32, PdfLinkTargetV0>,
     toc_entries: &[TocEntryMetadataV0],
+    equation_ordinals_by_anchor_id: &BTreeMap<u32, u32>,
     next_link_id: &mut u32,
     page_index: usize,
     next_anchor_id: &mut u32,
@@ -1846,6 +1927,10 @@ fn build_page_content_stream_v0(
         } else {
             None
         };
+        let display_math_line = line_index >= title_block_len
+            && quote_prefix_advance_pt.is_none()
+            && center_prefixed
+            && is_display_math_placeholder_line_v0(&line.glyphs);
         let render_glyphs_base: &[GlyphPlanV0] = if quote_prefix_advance_pt.is_some() {
             &line.glyphs[2..]
         } else if center_prefixed {
@@ -1952,12 +2037,13 @@ fn build_page_content_stream_v0(
             } else {
                 MARGIN_PT_V0
             };
-            if heading_kind.is_some() {
-                let heading_anchor_id = *next_anchor_id;
+            let mut equation_ordinal = None::<u32>;
+            if heading_kind.is_some() || display_math_line {
+                let anchor_id = *next_anchor_id;
                 *next_anchor_id = next_anchor_id.checked_add(1)?;
                 if anchor_destinations
                     .insert(
-                        heading_anchor_id,
+                        anchor_id,
                         AnchorDestinationV0 {
                             page_index,
                             y_pt: y,
@@ -1966,6 +2052,9 @@ fn build_page_content_stream_v0(
                     .is_some()
                 {
                     return None;
+                }
+                if display_math_line {
+                    equation_ordinal = equation_ordinals_by_anchor_id.get(&anchor_id).copied();
                 }
             }
             if let Some(prefix) = list_prefix {
@@ -2012,6 +2101,26 @@ fn build_page_content_stream_v0(
                 );
             } else {
                 emit_styled_segments_v0(&mut out, &segments, line_x, y, font_size_pt);
+            }
+            if let Some(ordinal) = equation_ordinal {
+                let equation_number = format!("({ordinal})").into_bytes();
+                let equation_number_width_pt = (equation_number.len() as f32) * (FONT_SIZE_PT_V0 * 0.6);
+                let equation_number_x =
+                    (PAGE_WIDTH_PT_V0 - MARGIN_PT_V0 - equation_number_width_pt).max(MARGIN_PT_V0);
+                let equation_segments = [PdfRenderSegmentV0 {
+                    style: PdfTextStyleV0::Regular,
+                    bytes: equation_number,
+                    advance_pt: equation_number_width_pt,
+                    is_link: false,
+                    superscript: false,
+                }];
+                emit_render_segments_with_superscript_v0(
+                    &mut out,
+                    &equation_segments,
+                    equation_number_x,
+                    y,
+                    FONT_SIZE_PT_V0,
+                );
             }
             out.extend_from_slice(b"\n");
             if !in_title_block && skip_indent_after_title_block {
@@ -2081,7 +2190,7 @@ fn build_page_content_stream_v0(
 
 fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
     let (body_pages, metadata_lines) = split_body_and_metadata_lines_v0(pages);
-    let Some((footnote_defs_by_id, link_targets_by_id, toc_entries)) =
+    let Some((footnote_defs_by_id, link_targets_by_id, toc_entries, equation_ordinals_by_anchor_id)) =
         parse_metadata_lines_v0(&metadata_lines)
     else {
         return Vec::new();
@@ -2101,6 +2210,7 @@ fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
             &footnote_defs_by_id,
             &link_targets_by_id,
             &toc_entries,
+            &equation_ordinals_by_anchor_id,
             &mut next_link_id,
             page_index,
             &mut next_anchor_id,

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -2255,6 +2255,25 @@ fn pdf_renderer_display_math_placeholder_line_is_centered_v0() {
 }
 
 #[test]
+fn pdf_renderer_display_math_with_equation_metadata_renders_right_number_v1() {
+    let xdv = write_dvi_v2_text_page_v0(b"Before.\n\n^ MATH DISPLAY\n\nAfter.\n\n!eq 1 1")
+        .expect("writer should accept equation metadata line");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let (display_x, _) = tm_position_for_line_containing_text_v0(&pdf, "(MATH DISPLAY)")
+        .expect("display placeholder x coordinate");
+    let (number_x, _) = tm_position_for_segment_substring_v0(&pdf, "\\(1\\)")
+        .expect("equation number x coordinate");
+    assert!(
+        number_x > display_x,
+        "equation number should render to the right of placeholder: display_x={display_x}, number_x={number_x}"
+    );
+    assert!(
+        number_x > 450.0,
+        "equation number should be near right margin: number_x={number_x}"
+    );
+}
+
+#[test]
 fn pdf_renderer_emits_link_annotation_with_in_bounds_rect_v0() {
     let xdv = write_dvi_v2_text_page_v0(b"Visit <{Example link}> now.\n\n!u 1 https://example.com")
         .expect("writer should accept href marker lines");
@@ -2340,6 +2359,34 @@ fn pdf_renderer_emits_figref_annotation_targeting_figure_anchor_v0() {
 }
 
 #[test]
+fn pdf_renderer_emits_eqref_annotation_targeting_equation_anchor_v1() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"Prelude.\n\n^ MATH DISPLAY\n\nSee <1>.\n\n!eq 1 1\n!l eq:first 1 equation 1 -\n!r eq:first 5 1\n!ra 1 1",
+    )
+    .expect("writer should accept equation and cross-ref marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    assert!(
+        pdf_text.contains("(See ) Tj") && pdf_text.contains("(1) Tj"),
+        "eqref text should render resolved equation ordinal without placeholder: {pdf_text}"
+    );
+
+    let page_one = parse_pdf_object_body_v0(&pdf, 3).expect("page object");
+    let annots = parse_pdf_ref_ids_v0(&page_one, "/Annots");
+    assert_eq!(annots.len(), 1, "expected one internal equation ref annotation");
+    let annotation = parse_pdf_object_body_v0(&pdf, annots[0]).expect("annotation");
+    assert!(
+        annotation.contains("/Dest ["),
+        "equation ref annotation should use internal destination: {annotation}"
+    );
+    assert_eq!(
+        parse_pdf_annotation_dest_page_id_v0(&annotation),
+        Some(3),
+        "equation ref destination should target page containing equation anchor"
+    );
+}
+
+#[test]
 fn pdf_renderer_multi_figure_ref_annotations_follow_ordinal_order_v1() {
     let xdv = write_dvi_v2_text_page_v0(
         b"Prelude.\n\n@S {Intro}\n\n!gbox\n!gcap Figure 1: First caption.\n\n!gbox\n!gcap Figure 2: Second caption.\n\nSee <1> and <2>.\n\n!l fig:first 2 figure 1 -\n!l fig:second 3 figure 2 -\n!r fig:first 11 2\n!r fig:second 11 3\n!ra 1 2\n!ra 2 3",
@@ -2400,6 +2447,19 @@ fn pdf_renderer_rejects_figure_label_metadata_with_zero_ordinal_v1() {
     assert!(
         pdf.is_none(),
         "renderer should fail-closed when figure label metadata carries zero ordinal"
+    );
+}
+
+#[test]
+fn pdf_renderer_rejects_equation_label_metadata_with_zero_ordinal_v1() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"Prelude.\n\n^ MATH DISPLAY\n\n!eq 1 1\n!l eq:bad 1 equation 0 -",
+    )
+    .expect("writer should accept marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed when equation label metadata carries zero ordinal"
     );
 }
 

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -32,6 +32,13 @@ This inline math placeholder stress keeps wrapping deterministic: alpha $x^2 + y
 \[
 x^2 + y^2 = z^2
 \]
+\label{eq:pythagoras}
+This first display equation is referenced later as \ref{eq:pythagoras} in deterministic cross-reference flow.
+\[
+a + b = c
+\]
+\label{eq:linear}
+This second display equation is referenced as \ref{eq:linear}, and both references should emit stable link annotations when hyperref-style markers are active.
 This second paragraph is intentionally plain text and separated by a blank line so paragraph flow,\linebreak
 first-line indentation, and width-sensitive wrapping are visible in the PDF preview with words like WWWW and iiiii.
 This paragraph adds a second marker\footnote{Second demo footnote text with \textbf{bold emphasis}.} and a second visible link style through \href{https://example.com/page2}{CarrelTeX demo link page two},right beside punctuation in regular body flow.

--- a/scripts/wasm_typeset_minimal_v0_emit_pdf.mjs
+++ b/scripts/wasm_typeset_minimal_v0_emit_pdf.mjs
@@ -419,8 +419,8 @@ async function run() {
   if (!streamOneBody || !streamTwoBody) {
     throw new Error('missing content stream object bodies');
   }
-  const footnoteOneY = parseTmYForNeedleV0(streamOneBody, '(1');
-  const footnoteTwoY = parseTmYForNeedleV0(streamTwoBody, '(2');
+  const footnoteOneY = parseTmYForNeedleV0(streamOneBody, '(1 First demo footnote text');
+  const footnoteTwoY = parseTmYForNeedleV0(streamTwoBody, '(2 Second demo footnote text');
   if (footnoteOneY == null || footnoteTwoY == null) {
     throw new Error('expected footnote lines on both page 1 and page 2');
   }


### PR DESCRIPTION
Implements carreltex#400 as a single bundle leaf.

Scope:
- Engine: display-math equation ordinals + label/ref resolution for equation targets.
- PDF preview: display equation right-side ordinal rendering + eqref internal annotation targeting.
- Fixtures/tests: two labeled display equations in minimal demo plus engine/xdv invariants.

Proofs:
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml
- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 6
- ./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 18