### PR TITLE
typeset_minimal: input/include v1 inclusion + input_v1 plumbing

### DIFF
--- a/crates/carreltex-engine/src/compile_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0.rs
@@ -359,7 +359,13 @@ pub fn compile_main_typeset_minimal_v0(mount: &mut Mount) -> CompileResultV0 {
     }
     if expanded_tokens
         .iter()
-        .any(|token| matches!(token, TokenV0::ControlSeq(name) if name.as_slice() == b"input"))
+        .any(|token| {
+            matches!(
+                token,
+                TokenV0::ControlSeq(name)
+                    if name.as_slice() == b"input" || name.as_slice() == b"include"
+            )
+        })
     {
         return invalid_result_v0(
             request.max_log_bytes,
@@ -513,7 +519,13 @@ pub fn compile_request_v0(mount: &mut Mount, req: &CompileRequestV0) -> CompileR
     }
     if expanded_tokens
         .iter()
-        .any(|token| matches!(token, TokenV0::ControlSeq(name) if name.as_slice() == b"input"))
+        .any(|token| {
+            matches!(
+                token,
+                TokenV0::ControlSeq(name)
+                    if name.as_slice() == b"input" || name.as_slice() == b"include"
+            )
+        })
     {
         return invalid_result_v0(
             req.max_log_bytes,

--- a/crates/carreltex-engine/src/compile_v0/input_expand_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/input_expand_v0.rs
@@ -6,6 +6,9 @@ use super::trace_v0::InputTraceV0;
 
 pub(crate) const MAX_INPUT_DEPTH_V0: usize = 32;
 pub(crate) const MAX_INPUT_EXPANSIONS_V0: usize = 1024;
+const INPUT_CONTROL_V0: &[u8] = b"input";
+const INCLUDE_CONTROL_V0: &[u8] = b"include";
+const PAGEBREAK_CONTROL_V0: &[u8] = b"pagebreak";
 
 pub(crate) fn expand_inputs_v0(
     tokens: &[TokenV0],
@@ -25,13 +28,14 @@ pub(crate) fn expand_inputs_v0(
     Ok((expanded, trace))
 }
 
-fn parse_input_path_group_v0(
+fn parse_input_like_path_group_v0(
     tokens: &[TokenV0],
     input_index: usize,
+    command_name: &[u8],
 ) -> Result<(String, usize), InvalidInputReasonV0> {
     if !matches!(
         tokens.get(input_index),
-        Some(TokenV0::ControlSeq(name)) if name.as_slice() == b"input"
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == command_name
     ) {
         return Err(InvalidInputReasonV0::InputValidationFailed);
     }
@@ -122,7 +126,9 @@ fn expand_inputs_inner_v0(
     let mut index = 0usize;
     while index < tokens.len() {
         match &tokens[index] {
-            TokenV0::ControlSeq(name) if name.as_slice() == b"input" => {
+            TokenV0::ControlSeq(name)
+                if name.as_slice() == INPUT_CONTROL_V0 || name.as_slice() == INCLUDE_CONTROL_V0 =>
+            {
                 *expansion_count = expansion_count
                     .checked_add(1)
                     .ok_or(InvalidInputReasonV0::InputExpansionsExceeded)?;
@@ -131,7 +137,9 @@ fn expand_inputs_inner_v0(
                 }
                 trace.expansions = *expansion_count as u64;
 
-                let (normalized_path, next_index) = parse_input_path_group_v0(tokens, index)?;
+                let is_include = name.as_slice() == INCLUDE_CONTROL_V0;
+                let (normalized_path, next_index) =
+                    parse_input_like_path_group_v0(tokens, index, name.as_slice())?;
                 if active_stack.iter().any(|path| path == &normalized_path) {
                     return Err(InvalidInputReasonV0::InputCycleFailed);
                 }
@@ -156,6 +164,12 @@ fn expand_inputs_inner_v0(
                 )?;
                 active_stack.pop();
 
+                if is_include {
+                    push_token_checked(
+                        &mut out,
+                        TokenV0::ControlSeq(PAGEBREAK_CONTROL_V0.to_vec()),
+                    )?;
+                }
                 extend_tokens_checked(&mut out, &expanded)?;
                 index = next_index;
             }

--- a/crates/carreltex-engine/src/compile_v0/tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/tests.rs
@@ -340,6 +340,35 @@ fn input_invalid_syntax_is_invalid() {
         assert!(result.log_bytes.ends_with(b"input_validation_failed"));
     }
 }
+
+#[test]
+fn include_missing_file_is_invalid() {
+    let mut mount = Mount::default();
+    let main_with_missing_include =
+        b"\\documentclass{article}\n\\begin{document}\n\\include{missing.tex}\n\\end{document}\n";
+    assert!(mount.add_file(b"main.tex", main_with_missing_include).is_ok());
+
+    let result = compile_request_v0(&mut mount, &valid_request());
+    assert_eq!(result.status, CompileStatus::InvalidInput);
+    assert!(result.log_bytes.starts_with(b"INVALID_INPUT:"));
+    assert!(result.log_bytes.ends_with(b"input_validation_failed"));
+}
+
+#[test]
+fn include_invalid_syntax_is_invalid() {
+    let cases: [&[u8]; 3] = [
+        b"\\documentclass{article}\n\\begin{document}\n\\include missing.tex\n\\end{document}\n",
+        b"\\documentclass{article}\n\\begin{document}\n\\include{}\n\\end{document}\n",
+        b"\\documentclass{article}\n\\begin{document}\n\\include{a b.tex}\n\\end{document}\n",
+    ];
+    for main in cases {
+        let mut mount = Mount::default();
+        assert!(mount.add_file(b"main.tex", main).is_ok());
+        let result = compile_request_v0(&mut mount, &valid_request());
+        assert_eq!(result.status, CompileStatus::InvalidInput);
+        assert!(result.log_bytes.ends_with(b"input_validation_failed"));
+    }
+}
 #[test]
 fn input_cycle_is_invalid() {
     let mut mount = Mount::default();

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -56,6 +56,77 @@ fn typeset_minimal_subset_compiles_ok() {
 }
 
 #[test]
+fn typeset_minimal_input_inlines_referenced_tex_file() {
+    let main = b"\\documentclass{article}\\begin{document}Start.\\input{sections/intro}End.\\end{document}";
+    let result = compile_typeset_with_files(main, &[(b"sections/intro.tex", b" Included body. ")]);
+    assert_eq!(result.status, CompileStatus::Ok);
+    let layout =
+        parse_dvi_v2_text_page_to_layout_v0(&result.main_xdv_bytes, 917_504).expect("layout parse");
+    let text = layout.pages[0]
+        .lines
+        .iter()
+        .map(|line| {
+            line.glyphs
+                .iter()
+                .map(|glyph| glyph.byte)
+                .collect::<Vec<u8>>()
+        })
+        .collect::<Vec<Vec<u8>>>()
+        .join(&b'\n');
+    let rendered = String::from_utf8_lossy(&text);
+    assert!(rendered.contains("Start. Included body. End."), "text={rendered:?}");
+}
+
+#[test]
+fn typeset_minimal_include_emits_forced_page_break_before_inlined_file() {
+    let main = b"\\documentclass{article}\\begin{document}PageA\\include{sections/next}PageB\\end{document}";
+    let result = compile_typeset_with_files(main, &[(b"sections/next.tex", b" Included section. ")]);
+    assert_eq!(result.status, CompileStatus::Ok);
+    let layout =
+        parse_dvi_v2_text_page_to_layout_v0(&result.main_xdv_bytes, 917_504).expect("layout parse");
+    assert!(layout.pages.len() >= 2, "expected page split from include");
+    let page1 = String::from_utf8_lossy(
+        &layout.pages[0]
+            .lines
+            .iter()
+            .flat_map(|line| line.glyphs.iter().map(|glyph| glyph.byte).chain(std::iter::once(b'\n')))
+            .collect::<Vec<u8>>(),
+    )
+    .to_string();
+    let page2 = String::from_utf8_lossy(
+        &layout.pages[1]
+            .lines
+            .iter()
+            .flat_map(|line| line.glyphs.iter().map(|glyph| glyph.byte).chain(std::iter::once(b'\n')))
+            .collect::<Vec<u8>>(),
+    )
+    .to_string();
+    assert!(page1.contains("PageA"), "page1={page1:?}");
+    assert!(page2.contains("Included section. PageB"), "page2={page2:?}");
+}
+
+#[test]
+fn typeset_minimal_rejects_missing_input_file() {
+    let main = b"\\documentclass{article}\\begin{document}\\input{missing/sub}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::InvalidInput);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_input_include_cycle() {
+    let main = b"\\documentclass{article}\\begin{document}\\input{cycle/a}\\end{document}";
+    let a = b"\\include{cycle/b}";
+    let b = b"\\input{cycle/a}";
+    let result = compile_typeset_with_files(
+        main,
+        &[(b"cycle/a.tex", a.as_slice()), (b"cycle/b.tex", b.as_slice())],
+    );
+    assert_eq!(result.status, CompileStatus::InvalidInput);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
 fn typeset_minimal_rejects_unsupported_control_sequence() {
     let main = b"\\documentclass{article}\\begin{document}\\foo{X}\\end{document}";
     let result = compile_typeset(main);

--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -61,6 +61,8 @@ printf 'fixture-bytes-for-appendices-apx-a-nested\n' > "$FIXTURE_SOURCE_DIR/xete
 printf 'fixture-bytes-for-appendices-apx-b-nested\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/appendices/apx_b.tex"
 printf 'fixture-bytes-for-appendices-apx-a-normalized\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/appendices__apx_a.tex"
 printf 'fixture-bytes-for-appendices-apx-b-normalized\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/appendices__apx_b.tex"
+printf '\\include{cycles/b}\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/cycles__a.tex"
+printf '\\input{cycles/a}\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/cycles__b.tex"
 printf 'fixture-bytes-for-demo-png\n' > "$FIXTURE_SOURCE_DIR/xetex/png/demo.png"
 printf 'fixture-bytes-for-probe-figure-png\n' > "$FIXTURE_SOURCE_DIR/xetex/png/probe-figure.png"
 printf 'fixture-bytes-for-figs-diagram-pdf\n' > "$FIXTURE_SOURCE_DIR/xetex/pdf/figs__diagram.pdf"

--- a/scripts/texlive_smoke/fixtures/typeset_demo_input_cycle_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_input_cycle_probe_v0.tex
@@ -1,0 +1,11 @@
+\documentclass{article}
+
+\title{CarrelTeX Input Cycle Probe}
+\author{Fixture Bot}
+\date{2026-03-06}
+
+\begin{document}
+\maketitle
+
+\input{cycles/a}
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_input_missing_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_input_missing_probe_v0.tex
@@ -1,0 +1,11 @@
+\documentclass{article}
+
+\title{CarrelTeX Input Missing Probe}
+\author{Fixture Bot}
+\date{2026-03-06}
+
+\begin{document}
+\maketitle
+
+\input{missing/section}
+\end{document}

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -123,9 +123,9 @@
     },
     {
       "id": "typeset_demo_input_include_probe_v0",
-      "tags": ["typeset", "input", "include", "probe", "ni"],
-      "expected_status": "INVALID",
-      "purpose": "Probes input/include resource-hint seam for deterministic on-demand request generation."
+      "tags": ["typeset", "input", "include", "probe", "ok"],
+      "expected_status": "OK",
+      "purpose": "Exercises combined input/include inclusion with deterministic page-break semantics for include."
     },
     {
       "id": "typeset_demo_resource_hints_invalid_probe_v0",
@@ -135,15 +135,27 @@
     },
     {
       "id": "typeset_demo_input_probe_v0",
-      "tags": ["typeset", "input", "probe", "ni"],
-      "expected_status": "NI",
-      "purpose": "Probes input resource-hint extraction and deterministic .tex request mapping."
+      "tags": ["typeset", "input", "probe", "ok"],
+      "expected_status": "OK",
+      "purpose": "Exercises basic \\input inclusion using resolver-backed tex resources."
     },
     {
       "id": "typeset_demo_include_probe_v0",
-      "tags": ["typeset", "include", "probe", "ni"],
-      "expected_status": "NI",
-      "purpose": "Probes include resource-hint extraction and deterministic .tex request mapping."
+      "tags": ["typeset", "include", "probe", "ok"],
+      "expected_status": "OK",
+      "purpose": "Exercises basic \\include inclusion with deterministic page break before included content."
+    },
+    {
+      "id": "typeset_demo_input_cycle_probe_v0",
+      "tags": ["typeset", "input", "cycle", "negative", "probe", "invalid"],
+      "expected_status": "INVALID",
+      "purpose": "Proves fail-closed cycle detection for recursive input/include graphs."
+    },
+    {
+      "id": "typeset_demo_input_missing_probe_v0",
+      "tags": ["typeset", "input", "missing", "negative", "probe", "invalid"],
+      "expected_status": "INVALID",
+      "purpose": "Proves fail-closed missing-file behavior for input inclusion."
     },
     {
       "id": "typeset_demo_ondemand_input_probe_v0",

--- a/scripts/wasm_fixture_gallery_v1/main.mjs
+++ b/scripts/wasm_fixture_gallery_v1/main.mjs
@@ -23,7 +23,7 @@ const STATUS_FAIL_V0 = 'FAIL';
 const STATUS_MISMATCH_V0 = 'MISMATCH';
 const EXPECTED_STATUS_VALUES_V0 = new Set([STATUS_OK_V0, STATUS_NI_V0, STATUS_INVALID_V0, STATUS_FAIL_V0]);
 const DEFAULT_ONDEMAND_FIXEDPOINT_MAX_ITERS_V1 = 3;
-const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'refs', 'bib', 'cite', 'bibitems', 'cites', 'hyperref', 'pkgopt', 'graphics', 'math', 'table'];
+const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'refs', 'bib', 'cite', 'bibitems', 'cites', 'hyperref', 'pkgopt', 'graphics', 'input', 'math', 'table'];
 const TYPED_ARTIFACTS_VERSION_V0 = 1;
 const MAX_TOC_ENTRIES_V0 = 256;
 const MAX_TOC_TITLE_BYTES_V0 = 256;
@@ -38,6 +38,8 @@ const MAX_PKGOPT_VALUE_BYTES_V0 = 256;
 const MAX_PKGOPT_OPTIONS_PER_ENTRY_V0 = 64;
 const MAX_GRAPHICS_ENTRIES_V0 = 256;
 const MAX_GRAPHICS_PATH_BYTES_V0 = 256;
+const MAX_INPUT_ENTRIES_V1 = 512;
+const MAX_INPUT_INCLUDE_DEPTH_V1 = 32;
 const MAX_MATH_ENTRIES_V0 = 256;
 const MAX_MATH_PAYLOAD_BYTES_V0 = 1024;
 const MAX_TABLE_ENTRIES_V0 = 64;
@@ -665,6 +667,16 @@ async function loadFixtureCasesV0() {
       id: 'typeset_demo_include_probe_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_include_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_input_cycle_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_input_cycle_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_input_missing_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_input_missing_probe_v0.tex',
     },
     {
       id: 'typeset_demo_ondemand_input_probe_v0',
@@ -1711,6 +1723,224 @@ function extractGraphicsEntriesFromSourceV0(sourceBytes) {
     index = pathGroup.next;
   }
   return entries;
+}
+
+function normalizeInputIncludeMountPathV1(rawValue) {
+  if (typeof rawValue !== 'string') {
+    return null;
+  }
+  const trimmed = rawValue.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  if (trimmed.startsWith('/') || trimmed.startsWith('\\')) {
+    return null;
+  }
+  if (trimmed.includes('\\')) {
+    return null;
+  }
+  if (/^[A-Za-z]:([\\/]|$)/.test(trimmed)) {
+    return null;
+  }
+  const normalizedSeparators = trimmed.replace(/\\/g, '/');
+  const segments = normalizedSeparators
+    .split('/')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0 && segment !== '.');
+  if (segments.length === 0) {
+    return null;
+  }
+  if (segments.some((segment) => segment === '..' || segment.includes('..'))) {
+    return null;
+  }
+  if (segments.some((segment) => !/^[A-Za-z0-9._-]+$/.test(segment))) {
+    return null;
+  }
+  const normalizedPath = segments.join('/');
+  const lastSegment = segments[segments.length - 1];
+  if (lastSegment.includes('.')) {
+    return normalizedPath;
+  }
+  return `${normalizedPath}.tex`;
+}
+
+function resolverNameFromMountPathV1(mountPath) {
+  if (typeof mountPath !== 'string' || mountPath.length === 0) {
+    return null;
+  }
+  const name = mountPath.replace(/\//g, '__');
+  if (!isSafeResolverTokenV0(name)) {
+    return null;
+  }
+  return name;
+}
+
+function extractInputIncludeDirectivesFromSourceV1(sourceBytes, sourcePath) {
+  const entries = [];
+  let index = 0;
+  while (index < sourceBytes.length) {
+    if (sourceBytes[index] !== 0x5c) {
+      index += 1;
+      continue;
+    }
+    let commandIndex = index + 1;
+    while (commandIndex < sourceBytes.length && isAsciiLetterByteV0(sourceBytes[commandIndex])) {
+      commandIndex += 1;
+    }
+    if (commandIndex === index + 1) {
+      index += 1;
+      continue;
+    }
+    const command = Buffer.from(sourceBytes.slice(index + 1, commandIndex)).toString('ascii');
+    if (command !== 'input' && command !== 'include') {
+      index = commandIndex;
+      continue;
+    }
+    const group = readBracedGroupV0(sourceBytes, commandIndex);
+    if (!group.ok || group.value.length === 0) {
+      index = commandIndex;
+      continue;
+    }
+    const values = splitCommaValuesV0(group.value);
+    for (const rawValue of values) {
+      const mountPath = normalizeInputIncludeMountPathV1(rawValue);
+      if (!mountPath) {
+        continue;
+      }
+      const resolverName = resolverNameFromMountPathV1(mountPath);
+      if (!resolverName) {
+        continue;
+      }
+      entries.push({
+        command,
+        hint_type: command === 'input' ? 'tex_input' : 'tex_include',
+        source_path: sourcePath,
+        value: mountPath,
+        resolver_name: resolverName,
+        source_span: buildSourceSpanV0(sourceBytes, index, group.next, 'input_v1'),
+      });
+    }
+    index = group.next;
+  }
+  return entries;
+}
+
+async function collectInputIncludeGraphV1(sourceBytes, resolver, caseSpec) {
+  const queue = [{
+    source_path: 'main.tex',
+    source_bytes: toUint8ArrayV0(sourceBytes),
+    depth: 0,
+  }];
+  const parsedPaths = new Set(['main.tex']);
+  const resolvedByMountPath = new Map();
+  const resolverRequestsByKey = new Map();
+  const graphEntries = [];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    const directives = extractInputIncludeDirectivesFromSourceV1(current.source_bytes, current.source_path);
+    for (const directive of directives) {
+      if (graphEntries.length >= MAX_INPUT_ENTRIES_V1) {
+        throw new Error(`input_v1 entries exceed cap ${MAX_INPUT_ENTRIES_V1}`);
+      }
+      const request = {
+        kind: 'texmf',
+        format: 'tex',
+        name: directive.resolver_name,
+        variant: caseSpec.mode,
+        hint_type: directive.hint_type,
+      };
+      resolverRequestsByKey.set(resolverRequestKeyV0(request), request);
+
+      let resolution = resolvedByMountPath.get(directive.value);
+      if (!resolution) {
+        resolution = await resolver.resolve({
+          kind: request.kind,
+          format: request.format,
+          name: request.name,
+          variant: request.variant,
+          resolver_id: resolver.resolverId,
+        });
+        resolvedByMountPath.set(directive.value, resolution);
+      }
+
+      const resolved = resolution.tag === 'Found';
+      if (current.source_path === 'main.tex') {
+        graphEntries.push({
+          command: directive.command,
+          source_path: directive.source_path,
+          value: directive.value,
+          resolver_name: directive.resolver_name,
+          source_span: directive.source_span,
+        });
+      }
+
+      if (!resolved || parsedPaths.has(directive.value)) {
+        continue;
+      }
+      if (current.depth + 1 > MAX_INPUT_INCLUDE_DEPTH_V1) {
+        throw new Error(`input_v1 include depth exceeds cap ${MAX_INPUT_INCLUDE_DEPTH_V1}`);
+      }
+      parsedPaths.add(directive.value);
+      queue.push({
+        source_path: directive.value,
+        source_bytes: toUint8ArrayV0(resolution.bytes),
+        depth: current.depth + 1,
+      });
+    }
+  }
+
+  graphEntries.sort((left, right) => {
+    const sourceCmp = left.source_path.localeCompare(right.source_path);
+    if (sourceCmp !== 0) {
+      return sourceCmp;
+    }
+    const startCmp = left.source_span.start_byte - right.source_span.start_byte;
+    if (startCmp !== 0) {
+      return startCmp;
+    }
+    const endCmp = left.source_span.end_byte - right.source_span.end_byte;
+    if (endCmp !== 0) {
+      return endCmp;
+    }
+    const commandCmp = left.command.localeCompare(right.command);
+    if (commandCmp !== 0) {
+      return commandCmp;
+    }
+    return left.value.localeCompare(right.value);
+  });
+
+  const mountedFiles = [...resolvedByMountPath.entries()]
+    .filter(([, resolution]) => resolution.tag === 'Found')
+    .sort(([leftPath], [rightPath]) => leftPath.localeCompare(rightPath))
+    .map(([mountPath, resolution]) => [mountPath, toUint8ArrayV0(resolution.bytes)]);
+
+  const resolverRequests = [...resolverRequestsByKey.values()]
+    .sort((left, right) => resolverRequestKeyV0(left).localeCompare(resolverRequestKeyV0(right)));
+
+  return {
+    entries: graphEntries,
+    mounted_files: mountedFiles,
+    resolver_requests: resolverRequests,
+  };
+}
+
+async function emitInputTypedArtifactV1(caseOutDir, inputEntries) {
+  const payload = {
+    version: TYPED_ARTIFACTS_VERSION_V0,
+    schema: 'input_v1',
+    entries: inputEntries,
+  };
+  const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  const relpath = 'input_v1.json';
+  const fullPath = path.join(caseOutDir, relpath);
+  await writeFile(fullPath, bytes);
+  return {
+    present: true,
+    items: payload.entries.length,
+    artifact_relpath: relpath,
+    artifact_sha256: sha256HexV0(bytes),
+  };
 }
 
 function addResourceHintEntryV0(entries, sourceBytes, caseId, hintType, value, startByte, endByte) {
@@ -2904,7 +3134,13 @@ async function emitEmptyResourceHintsArtifactV0(caseOutDir) {
   };
 }
 
-async function emitTypedArtifactsV0(caseSpec, caseOutDir, typedArtifacts, fixtureBytes) {
+async function emitTypedArtifactsV0(
+  caseSpec,
+  caseOutDir,
+  typedArtifacts,
+  fixtureBytes,
+  inputEntries = [],
+) {
   if (caseSpec.id === 'typeset_demo_toc_probe_v0') {
     typedArtifacts.toc = await emitTocTypedArtifactV0(caseOutDir, fixtureBytes);
   }
@@ -2940,6 +3176,9 @@ async function emitTypedArtifactsV0(caseSpec, caseOutDir, typedArtifacts, fixtur
   }
   if (caseSpec.id === 'typeset_demo_graphics_probe_v0') {
     typedArtifacts.graphics = await emitGraphicsTypedArtifactV0(caseOutDir, fixtureBytes);
+  }
+  if (caseSpec.mode === 'typeset' && Array.isArray(inputEntries) && inputEntries.length > 0) {
+    typedArtifacts.input = await emitInputTypedArtifactV1(caseOutDir, inputEntries);
   }
 }
 
@@ -3176,6 +3415,19 @@ async function collectResolverRequestsFromTypedArtifactsV0(caseSpec, caseOutDir,
     }
   }
 
+  const inputRelpath = typedArtifacts?.input?.artifact_relpath;
+  if (typedArtifacts?.input?.present === true && typeof inputRelpath === 'string' && inputRelpath.length > 0) {
+    const inputPayload = JSON.parse((await readFile(path.join(caseOutDir, inputRelpath))).toString('utf8'));
+    const inputEntries = Array.isArray(inputPayload?.entries) ? inputPayload.entries : [];
+    for (const entry of inputEntries) {
+      if (typeof entry?.value !== 'string' || entry.value.length === 0) {
+        continue;
+      }
+      const hintType = entry?.command === 'include' ? 'tex_include' : 'tex_input';
+      addTexmfRequest(entry.value, 'tex', hintType);
+    }
+  }
+
   return [...requestsByKey.values()].sort((left, right) => resolverRequestKeyV0(left).localeCompare(resolverRequestKeyV0(right)));
 }
 
@@ -3327,6 +3579,11 @@ async function runCaseV0(
   let report = { status: 'INVALID_INPUT' };
   let caseStatus = STATUS_FAIL_V0;
   let errorMessage = '';
+  let inputInclusionGraph = {
+    entries: [],
+    mounted_files: [],
+    resolver_requests: [],
+  };
 
   try {
     if (ctx.mountReset() !== 0) {
@@ -3334,6 +3591,18 @@ async function runCaseV0(
     }
     if (helpers.addMountedFile('main.tex', fixtureBytes, `${caseSpec.id}_main`) !== 0) {
       throw new Error('mount_add_file(main.tex) failed');
+    }
+    if (caseSpec.mode === 'typeset') {
+      inputInclusionGraph = await collectInputIncludeGraphV1(fixtureBytes, resolver, caseSpec);
+      for (const [mountPath, mountBytes] of inputInclusionGraph.mounted_files) {
+        if (mountPath === 'main.tex') {
+          continue;
+        }
+        const mountLabel = `${caseSpec.id}_${mountPath.replaceAll('/', '__')}`;
+        if (helpers.addMountedFile(mountPath, mountBytes, mountLabel) !== 0) {
+          throw new Error(`mount_add_file(${mountPath}) failed`);
+        }
+      }
     }
     if (ctx.mountFinalize() !== 0) {
       throw new Error('mount_finalize failed');
@@ -3423,6 +3692,9 @@ async function runCaseV0(
     hint_type: 'entrypoint',
   };
   resolverRequestsByKey.set(resolverRequestKeyV0(rootResolverRequest), rootResolverRequest);
+  for (const request of inputInclusionGraph.resolver_requests) {
+    resolverRequestsByKey.set(resolverRequestKeyV0(request), request);
+  }
 
   const summary = {
     case_id: caseSpec.id,
@@ -3468,7 +3740,13 @@ async function runCaseV0(
     errorMessage = errorMessage ? `${errorMessage}; ${message}` : message;
     summary.status = caseStatus;
   }
-  await emitTypedArtifactsV0(caseSpec, caseOutDir, summary.typed_artifacts, fixtureBytes);
+  await emitTypedArtifactsV0(
+    caseSpec,
+    caseOutDir,
+    summary.typed_artifacts,
+    fixtureBytes,
+    inputInclusionGraph.entries,
+  );
   const typedArtifactRequests = await collectResolverRequestsFromResourceHintsV0(
     caseSpec,
     caseOutDir,

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_baseline_generator.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_baseline_generator.cjs
@@ -47,7 +47,7 @@ if (!indexB.typed_artifact_sha256 || typeof indexB.typed_artifact_sha256 !== 'ob
   console.error('FAIL: baseline index rerun missing typed_artifact_sha256 map');
   process.exit(1);
 }
-const typedKeys = ['toc', 'labels', 'bib', 'cite', 'hyperref', 'pkgopt', 'graphics', 'math', 'table'];
+const typedKeys = ['toc', 'labels', 'bib', 'cite', 'hyperref', 'pkgopt', 'graphics', 'input', 'math', 'table'];
 for (const key of typedKeys) {
   const valueA = indexA.typed_artifact_sha256[key];
   const valueB = indexB.typed_artifact_sha256[key];

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
@@ -677,7 +677,7 @@ if (!typedArtifactShaMap || typeof typedArtifactShaMap !== 'object') {
   console.error('FAIL: expected report.typed_artifact_sha256 map after first run');
   process.exit(1);
 }
-const typedKeys = ['toc', 'labels', 'bib', 'cite', 'hyperref', 'pkgopt', 'graphics', 'math', 'table'];
+const typedKeys = ['toc', 'labels', 'bib', 'cite', 'hyperref', 'pkgopt', 'graphics', 'input', 'math', 'table'];
 for (const key of typedKeys) {
   const value = typedArtifactShaMap[key];
   if (typeof value !== 'string' || !/^[0-9a-f]{64}$/.test(value)) {
@@ -685,6 +685,31 @@ for (const key of typedKeys) {
     process.exit(1);
   }
 }
+
+const inputProbeSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_input_probe_v0', 'summary.json'), 'utf8'),
+);
+if (inputProbeSummary?.typed_artifacts?.input?.present !== true) {
+  console.error('FAIL: expected input_v1 artifact present for typeset_demo_input_probe_v0');
+  process.exit(1);
+}
+if (!(inputProbeSummary?.typed_artifacts?.input?.items > 0)) {
+  console.error('FAIL: expected non-empty input_v1 entries for typeset_demo_input_probe_v0');
+  process.exit(1);
+}
+
+const includeProbeSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_include_probe_v0', 'summary.json'), 'utf8'),
+);
+if (includeProbeSummary?.typed_artifacts?.input?.present !== true) {
+  console.error('FAIL: expected input_v1 artifact present for typeset_demo_include_probe_v0');
+  process.exit(1);
+}
+if (!(includeProbeSummary?.typed_artifacts?.input?.items > 0)) {
+  console.error('FAIL: expected non-empty input_v1 entries for typeset_demo_include_probe_v0');
+  process.exit(1);
+}
+
 fs.writeFileSync(
   path.join(baselineRoot, 'typed_artifact_sha256_first.json'),
   `${JSON.stringify(typedArtifactShaMap, null, 2)}\n`,

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_request_list.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_request_list.cjs
@@ -185,6 +185,20 @@ if (!includeProbeRequest) {
   console.error('FAIL: request list must include include probe hint request for chapters__ch1.tex');
   process.exit(1);
 }
+const inputCycleProbeRequest = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'tex' && request.name === 'cycles__a.tex' && request.variant === 'typeset',
+);
+if (!inputCycleProbeRequest) {
+  console.error('FAIL: request list must include input cycle probe hint request for cycles__a.tex');
+  process.exit(1);
+}
+const inputMissingProbeRequest = listA.requests.find(
+  (request) => request.kind === 'texmf' && request.format === 'tex' && request.name === 'missing__section.tex' && request.variant === 'typeset',
+);
+if (!inputMissingProbeRequest) {
+  console.error('FAIL: request list must include input missing probe hint request for missing__section.tex');
+  process.exit(1);
+}
 const ondemandInputProbeRequest = listA.requests.find(
   (request) => request.kind === 'texmf' && request.format === 'tex' && request.name === 'ondemand__extra_section.tex' && request.variant === 'typeset',
 );

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
@@ -63,7 +63,7 @@ if (resourceHintsShaSecond !== resourceHintsShaFirst) {
   console.error('FAIL: report.resource_hints_v0 must be stable across reruns');
   process.exit(1);
 }
-const requiredTypedKeys = ['toc', 'labels', 'refs', 'bib', 'cite', 'hyperref', 'pkgopt', 'graphics', 'math', 'table'];
+const requiredTypedKeys = ['toc', 'labels', 'refs', 'bib', 'cite', 'hyperref', 'pkgopt', 'graphics', 'input', 'math', 'table'];
 const labelsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'labels_v1_first.sha256'), 'utf8').trim();
 const refsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'refs_v1_first.sha256'), 'utf8').trim();
 const tocShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'toc_v1_first.sha256'), 'utf8').trim();
@@ -122,6 +122,16 @@ if (!graphicsOptionsInvalidStatus || graphicsOptionsInvalidStatus.status !== 'IN
 const resourceHintsInvalidStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_resource_hints_invalid_probe_v0');
 if (!resourceHintsInvalidStatus || resourceHintsInvalidStatus.status !== 'INVALID') {
   console.error('FAIL: expected typeset_demo_resource_hints_invalid_probe_v0 status INVALID');
+  process.exit(1);
+}
+const inputCycleInvalidStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_input_cycle_probe_v0');
+if (!inputCycleInvalidStatus || inputCycleInvalidStatus.status !== 'INVALID') {
+  console.error('FAIL: expected typeset_demo_input_cycle_probe_v0 status INVALID');
+  process.exit(1);
+}
+const inputMissingInvalidStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_input_missing_probe_v0');
+if (!inputMissingInvalidStatus || inputMissingInvalidStatus.status !== 'INVALID') {
+  console.error('FAIL: expected typeset_demo_input_missing_probe_v0 status INVALID');
   process.exit(1);
 }
 for (const status of okStatuses) {


### PR DESCRIPTION
## Summary
- add `\include{...}` support in compile-time expansion with v1 semantics (`\pagebreak` + inlined content)
- fail closed if unresolved `\input` / `\include` remain after expansion
- wire fixture gallery prefetch/mount for input/include references and emit stable `input_v1` typed artifacts
- add deterministic cycle/missing probes and proof assertions for input/include behavior

## Scope
- locked packet: `\input` / `\include` v1 actual inclusion (single PR)

## Frozen head
`a7af196cc209294425606b9b0b22d15206e0ef57`

Proof tails are posted in the PR comments.
