### PR TITLE
typeset: hyperref annotations v2 across input/include anchors

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -46,6 +46,28 @@ fn layout_lines_bytes(main: &[u8]) -> Vec<Vec<u8>> {
         .collect()
 }
 
+fn layout_text_from_xdv_bytes(xdv_bytes: &[u8]) -> String {
+    let layout = parse_dvi_v2_text_page_to_layout_v0(xdv_bytes, 917_504).expect("layout parse");
+    let mut out = Vec::<u8>::new();
+    for (page_index, page) in layout.pages.iter().enumerate() {
+        if page_index > 0 {
+            out.push(0x0c);
+            out.push(b'\n');
+        }
+        for line in &page.lines {
+            out.extend(line.glyphs.iter().map(|glyph| glyph.byte));
+            out.push(b'\n');
+        }
+    }
+    String::from_utf8_lossy(&out).to_string()
+}
+
+fn compile_typeset_text_with_files(main: &[u8], extra_files: &[(&[u8], &[u8])]) -> String {
+    let result = compile_typeset_with_files(main, extra_files);
+    assert_eq!(result.status, CompileStatus::Ok);
+    layout_text_from_xdv_bytes(&result.main_xdv_bytes)
+}
+
 #[test]
 fn typeset_minimal_subset_compiles_ok() {
     let main = b"\\documentclass{article}\\title{CarrelTeX Minimal Typeset Demo}\\author{Alice \\and Bob}\\date{2026-03-04}\\begin{document}\\maketitle Hello, world. This is a paragraph with \\emph{emphasis} and \\textbf{bold}.\\end{document}";
@@ -103,6 +125,39 @@ fn typeset_minimal_include_emits_forced_page_break_before_inlined_file() {
     .to_string();
     assert!(page1.contains("PageA"), "page1={page1:?}");
     assert!(page2.contains("Included section. PageB"), "page2={page2:?}");
+}
+
+#[test]
+fn typeset_minimal_hyperref_labels_from_input_resolve_in_main_document_order_v2() {
+    let main = b"\\documentclass{article}\\begin{document}\\input{sections/one}Main ref \\ref{sec:one}.\\href{https://example.com}{link}\\end{document}";
+    let included = b"\\section{Included One}\\label{sec:one}Included body.";
+    let text = compile_typeset_text_with_files(main, &[(b"sections/one.tex", included)]);
+    assert!(text.contains("@S {Included One}"), "text={text:?}");
+    assert!(
+        text.contains("!l sec:one 1 heading 1 Included One"),
+        "text={text:?}"
+    );
+    assert!(text.contains("Main ref <1>."), "text={text:?}");
+    assert!(text.contains("!r sec:one "), "text={text:?}");
+    assert!(text.contains("!ra 1 1"), "text={text:?}");
+}
+
+#[test]
+fn typeset_minimal_hyperref_refs_keep_anchor_order_across_include_boundaries_v2() {
+    let main = b"\\documentclass{article}\\begin{document}\\section{Main}\\label{sec:main}\\include{sections/two}Refs: \\ref{sec:two}, \\ref{fig:two}, \\ref{eq:two}.\\href{https://example.com}{link}\\end{document}";
+    let included = b"\\section{Included Two}\\label{sec:two}\\begin{figure}\\caption{Included figure}\\end{figure}\\label{fig:two}\\[x+y\\]\\label{eq:two}";
+    let text = compile_typeset_text_with_files(main, &[(b"sections/two.tex", included)]);
+    assert!(text.contains("!l sec:main 1 heading 1 Main"), "text={text:?}");
+    assert!(
+        text.contains("!l sec:two 2 heading 1 Included Two"),
+        "text={text:?}"
+    );
+    assert!(text.contains("!l fig:two 3 figure 1 -"), "text={text:?}");
+    assert!(text.contains("!l eq:two 4 equation 1 -"), "text={text:?}");
+    assert!(text.contains("Refs: <2>, <1>, <1>."), "text={text:?}");
+    assert!(text.contains("!ra 1 2"), "text={text:?}");
+    assert!(text.contains("!ra 2 3"), "text={text:?}");
+    assert!(text.contains("!ra 3 4"), "text={text:?}");
 }
 
 #[test]
@@ -230,6 +285,19 @@ fn typeset_minimal_toc_entries_follow_heading_order_with_stable_anchors() {
     let second = text.find("!toc 2 2 Two").expect("second toc entry");
     let third = text.find("!toc 1 3 Three").expect("third toc entry");
     assert!(first < second && second < third, "body={text:?}");
+}
+
+#[test]
+fn typeset_minimal_toc_links_keep_input_heading_anchor_order_with_hyperref_v2() {
+    let main = b"\\documentclass{article}\\title{T}\\author{A}\\date{D}\\begin{document}\\maketitle\\tableofcontents\\input{sections/toc}\\section{Tail}\\href{https://example.com}{link}\\end{document}";
+    let included = b"\\section{Input Section}\\subsection{Input Detail}";
+    let text = compile_typeset_text_with_files(main, &[(b"sections/toc.tex", included)]);
+    let first = text.find("!toc 1 1 <Input Section>").expect("first toc entry");
+    let second = text
+        .find("!toc 2 2 <Input Detail>")
+        .expect("second toc entry");
+    let third = text.find("!toc 1 3 <Tail>").expect("third toc entry");
+    assert!(first < second && second < third, "text={text:?}");
 }
 
 #[test]

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -351,9 +351,35 @@ fn split_superscript_segments_v0(segments: &[PdfStyledSegmentV0]) -> Vec<PdfRend
     out
 }
 
+fn is_structured_non_title_line_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    detect_heading_prefix_v0(glyphs).is_some()
+        || detect_list_prefix_v0(glyphs).is_some()
+        || detect_quote_prefix_advance_pt_v0(glyphs).is_some()
+        || has_center_prefix_v0(glyphs)
+        || has_right_prefix_v0(glyphs)
+        || has_noindent_prefix_v0(glyphs)
+        || has_table_row_prefix_v0(glyphs)
+        || has_figure_box_prefix_v0(glyphs)
+        || has_figure_caption_prefix_v0(glyphs)
+        || has_figure_image_prefix_v0(glyphs)
+        || has_toc_placeholder_line_v0(glyphs)
+        || has_toc_entry_line_prefix_v0(glyphs)
+        || has_footnote_line_prefix_v0(glyphs)
+        || has_href_url_line_prefix_v0(glyphs)
+        || has_label_line_prefix_v0(glyphs)
+        || has_ref_line_prefix_v0(glyphs)
+        || has_ref_anchor_link_line_prefix_v0(glyphs)
+        || has_equation_line_prefix_v0(glyphs)
+        || has_bibitem_line_prefix_v0(glyphs)
+        || has_cite_line_prefix_v0(glyphs)
+}
+
 fn detect_title_block_len_v0(lines: &[LinePlanV0]) -> usize {
     let mut index = 0usize;
-    while index < lines.len() && !lines[index].glyphs.is_empty() {
+    while index < lines.len()
+        && !lines[index].glyphs.is_empty()
+        && !is_structured_non_title_line_v0(&lines[index].glyphs)
+    {
         index += 1;
     }
     if index > 0 && index < lines.len() {

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -698,6 +698,21 @@ fn parse_pdf_annotation_dest_page_id_v0(body: &str) -> Option<u32> {
     fields[0].parse::<u32>().ok()
 }
 
+fn parse_pdf_annotation_dest_xyz_v0(body: &str) -> Option<(u32, f32, f32)> {
+    let marker = "/Dest [";
+    let start = body.find(marker)? + marker.len();
+    let end = body[start..].find(']')? + start;
+    let fields = body[start..end].split_whitespace().collect::<Vec<_>>();
+    if fields.len() < 6 || fields[1] != "0" || fields[2] != "R" || fields[3] != "/XYZ" {
+        return None;
+    }
+    let page_id = fields[0].parse::<u32>().ok()?;
+    let x_pt = fields[4].parse::<f32>().ok()?;
+    let y_token = fields[5].trim_end_matches(']');
+    let y_pt = y_token.parse::<f32>().ok()?;
+    Some((page_id, x_pt, y_pt))
+}
+
 fn parse_pdf_action_uri_v0(body: &str) -> Option<String> {
     let marker = "/URI (";
     let start = body.find(marker)? + marker.len();
@@ -2971,6 +2986,40 @@ fn pdf_renderer_emits_toc_link_annotations_targeting_heading_anchors_v0() {
             "annotation rect must stay within page bounds: {rect:?}"
         );
     }
+}
+
+#[test]
+fn pdf_renderer_toc_annotation_destination_order_is_stable_v2() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"Prelude.\n\n!toc\n\n@S {Intro section}\n\n@s {Detail section}\n\n!toc 1 1 <Intro section>\n!toc 2 2 <Detail section>",
+    ).expect("writer should accept toc metadata and heading lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let page_one = parse_pdf_object_body_v0(&pdf, 3).expect("page object");
+    let annots = parse_pdf_ref_ids_v0(&page_one, "/Annots");
+    assert_eq!(annots.len(), 2, "expected two toc annotations");
+
+    let destinations = annots
+        .iter()
+        .map(|id| {
+            let body = parse_pdf_object_body_v0(&pdf, *id).expect("annotation body");
+            parse_pdf_annotation_dest_xyz_v0(&body).expect("annotation destination")
+        })
+        .collect::<Vec<_>>();
+    for (page_id, _, _) in &destinations {
+        assert_eq!(
+            *page_id,
+            3,
+            "toc annotations should target page containing heading anchors"
+        );
+    }
+
+    let (_, _, section_y) = destinations[0];
+    let (_, _, subsection_y) = destinations[1];
+    assert!(
+        section_y > subsection_y,
+        "section anchor should appear above subsection anchor: {destinations:?}"
+    );
 }
 
 #[test]

--- a/scripts/proof_wasm_fixture_gallery_v0.sh
+++ b/scripts/proof_wasm_fixture_gallery_v0.sh
@@ -51,8 +51,46 @@ printf 'fixture-bytes-for-chapters-intro\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/cha
 printf 'fixture-bytes-for-chapters-appendix\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapters__appendix.tex"
 printf 'fixture-bytes-for-sections-intro-nested\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/sections/intro.tex"
 printf 'fixture-bytes-for-chapters-ch1-nested\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapters/ch1.tex"
+cat > "$FIXTURE_SOURCE_DIR/xetex/tex/sections/one.tex" <<'EOF'
+\section{Included One}
+\label{sec:one}
+Included section body.
+EOF
+cat > "$FIXTURE_SOURCE_DIR/xetex/tex/sections/two.tex" <<'EOF'
+\section{Included Two}
+\label{sec:two}
+\begin{figure}
+\caption{Included figure}
+\end{figure}
+\label{fig:two}
+\[x+y\]
+\label{eq:two}
+EOF
+cat > "$FIXTURE_SOURCE_DIR/xetex/tex/sections/toc_headings.tex" <<'EOF'
+\section{Input Section}
+\subsection{Input Detail}
+EOF
 printf 'fixture-bytes-for-sections-intro-normalized\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/sections__intro.tex"
 printf 'fixture-bytes-for-chapters-ch1-normalized\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/chapters__ch1.tex"
+cat > "$FIXTURE_SOURCE_DIR/xetex/tex/sections__one.tex" <<'EOF'
+\section{Included One}
+\label{sec:one}
+Included section body.
+EOF
+cat > "$FIXTURE_SOURCE_DIR/xetex/tex/sections__two.tex" <<'EOF'
+\section{Included Two}
+\label{sec:two}
+\begin{figure}
+\caption{Included figure}
+\end{figure}
+\label{fig:two}
+\[x+y\]
+\label{eq:two}
+EOF
+cat > "$FIXTURE_SOURCE_DIR/xetex/tex/sections__toc_headings.tex" <<'EOF'
+\section{Input Section}
+\subsection{Input Detail}
+EOF
 printf 'fixture-bytes-for-ondemand-extra-section-nested\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/ondemand/extra_section.tex"
 printf 'fixture-bytes-for-ondemand-chapter-one-nested\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/ondemand/chapter_one.tex"
 printf 'fixture-bytes-for-ondemand-extra-section-normalized\n' > "$FIXTURE_SOURCE_DIR/xetex/tex/ondemand__extra_section.tex"

--- a/scripts/texlive_smoke/fixtures/typeset_demo_hyperref_include_label_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_hyperref_include_label_probe_v0.tex
@@ -1,0 +1,11 @@
+\documentclass{article}
+
+\begin{document}
+\section{Main section}
+\label{sec:main}
+
+\include{sections/two}
+
+Cross-file refs: \ref{sec:two}, \ref{fig:two}, \ref{eq:two}.
+\href{https://example.com/include}{Include link}
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_hyperref_input_label_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_hyperref_input_label_probe_v0.tex
@@ -1,0 +1,8 @@
+\documentclass{article}
+
+\begin{document}
+\input{sections/one}
+
+Reference to included heading: \ref{sec:one}.
+\href{https://example.com/input}{Input link}
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_hyperref_toc_input_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_hyperref_toc_input_probe_v0.tex
@@ -1,0 +1,13 @@
+\documentclass{article}
+
+\title{Input TOC Hyperref Probe}
+\author{Fixture Bot}
+\date{2026-03-06}
+
+\begin{document}
+\maketitle
+\tableofcontents
+\input{sections/toc_headings}
+\section{Tail section}
+\href{https://example.com/toc}{TOC link}
+\end{document}

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -128,6 +128,24 @@
       "purpose": "Exercises combined input/include inclusion with deterministic page-break semantics for include."
     },
     {
+      "id": "typeset_demo_hyperref_input_label_probe_v0",
+      "tags": ["typeset", "hyperref", "input", "labels", "refs", "probe", "ok"],
+      "expected_status": "OK",
+      "purpose": "Exercises label/ref hyperlink resolution when section anchors are defined inside input-expanded content."
+    },
+    {
+      "id": "typeset_demo_hyperref_include_label_probe_v0",
+      "tags": ["typeset", "hyperref", "include", "labels", "refs", "figure", "equation", "probe", "ok"],
+      "expected_status": "OK",
+      "purpose": "Exercises deterministic ref target mapping across include page boundaries for heading/figure/equation anchors."
+    },
+    {
+      "id": "typeset_demo_hyperref_toc_input_probe_v0",
+      "tags": ["typeset", "hyperref", "toc", "input", "probe", "ok"],
+      "expected_status": "OK",
+      "purpose": "Exercises TOC hyperlink anchor mapping when headings originate from input-expanded files."
+    },
+    {
       "id": "typeset_demo_resource_hints_invalid_probe_v0",
       "tags": ["typeset", "resource-hints", "invalid", "unsafe-path", "probe"],
       "expected_status": "INVALID",

--- a/scripts/wasm_fixture_gallery_v1/main.mjs
+++ b/scripts/wasm_fixture_gallery_v1/main.mjs
@@ -673,6 +673,21 @@ async function loadFixtureCasesV0() {
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_input_include_probe_v0.tex',
     },
     {
+      id: 'typeset_demo_hyperref_input_label_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_hyperref_input_label_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_hyperref_include_label_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_hyperref_include_label_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_hyperref_toc_input_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_hyperref_toc_input_probe_v0.tex',
+    },
+    {
       id: 'typeset_demo_input_probe_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_input_probe_v0.tex',


### PR DESCRIPTION
## Summary\n- stabilize title-block detection so structured heading/list/metadata lines are never misclassified as title lines in PDF preview\n- add cross-file hyperref label/ref + TOC anchor coverage for input/include-expanded fixtures\n- wire new fixtures into gallery manifest + runner and seed deterministic fixture-source blobs in gallery proof\n\n## Proofs\n- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests\n- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml\n- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12\n- ./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25