### PR TITLE
typeset_minimal graphics v2 includegraphics sizing subset

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -50,6 +50,11 @@ const TABLE_ROW_PREFIX_MARKER_V0: &[u8] = b"!t ";
 const FIGURE_BOX_PREFIX_MARKER_V0: &[u8] = b"!gbox";
 const FIGURE_IMAGE_PREFIX_MARKER_V0: &[u8] = b"!gimg ";
 const FIGURE_CAPTION_PREFIX_MARKER_V0: &[u8] = b"!gcap ";
+const DEFAULT_FIGURE_PLACEHOLDER_WIDTH_MPT_V0: u32 = 180_000;
+const DEFAULT_FIGURE_PLACEHOLDER_HEIGHT_MPT_V0: u32 = 120_000;
+const MAX_FIGURE_PLACEHOLDER_WIDTH_MPT_V0: u32 = 468_000;
+const MAX_FIGURE_PLACEHOLDER_HEIGHT_MPT_V0: u32 = 288_000;
+const INCLUDEGRAPHICS_ALLOWED_WIDTH_UNITS_V0: [&[u8]; 4] = [b"pt", b"mm", b"cm", b"in"];
 const TOC_PLACEHOLDER_MARKER_V0: &[u8] = b"!toc";
 const TOC_ENTRY_LINE_PREFIX_MARKER_V0: &[u8] = b"!toc ";
 const REF_MARKER_PREFIX_V0: &[u8] = b"@@REF:";
@@ -150,6 +155,18 @@ struct CiteOccurrenceMetaV0 {
     key: Vec<u8>,
     line_index: u32,
     resolved_ordinal: Option<u32>,
+}
+
+#[derive(Clone, Copy)]
+struct FigureSizingMptV0 {
+    width_mpt: u32,
+    height_mpt: u32,
+}
+
+#[derive(Clone)]
+struct IncludeGraphicsCommandV0 {
+    path: Vec<u8>,
+    sizing: FigureSizingMptV0,
 }
 
 #[derive(Default)]
@@ -1036,6 +1053,214 @@ fn has_allowed_graphics_extension_v0(path: &[u8]) -> bool {
     matches!(ext.as_slice(), b"png" | b"jpg" | b"jpeg" | b"pdf")
 }
 
+fn parse_decimal_milli_v0(value: &[u8]) -> Option<u32> {
+    if value.is_empty() {
+        return None;
+    }
+    if value.iter().any(|byte| matches!(byte, b'+' | b'-' | b'e' | b'E')) {
+        return None;
+    }
+    let mut dot_index = None::<usize>;
+    for (index, byte) in value.iter().enumerate() {
+        if *byte == b'.' {
+            if dot_index.is_some() {
+                return None;
+            }
+            dot_index = Some(index);
+            continue;
+        }
+        if !byte.is_ascii_digit() {
+            return None;
+        }
+    }
+    let (int_part, frac_part) = if let Some(index) = dot_index {
+        (&value[..index], &value[index + 1..])
+    } else {
+        (value, &b""[..])
+    };
+    if int_part.is_empty() || frac_part.len() > 3 {
+        return None;
+    }
+    let int_value = std::str::from_utf8(int_part).ok()?.parse::<u64>().ok()?;
+    let mut frac_value = 0u64;
+    if !frac_part.is_empty() {
+        frac_value = std::str::from_utf8(frac_part).ok()?.parse::<u64>().ok()?;
+        for _ in 0..(3 - frac_part.len()) {
+            frac_value = frac_value.checked_mul(10)?;
+        }
+    }
+    let milli = int_value.checked_mul(1000)?.checked_add(frac_value)?;
+    if milli == 0 || milli > u32::MAX as u64 {
+        return None;
+    }
+    Some(milli as u32)
+}
+
+fn convert_dimension_to_milli_pt_v0(value_milli: u32, unit: &[u8]) -> Option<u32> {
+    let value = u64::from(value_milli);
+    let converted = if unit == b"pt" {
+        value
+    } else if unit == b"in" {
+        value.checked_mul(72)?
+    } else if unit == b"cm" {
+        value.checked_mul(3600)?.checked_div(127)?
+    } else if unit == b"mm" {
+        value.checked_mul(360)?.checked_div(127)?
+    } else {
+        return None;
+    };
+    if converted == 0 || converted > u32::MAX as u64 {
+        return None;
+    }
+    Some(converted as u32)
+}
+
+fn parse_dimension_milli_pt_v0(value: &[u8]) -> Option<u32> {
+    let trimmed = trim_horizontal_space_bytes_v0(value);
+    if trimmed.is_empty() {
+        return None;
+    }
+    let mut suffix_start = trimmed.len();
+    while suffix_start > 0 && trimmed[suffix_start - 1].is_ascii_alphabetic() {
+        suffix_start -= 1;
+    }
+    let unit = if suffix_start == trimmed.len() {
+        b"pt".as_slice()
+    } else {
+        &trimmed[suffix_start..]
+    };
+    if !INCLUDEGRAPHICS_ALLOWED_WIDTH_UNITS_V0
+        .iter()
+        .any(|allowed| *allowed == unit)
+    {
+        return None;
+    }
+    let number_part = trim_horizontal_space_bytes_v0(&trimmed[..suffix_start]);
+    let value_milli = parse_decimal_milli_v0(number_part)?;
+    convert_dimension_to_milli_pt_v0(value_milli, unit)
+}
+
+fn scale_dimension_milli_pt_v0(base_milli: u32, scale_milli: u32) -> Option<u32> {
+    let scaled = u64::from(base_milli)
+        .checked_mul(u64::from(scale_milli))?
+        .checked_div(1000)?;
+    if scaled == 0 || scaled > u32::MAX as u64 {
+        return None;
+    }
+    Some(scaled as u32)
+}
+
+fn scale_by_ratio_milli_pt_v0(value: u32, numerator: u32, denominator: u32) -> Option<u32> {
+    let scaled = u64::from(value)
+        .checked_mul(u64::from(numerator))?
+        .checked_div(u64::from(denominator))?;
+    if scaled == 0 || scaled > u32::MAX as u64 {
+        return None;
+    }
+    Some(scaled as u32)
+}
+
+fn apply_figure_sizing_caps_v0(sizing: FigureSizingMptV0) -> FigureSizingMptV0 {
+    FigureSizingMptV0 {
+        width_mpt: sizing
+            .width_mpt
+            .min(MAX_FIGURE_PLACEHOLDER_WIDTH_MPT_V0)
+            .max(1),
+        height_mpt: sizing
+            .height_mpt
+            .min(MAX_FIGURE_PLACEHOLDER_HEIGHT_MPT_V0)
+            .max(1),
+    }
+}
+
+fn parse_includegraphics_options_v0(raw: &[u8]) -> Option<FigureSizingMptV0> {
+    let mut width_mpt = None::<u32>;
+    let mut height_mpt = None::<u32>;
+    let mut scale_milli = None::<u32>;
+    let mut saw_entry = false;
+    for chunk in raw.split(|byte| *byte == b',') {
+        let trimmed = trim_horizontal_space_bytes_v0(chunk);
+        if trimmed.is_empty() {
+            return None;
+        }
+        saw_entry = true;
+        let equals_index = trimmed.iter().position(|byte| *byte == b'=')?;
+        if equals_index == 0 || equals_index + 1 >= trimmed.len() {
+            return None;
+        }
+        let key = trim_horizontal_space_bytes_v0(&trimmed[..equals_index])
+            .iter()
+            .map(u8::to_ascii_lowercase)
+            .collect::<Vec<u8>>();
+        let value = trim_horizontal_space_bytes_v0(&trimmed[equals_index + 1..]);
+        if value.is_empty() {
+            return None;
+        }
+        match key.as_slice() {
+            b"width" => {
+                if width_mpt.is_some() {
+                    return None;
+                }
+                width_mpt = Some(parse_dimension_milli_pt_v0(value)?);
+            }
+            b"height" => {
+                if height_mpt.is_some() {
+                    return None;
+                }
+                height_mpt = Some(parse_dimension_milli_pt_v0(value)?);
+            }
+            b"scale" => {
+                if scale_milli.is_some() {
+                    return None;
+                }
+                scale_milli = Some(parse_decimal_milli_v0(value)?);
+            }
+            _ => return None,
+        }
+    }
+    if !saw_entry {
+        return None;
+    }
+    if scale_milli.is_some() && (width_mpt.is_some() || height_mpt.is_some()) {
+        return None;
+    }
+    let default_sizing = FigureSizingMptV0 {
+        width_mpt: DEFAULT_FIGURE_PLACEHOLDER_WIDTH_MPT_V0,
+        height_mpt: DEFAULT_FIGURE_PLACEHOLDER_HEIGHT_MPT_V0,
+    };
+    let resolved = if let Some(scale) = scale_milli {
+        FigureSizingMptV0 {
+            width_mpt: scale_dimension_milli_pt_v0(default_sizing.width_mpt, scale)?,
+            height_mpt: scale_dimension_milli_pt_v0(default_sizing.height_mpt, scale)?,
+        }
+    } else {
+        match (width_mpt, height_mpt) {
+            (Some(width), Some(height)) => FigureSizingMptV0 {
+                width_mpt: width,
+                height_mpt: height,
+            },
+            (Some(width), None) => FigureSizingMptV0 {
+                width_mpt: width,
+                height_mpt: scale_by_ratio_milli_pt_v0(
+                    width,
+                    DEFAULT_FIGURE_PLACEHOLDER_HEIGHT_MPT_V0,
+                    DEFAULT_FIGURE_PLACEHOLDER_WIDTH_MPT_V0,
+                )?,
+            },
+            (None, Some(height)) => FigureSizingMptV0 {
+                width_mpt: scale_by_ratio_milli_pt_v0(
+                    height,
+                    DEFAULT_FIGURE_PLACEHOLDER_WIDTH_MPT_V0,
+                    DEFAULT_FIGURE_PLACEHOLDER_HEIGHT_MPT_V0,
+                )?,
+                height_mpt: height,
+            },
+            (None, None) => return None,
+        }
+    };
+    Some(apply_figure_sizing_caps_v0(resolved))
+}
+
 fn normalize_graphics_path_v0(raw_path: &[u8]) -> Option<Vec<u8>> {
     if raw_path.is_empty() {
         return None;
@@ -1082,16 +1307,49 @@ fn normalize_graphics_path_v0(raw_path: &[u8]) -> Option<Vec<u8>> {
     Some(normalized)
 }
 
-fn consume_includegraphics_path_v0(tokens: &[TokenV0], index: usize) -> Option<(Vec<u8>, usize)> {
+fn consume_includegraphics_command_v0(
+    tokens: &[TokenV0],
+    index: usize,
+) -> Option<(IncludeGraphicsCommandV0, usize)> {
     if !matches!(
         tokens.get(index),
         Some(TokenV0::ControlSeq(name)) if name.as_slice() == INCLUDEGRAPHICS_CONTROL_V0
     ) {
         return None;
     }
-    let group_index = skip_spaces(tokens, index + 1);
+    let mut group_index = skip_spaces(tokens, index + 1);
+    let mut sizing = FigureSizingMptV0 {
+        width_mpt: DEFAULT_FIGURE_PLACEHOLDER_WIDTH_MPT_V0,
+        height_mpt: DEFAULT_FIGURE_PLACEHOLDER_HEIGHT_MPT_V0,
+    };
     if matches!(tokens.get(group_index), Some(TokenV0::Char(b'['))) {
-        return None;
+        let mut cursor = group_index + 1;
+        let mut option_bytes = Vec::<u8>::new();
+        let mut saw_non_space = false;
+        while let Some(token) = tokens.get(cursor) {
+            match token {
+                TokenV0::Char(b']') => {
+                    if !saw_non_space {
+                        return None;
+                    }
+                    sizing = parse_includegraphics_options_v0(&option_bytes)?;
+                    group_index = cursor + 1;
+                    break;
+                }
+                TokenV0::Char(byte) => {
+                    option_bytes.push(*byte);
+                    if !is_horizontal_space_v0(*byte) {
+                        saw_non_space = true;
+                    }
+                }
+                TokenV0::Space => option_bytes.push(b' '),
+                _ => return None,
+            }
+            cursor += 1;
+        }
+        if !matches!(tokens.get(cursor), Some(TokenV0::Char(b']'))) {
+            return None;
+        }
     }
     let (group_start, group_end, next) = consume_group_bounds(tokens, group_index)?;
     let mut raw_path = Vec::<u8>::new();
@@ -1102,7 +1360,13 @@ fn consume_includegraphics_path_v0(tokens: &[TokenV0], index: usize) -> Option<(
         }
     }
     let normalized = normalize_graphics_path_v0(&raw_path)?;
-    Some((normalized, next))
+    Some((
+        IncludeGraphicsCommandV0 {
+            path: normalized,
+            sizing,
+        },
+        next,
+    ))
 }
 
 fn consume_tabular_environment_v0(
@@ -1203,7 +1467,7 @@ fn consume_figure_environment_v0(
     }
 
     let mut caption: Option<Vec<u8>> = None;
-    let mut image_path: Option<Vec<u8>> = None;
+    let mut image: Option<IncludeGraphicsCommandV0> = None;
     loop {
         cursor = skip_spaces(tokens, cursor);
         match tokens.get(cursor) {
@@ -1220,11 +1484,15 @@ fn consume_figure_environment_v0(
                 push_paragraph_break(out);
                 out.extend_from_slice(FIGURE_BOX_PREFIX_MARKER_V0);
                 push_newline(out);
-                if let Some(path) = &image_path {
+                if let Some(image_meta) = &image {
                     out.extend_from_slice(FIGURE_IMAGE_PREFIX_MARKER_V0);
                     out.extend_from_slice(figure_anchor_id.to_string().as_bytes());
                     out.push(b' ');
-                    out.extend_from_slice(path);
+                    out.extend_from_slice(&image_meta.path);
+                    out.push(b' ');
+                    out.extend_from_slice(image_meta.sizing.width_mpt.to_string().as_bytes());
+                    out.push(b' ');
+                    out.extend_from_slice(image_meta.sizing.height_mpt.to_string().as_bytes());
                     push_newline(out);
                 }
                 out.extend_from_slice(FIGURE_CAPTION_PREFIX_MARKER_V0);
@@ -1261,11 +1529,11 @@ fn consume_figure_environment_v0(
                 cursor = next;
             }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == INCLUDEGRAPHICS_CONTROL_V0 => {
-                if image_path.is_some() {
+                if image.is_some() {
                     return None;
                 }
-                let (path, next) = consume_includegraphics_path_v0(tokens, cursor)?;
-                image_path = Some(path);
+                let (parsed_image, next) = consume_includegraphics_command_v0(tokens, cursor)?;
+                image = Some(parsed_image);
                 cursor = next;
             }
             Some(TokenV0::ControlSeq(name))

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -805,7 +805,7 @@ fn typeset_minimal_figure_stub_accepts_includegraphics_path_marker() {
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
     assert!(
-        text.contains("!gbox\n!gimg 1 demo.png\n!gcap Figure 1: Nope"),
+        text.contains("!gbox\n!gimg 1 demo.png 180000 120000\n!gcap Figure 1: Nope"),
         "body={text:?}"
     );
 }
@@ -815,7 +815,10 @@ fn typeset_minimal_figure_stub_accepts_includegraphics_without_extension_by_norm
     let main = b"\\documentclass{article}\\begin{document}\\begin{figure}\\includegraphics{figs/demo}\\caption{No ext}\\end{figure}\\end{document}";
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
-    assert!(text.contains("!gimg 1 figs/demo.png"), "body={text:?}");
+    assert!(
+        text.contains("!gimg 1 figs/demo.png 180000 120000"),
+        "body={text:?}"
+    );
 }
 
 #[test]
@@ -842,8 +845,62 @@ fn typeset_minimal_figure_refs_with_hyperref_emit_anchor_links_in_order() {
 }
 
 #[test]
-fn typeset_minimal_rejects_figure_includegraphics_optional_args() {
-    let main = b"\\documentclass{article}\\begin{document}\\begin{figure}\\includegraphics[width=0.5\\textwidth]{demo.png}\\caption{Nope}\\end{figure}\\end{document}";
+fn typeset_minimal_figure_stub_accepts_includegraphics_width_option() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{figure}\\includegraphics[width=144pt]{demo.png}\\caption{Sized}\\end{figure}\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("!gimg 1 demo.png 144000 96000"),
+        "body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_figure_stub_accepts_includegraphics_scale_option() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{figure}\\includegraphics[scale=1.5]{demo.png}\\caption{Scaled}\\end{figure}\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("!gimg 1 demo.png 270000 180000"),
+        "body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_rejects_figure_includegraphics_unknown_option_key() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{figure}\\includegraphics[keepaspectratio=true]{demo.png}\\caption{Nope}\\end{figure}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_figure_includegraphics_duplicate_option_key() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{figure}\\includegraphics[width=120pt,width=80pt]{demo.png}\\caption{Nope}\\end{figure}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_figure_includegraphics_scientific_option_value() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{figure}\\includegraphics[scale=1e2]{demo.png}\\caption{Nope}\\end{figure}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_figure_includegraphics_macro_payload_option_value() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{figure}\\includegraphics[width=\\textwidth]{demo.png}\\caption{Nope}\\end{figure}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_figure_includegraphics_non_positive_option_value() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{figure}\\includegraphics[height=0pt]{demo.png}\\caption{Nope}\\end{figure}\\end{document}";
     let result = compile_typeset(main);
     assert_eq!(result.status, CompileStatus::NotImplemented);
     assert!(result.main_xdv_bytes.is_empty());

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -51,6 +51,12 @@ const TABLE_BORDER_TOP_OFFSET_PT_V0: f32 = 4.0;
 const TABLE_BORDER_BOTTOM_OFFSET_PT_V0: f32 = 4.0;
 const FIGURE_PLACEHOLDER_LINE_V0: &[u8] = b"[ Figure placeholder ]";
 const FIGURE_CAPTION_FONT_SIZE_PT_V0: f32 = 11.0;
+const DEFAULT_FIGURE_PLACEHOLDER_WIDTH_PT_V0: f32 = 180.0;
+const DEFAULT_FIGURE_PLACEHOLDER_HEIGHT_PT_V0: f32 = 120.0;
+const MAX_FIGURE_PLACEHOLDER_WIDTH_PT_V0: f32 = PAGE_WIDTH_PT_V0 - (2.0 * MARGIN_PT_V0);
+const MAX_FIGURE_PLACEHOLDER_HEIGHT_PT_V0: f32 = 288.0;
+const FIGURE_PLACEHOLDER_LABEL_INSET_PT_V0: f32 = 8.0;
+const FIGURE_PLACEHOLDER_TO_CAPTION_GAP_PT_V0: f32 = 8.0;
 const TOC_TITLE_TEXT_V0: &[u8] = b"Contents";
 const TOC_TITLE_FONT_SIZE_PT_V0: f32 = 14.0;
 const TOC_ENTRY_INDENT_STEP_PT_V0: f32 = 18.0;
@@ -615,7 +621,14 @@ fn is_safe_figure_image_path_byte_v0(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b'.' | b'_' | b'-')
 }
 
-fn parse_figure_image_line_v0(glyphs: &[GlyphPlanV0]) -> Option<(u32, Vec<u8>)> {
+#[derive(Clone)]
+struct FigureImageMetadataV0 {
+    image_path: Vec<u8>,
+    width_pt: f32,
+    height_pt: f32,
+}
+
+fn parse_figure_image_line_v0(glyphs: &[GlyphPlanV0]) -> Option<FigureImageMetadataV0> {
     if !has_figure_image_prefix_v0(glyphs) {
         return None;
     }
@@ -639,8 +652,64 @@ fn parse_figure_image_line_v0(glyphs: &[GlyphPlanV0]) -> Option<(u32, Vec<u8>)> 
     if cursor >= glyphs.len() {
         return None;
     }
+
+    let mut path_end = glyphs.len();
+    let mut width_pt = DEFAULT_FIGURE_PLACEHOLDER_WIDTH_PT_V0;
+    let mut height_pt = DEFAULT_FIGURE_PLACEHOLDER_HEIGHT_PT_V0;
+    let mut parsed_size_suffix = false;
+    for split in cursor..glyphs.len() {
+        if glyphs[split].byte != b' ' {
+            continue;
+        }
+        if split + 1 >= glyphs.len() || !glyphs[split + 1].byte.is_ascii_digit() {
+            continue;
+        }
+        let mut second_sep = split + 1;
+        while second_sep < glyphs.len() && glyphs[second_sep].byte.is_ascii_digit() {
+            second_sep += 1;
+        }
+        if second_sep >= glyphs.len() || glyphs[second_sep].byte != b' ' {
+            continue;
+        }
+        let mut height_start = second_sep + 1;
+        if height_start >= glyphs.len() || !glyphs[height_start].byte.is_ascii_digit() {
+            continue;
+        }
+        while height_start < glyphs.len() && glyphs[height_start].byte.is_ascii_digit() {
+            height_start += 1;
+        }
+        if height_start != glyphs.len() {
+            continue;
+        }
+        let width_raw = glyphs[split + 1..second_sep]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .collect::<Vec<u8>>();
+        let height_raw = glyphs[second_sep + 1..height_start]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .collect::<Vec<u8>>();
+        let width_mpt = std::str::from_utf8(&width_raw).ok()?.parse::<u32>().ok()?;
+        let height_mpt = std::str::from_utf8(&height_raw).ok()?.parse::<u32>().ok()?;
+        if width_mpt == 0 || height_mpt == 0 {
+            return None;
+        }
+        width_pt = (width_mpt as f32) / 1000.0;
+        height_pt = (height_mpt as f32) / 1000.0;
+        if width_pt <= 0.0
+            || height_pt <= 0.0
+            || width_pt > MAX_FIGURE_PLACEHOLDER_WIDTH_PT_V0
+            || height_pt > MAX_FIGURE_PLACEHOLDER_HEIGHT_PT_V0
+        {
+            return None;
+        }
+        path_end = split;
+        parsed_size_suffix = true;
+        break;
+    }
+
     let mut image_path = Vec::<u8>::new();
-    for glyph in &glyphs[cursor..] {
+    for glyph in &glyphs[cursor..path_end] {
         if !is_safe_figure_image_path_byte_v0(glyph.byte) {
             return None;
         }
@@ -649,7 +718,14 @@ fn parse_figure_image_line_v0(glyphs: &[GlyphPlanV0]) -> Option<(u32, Vec<u8>)> 
     if image_path.is_empty() {
         return None;
     }
-    Some((anchor_id, image_path))
+    if !parsed_size_suffix && path_end != glyphs.len() {
+        return None;
+    }
+    Some(FigureImageMetadataV0 {
+        image_path,
+        width_pt,
+        height_pt,
+    })
 }
 
 fn placeholder_segments_v0(image_path: Option<&[u8]>) -> Vec<PdfStyledSegmentV0> {
@@ -813,7 +889,7 @@ fn emit_table_block_v0(
 
 fn emit_figure_block_v0(
     out: &mut Vec<u8>,
-    image_path: Option<&[u8]>,
+    image_metadata: Option<&FigureImageMetadataV0>,
     caption_glyphs: &[GlyphPlanV0],
     y: &mut f32,
     min_body_y_pt: f32,
@@ -822,22 +898,57 @@ fn emit_figure_block_v0(
         return None;
     }
 
-    let placeholder_segments = placeholder_segments_v0(image_path);
+    let placeholder_segments = placeholder_segments_v0(image_metadata.map(|meta| meta.image_path.as_slice()));
     let placeholder_render_segments = split_superscript_segments_v0(&placeholder_segments);
-    let placeholder_width_pt = placeholder_render_segments
+    let placeholder_text_width_pt = placeholder_render_segments
         .iter()
         .map(|segment| segment.advance_pt)
         .sum::<f32>();
+    let placeholder_box_width_pt = image_metadata
+        .map(|meta| meta.width_pt)
+        .unwrap_or(DEFAULT_FIGURE_PLACEHOLDER_WIDTH_PT_V0);
+    let placeholder_box_height_pt = image_metadata
+        .map(|meta| meta.height_pt)
+        .unwrap_or(DEFAULT_FIGURE_PLACEHOLDER_HEIGHT_PT_V0);
+    let placeholder_width_pt = placeholder_box_width_pt.max(
+        placeholder_text_width_pt + (FIGURE_PLACEHOLDER_LABEL_INSET_PT_V0 * 2.0),
+    );
+    if placeholder_width_pt > MAX_FIGURE_PLACEHOLDER_WIDTH_PT_V0 {
+        return None;
+    }
+    let required_placeholder_bottom_y = *y - placeholder_box_height_pt;
+    if required_placeholder_bottom_y < min_body_y_pt {
+        return None;
+    }
     let placeholder_x_pt = centered_line_x_v0(placeholder_width_pt);
+    let max_placeholder_right = PAGE_WIDTH_PT_V0 - MARGIN_PT_V0;
+    if placeholder_x_pt + placeholder_width_pt > max_placeholder_right + 0.01 {
+        return None;
+    }
     emit_render_segments_with_superscript_v0(
         out,
         &placeholder_render_segments,
-        placeholder_x_pt,
-        *y,
+        placeholder_x_pt + FIGURE_PLACEHOLDER_LABEL_INSET_PT_V0,
+        *y - FIGURE_PLACEHOLDER_LABEL_INSET_PT_V0,
         FONT_SIZE_PT_V0,
     );
     out.extend_from_slice(b"\n");
-    *y -= LEADING_PT_V0;
+    out.extend_from_slice(b"ET\n");
+    out.extend_from_slice(b"0 G\n");
+    out.extend_from_slice(format!("{TABLE_BORDER_LINE_WIDTH_PT_V0} w\n").as_bytes());
+    out.extend_from_slice(
+        format!(
+            "{:.2} {:.2} {:.2} {:.2} re S\n",
+            placeholder_x_pt,
+            required_placeholder_bottom_y,
+            placeholder_width_pt,
+            placeholder_box_height_pt,
+        )
+        .as_bytes(),
+    );
+    out.extend_from_slice(b"BT\n");
+    out.extend_from_slice(b"0 g\n");
+    *y = required_placeholder_bottom_y - FIGURE_PLACEHOLDER_TO_CAPTION_GAP_PT_V0;
 
     if *y < min_body_y_pt {
         return None;
@@ -1878,11 +1989,11 @@ fn build_page_content_stream_v0(
                 return None;
             }
             let mut cursor = line_index + 1;
-            let mut image_path: Option<Vec<u8>> = None;
+            let mut image_metadata: Option<FigureImageMetadataV0> = None;
             if let Some(image_line) = lines.get(cursor) {
                 if has_figure_image_prefix_v0(&image_line.glyphs) {
-                    let (_, parsed_path) = parse_figure_image_line_v0(&image_line.glyphs)?;
-                    image_path = Some(parsed_path);
+                    let parsed_image = parse_figure_image_line_v0(&image_line.glyphs)?;
+                    image_metadata = Some(parsed_image);
                     cursor += 1;
                 }
             }
@@ -1890,7 +2001,7 @@ fn build_page_content_stream_v0(
             let caption_glyphs = parse_figure_caption_line_v0(&caption_line.glyphs)?;
             emit_figure_block_v0(
                 &mut out,
-                image_path.as_deref(),
+                image_metadata.as_ref(),
                 &caption_glyphs,
                 &mut y,
                 min_body_y_pt,

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -2886,6 +2886,39 @@ fn pdf_renderer_figure_block_spacing_invariants_v0() {
 }
 
 #[test]
+fn pdf_renderer_figure_metadata_width_affects_placeholder_alignment_v2() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"!gbox\n!gimg 1 figures/narrow.png 120000 80000\n!gcap Figure 1: Narrow caption.\n\n!gbox\n!gimg 2 figures/wide.png 360000 240000\n!gcap Figure 2: Wide caption.",
+    )
+    .expect("writer should accept figure marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let (narrow_x, _) =
+        tm_position_for_line_containing_text_v0(&pdf, "([ Figure placeholder: figures/narrow.png ])")
+            .expect("narrow placeholder position");
+    let (wide_x, _) =
+        tm_position_for_line_containing_text_v0(&pdf, "([ Figure placeholder: figures/wide.png ])")
+            .expect("wide placeholder position");
+    assert!(
+        wide_x + 1.0 < narrow_x,
+        "wider placeholder should start further left: narrow_x={narrow_x}, wide_x={wide_x}"
+    );
+}
+
+#[test]
+fn pdf_renderer_rejects_figure_image_metadata_width_overflow_v2() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"!gbox\n!gimg 1 figures/demo.png 500000 120000\n!gcap Figure 1: Caption.",
+    )
+    .expect("writer should accept figure marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed for figure placeholder width overflow"
+    );
+}
+
+#[test]
 fn pdf_renderer_rejects_malformed_figure_image_metadata_line_v0() {
     let xdv = write_dvi_v2_text_page_v0(b"!gbox\n!gimg demo.png\n!gcap Caption")
         .expect("writer should accept figure marker lines");

--- a/scripts/texlive_smoke/fixtures/typeset_demo_graphics_scale_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_graphics_scale_probe_v0.tex
@@ -1,0 +1,15 @@
+\documentclass{article}
+\usepackage{graphicx}
+
+\title{CarrelTeX Graphics Scale Probe}
+\author{Fixture Bot}
+\date{2026-03-06}
+
+\begin{document}
+\maketitle
+
+\begin{figure}
+\includegraphics[scale=1.50]{demo}
+\caption{Scaled figure placeholder.}
+\end{figure}
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_graphics_width_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_graphics_width_probe_v0.tex
@@ -1,0 +1,15 @@
+\documentclass{article}
+\usepackage{graphicx}
+
+\title{CarrelTeX Graphics Width Probe}
+\author{Fixture Bot}
+\date{2026-03-06}
+
+\begin{document}
+\maketitle
+
+\begin{figure}
+\includegraphics[width=144pt]{demo}
+\caption{Width sized figure placeholder.}
+\end{figure}
+\end{document}

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -86,6 +86,18 @@
       "purpose": "Exercises includegraphics stub v1 in figure mode so graphics dependencies become auditable resource edges."
     },
     {
+      "id": "typeset_demo_graphics_width_probe_v0",
+      "tags": ["typeset", "graphics", "includegraphics", "width", "probe", "ok"],
+      "expected_status": "OK",
+      "purpose": "Exercises safe includegraphics width option parsing and deterministic placeholder sizing."
+    },
+    {
+      "id": "typeset_demo_graphics_scale_probe_v0",
+      "tags": ["typeset", "graphics", "includegraphics", "scale", "probe", "ok"],
+      "expected_status": "OK",
+      "purpose": "Exercises safe includegraphics scale option parsing and deterministic placeholder sizing."
+    },
+    {
       "id": "typeset_demo_graphicspath_probe_v0",
       "tags": ["typeset", "graphics", "graphicspath", "probe", "ni"],
       "expected_status": "NI",

--- a/scripts/wasm_fixture_gallery_v1/main.mjs
+++ b/scripts/wasm_fixture_gallery_v1/main.mjs
@@ -42,6 +42,10 @@ const MAX_PACKAGES_OPTIONS_PER_ENTRY_V1 = 64;
 const MAX_PACKAGES_OPTION_BYTES_V1 = 256;
 const MAX_GRAPHICS_ENTRIES_V0 = 256;
 const MAX_GRAPHICS_PATH_BYTES_V0 = 256;
+const DEFAULT_GRAPHICS_PLACEHOLDER_WIDTH_PT_V2 = 180.0;
+const DEFAULT_GRAPHICS_PLACEHOLDER_HEIGHT_PT_V2 = 120.0;
+const MAX_GRAPHICS_PLACEHOLDER_WIDTH_PT_V2 = 468.0;
+const MAX_GRAPHICS_PLACEHOLDER_HEIGHT_PT_V2 = 288.0;
 const MAX_INPUT_ENTRIES_V1 = 512;
 const MAX_INPUT_INCLUDE_DEPTH_V1 = 32;
 const MAX_MATH_ENTRIES_V0 = 256;
@@ -636,6 +640,16 @@ async function loadFixtureCasesV0() {
       id: 'typeset_demo_graphics_probe_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_graphics_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_graphics_width_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_graphics_width_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_graphics_scale_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_graphics_scale_probe_v0.tex',
     },
     {
       id: 'typeset_demo_graphicspath_probe_v0',
@@ -1810,7 +1824,101 @@ function extractPackagesEntriesFromSourceV1(sourceBytes) {
   return entries;
 }
 
-function extractGraphicsEntriesFromSourceV0(sourceBytes) {
+function parsePositiveDecimalStrictV2(rawValue, context) {
+  const trimmed = `${rawValue}`.trim();
+  if (!/^[0-9]+(?:\.[0-9]+)?$/.test(trimmed)) {
+    throw new Error(`${context} has malformed decimal '${rawValue}'`);
+  }
+  const parsed = Number.parseFloat(trimmed);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${context} must be positive '${rawValue}'`);
+  }
+  return parsed;
+}
+
+function parseLengthPtStrictV2(rawValue, context) {
+  const trimmed = `${rawValue}`.trim();
+  const match = /^([0-9]+(?:\.[0-9]+)?)(pt|mm|cm|in)?$/i.exec(trimmed);
+  if (!match) {
+    throw new Error(`${context} has malformed length '${rawValue}'`);
+  }
+  const numeric = parsePositiveDecimalStrictV2(match[1], context);
+  const unit = (match[2] ?? 'pt').toLowerCase();
+  if (unit === 'pt') {
+    return numeric;
+  }
+  if (unit === 'in') {
+    return numeric * 72.0;
+  }
+  if (unit === 'cm') {
+    return (numeric * 72.0) / 2.54;
+  }
+  if (unit === 'mm') {
+    return (numeric * 72.0) / 25.4;
+  }
+  throw new Error(`${context} has unsupported unit '${unit}'`);
+}
+
+function clampGraphicsDimensionV2(valuePt, maxPt) {
+  return Math.max(1.0, Math.min(maxPt, valuePt));
+}
+
+function parseGraphicsSizingOptionsStrictV2(rawValue) {
+  const entries = rawValue.split(',');
+  const options = new Map();
+  for (const chunk of entries) {
+    const trimmed = chunk.trim();
+    if (trimmed.length === 0) {
+      throw new Error('graphics_v2 includegraphics options has empty entry');
+    }
+    const equalsIndex = trimmed.indexOf('=');
+    if (equalsIndex <= 0 || equalsIndex === trimmed.length - 1) {
+      throw new Error(`graphics_v2 includegraphics option '${trimmed}' is malformed`);
+    }
+    const key = trimmed.slice(0, equalsIndex).trim().toLowerCase();
+    const value = trimmed.slice(equalsIndex + 1).trim();
+    if (!['width', 'height', 'scale'].includes(key)) {
+      throw new Error(`graphics_v2 includegraphics option '${key}' is unsupported`);
+    }
+    if (options.has(key)) {
+      throw new Error(`graphics_v2 includegraphics option '${key}' is duplicated`);
+    }
+    options.set(key, value);
+  }
+  if (options.size === 0) {
+    throw new Error('graphics_v2 includegraphics options must be non-empty');
+  }
+  if (options.has('scale') && (options.has('width') || options.has('height'))) {
+    throw new Error('graphics_v2 includegraphics scale cannot be combined with width/height');
+  }
+
+  let widthPt = DEFAULT_GRAPHICS_PLACEHOLDER_WIDTH_PT_V2;
+  let heightPt = DEFAULT_GRAPHICS_PLACEHOLDER_HEIGHT_PT_V2;
+  let scale = null;
+  if (options.has('scale')) {
+    scale = parsePositiveDecimalStrictV2(options.get('scale'), 'graphics_v2 scale');
+    widthPt *= scale;
+    heightPt *= scale;
+  } else if (options.has('width') && options.has('height')) {
+    widthPt = parseLengthPtStrictV2(options.get('width'), 'graphics_v2 width');
+    heightPt = parseLengthPtStrictV2(options.get('height'), 'graphics_v2 height');
+  } else if (options.has('width')) {
+    widthPt = parseLengthPtStrictV2(options.get('width'), 'graphics_v2 width');
+    heightPt = widthPt * (DEFAULT_GRAPHICS_PLACEHOLDER_HEIGHT_PT_V2 / DEFAULT_GRAPHICS_PLACEHOLDER_WIDTH_PT_V2);
+  } else if (options.has('height')) {
+    heightPt = parseLengthPtStrictV2(options.get('height'), 'graphics_v2 height');
+    widthPt = heightPt * (DEFAULT_GRAPHICS_PLACEHOLDER_WIDTH_PT_V2 / DEFAULT_GRAPHICS_PLACEHOLDER_HEIGHT_PT_V2);
+  }
+  widthPt = clampGraphicsDimensionV2(widthPt, MAX_GRAPHICS_PLACEHOLDER_WIDTH_PT_V2);
+  heightPt = clampGraphicsDimensionV2(heightPt, MAX_GRAPHICS_PLACEHOLDER_HEIGHT_PT_V2);
+  return {
+    width_pt: Number(widthPt.toFixed(3)),
+    height_pt: Number(heightPt.toFixed(3)),
+    scale: scale === null ? null : Number(scale.toFixed(6)),
+  };
+}
+
+function extractGraphicsEntriesFromSourceV2(sourceBytes) {
   const allowedExtensions = new Set(['png', 'jpg', 'jpeg', 'pdf']);
   const entries = [];
   let index = 0;
@@ -1835,6 +1943,13 @@ function extractGraphicsEntriesFromSourceV0(sourceBytes) {
 
     let next = commandIndex;
     const optGroup = readBracketGroupV0(sourceBytes, next);
+    const sizingOpts = optGroup.ok
+      ? parseGraphicsSizingOptionsStrictV2(optGroup.value)
+      : {
+          width_pt: DEFAULT_GRAPHICS_PLACEHOLDER_WIDTH_PT_V2,
+          height_pt: DEFAULT_GRAPHICS_PLACEHOLDER_HEIGHT_PT_V2,
+          scale: null,
+        };
     if (optGroup.ok) {
       next = optGroup.next;
     }
@@ -1858,21 +1973,22 @@ function extractGraphicsEntriesFromSourceV0(sourceBytes) {
     const dotIndex = resolverPath.lastIndexOf('.');
     const extension = dotIndex >= 0 ? resolverPath.slice(dotIndex + 1).toLowerCase() : '';
     if (!allowedExtensions.has(extension)) {
-      throw new Error(`graphics_v1 unsupported extension '${extension}'`);
+      throw new Error(`graphics_v2 unsupported extension '${extension}'`);
     }
 
     const pathBytes = Buffer.from(pathAsWritten, 'utf8');
     if (pathBytes.length > MAX_GRAPHICS_PATH_BYTES_V0) {
-      throw new Error(`graphics_v1 path exceeds cap ${MAX_GRAPHICS_PATH_BYTES_V0}`);
+      throw new Error(`graphics_v2 path exceeds cap ${MAX_GRAPHICS_PATH_BYTES_V0}`);
     }
     entries.push({
       command,
       path: pathAsWritten,
       resolver_path: resolverPath,
-      source_span: buildSourceSpanV0(sourceBytes, index, pathGroup.next, 'graphics_v1'),
+      opts: sizingOpts,
+      source_span: buildSourceSpanV0(sourceBytes, index, pathGroup.next, 'graphics_v2'),
     });
     if (entries.length > MAX_GRAPHICS_ENTRIES_V0) {
-      throw new Error(`graphics_v1 entries exceed cap ${MAX_GRAPHICS_ENTRIES_V0}`);
+      throw new Error(`graphics_v2 entries exceed cap ${MAX_GRAPHICS_ENTRIES_V0}`);
     }
     index = pathGroup.next;
   }
@@ -3214,11 +3330,11 @@ async function emitPackagesTypedArtifactV1(caseOutDir, fixtureBytes) {
 async function emitGraphicsTypedArtifactV0(caseOutDir, fixtureBytes) {
   const payload = {
     version: TYPED_ARTIFACTS_VERSION_V0,
-    schema: 'graphics_v1',
-    entries: extractGraphicsEntriesFromSourceV0(fixtureBytes),
+    schema: 'graphics_v2',
+    entries: extractGraphicsEntriesFromSourceV2(fixtureBytes),
   };
   const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
-  const relpath = 'graphics_v1.json';
+  const relpath = 'graphics_v2.json';
   const fullPath = path.join(caseOutDir, relpath);
   await writeFile(fullPath, bytes);
   return {
@@ -3349,7 +3465,11 @@ async function emitTypedArtifactsV0(
   if (PACKAGE_ARTIFACT_CASE_IDS_V1.has(caseSpec.id)) {
     typedArtifacts.packages = await emitPackagesTypedArtifactV1(caseOutDir, fixtureBytes);
   }
-  if (caseSpec.id === 'typeset_demo_graphics_probe_v0') {
+  if (
+    caseSpec.id === 'typeset_demo_graphics_probe_v0'
+    || caseSpec.id === 'typeset_demo_graphics_width_probe_v0'
+    || caseSpec.id === 'typeset_demo_graphics_scale_probe_v0'
+  ) {
     typedArtifacts.graphics = await emitGraphicsTypedArtifactV0(caseOutDir, fixtureBytes);
   }
   if (caseSpec.mode === 'typeset' && Array.isArray(inputEntries) && inputEntries.length > 0) {
@@ -3557,8 +3677,15 @@ async function collectResolverRequestsFromTypedArtifactsV0(caseSpec, caseOutDir,
     const graphicsPayload = JSON.parse((await readFile(path.join(caseOutDir, graphicsRelpath))).toString('utf8'));
     const graphicsEntries = Array.isArray(graphicsPayload?.entries) ? graphicsPayload.entries : [];
     for (const entry of graphicsEntries) {
-      if (typeof entry?.path === 'string' && entry.path.length > 0) {
-        addTexmfRequest(entry.path, 'graphic', 'graphics_path');
+      const resolverPath = typeof entry?.resolver_path === 'string' && entry.resolver_path.length > 0
+        ? entry.resolver_path
+        : null;
+      const fallbackPath = typeof entry?.path === 'string' && entry.path.length > 0
+        ? entry.path
+        : null;
+      const requestPath = resolverPath ?? fallbackPath;
+      if (requestPath) {
+        addTexmfRequest(requestPath, 'graphic', 'graphics_path');
       }
     }
   }

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
@@ -544,9 +544,9 @@ if (graphicsSummary?.typed_artifacts?.graphics?.present !== true) {
   console.error('FAIL: expected graphics typed artifact present after first run');
   process.exit(1);
 }
-const graphicsPath = path.join(outDir, 'typeset_demo_graphics_probe_v0', 'graphics_v1.json');
+const graphicsPath = path.join(outDir, 'typeset_demo_graphics_probe_v0', 'graphics_v2.json');
 if (!fs.existsSync(graphicsPath)) {
-  console.error('FAIL: expected graphics_v1.json artifact after first run');
+  console.error('FAIL: expected graphics_v2.json artifact after first run');
   process.exit(1);
 }
 const graphicsShaFirst = graphicsSummary.typed_artifacts.graphics.artifact_sha256;
@@ -556,15 +556,29 @@ if (typeof graphicsShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(graphicsShaFi
 }
 const graphicsArtifactFirst = JSON.parse(fs.readFileSync(graphicsPath, 'utf8'));
 if (!Array.isArray(graphicsArtifactFirst?.entries)) {
-  console.error('FAIL: expected graphics_v1.entries array in first-run artifact');
+  console.error('FAIL: expected graphics_v2.entries array in first-run artifact');
   process.exit(1);
 }
 if (graphicsArtifactFirst.entries.length <= 0) {
-  console.error('FAIL: expected non-empty graphics_v1.entries for graphics probe');
+  console.error('FAIL: expected non-empty graphics_v2.entries for graphics probe');
   process.exit(1);
 }
-assertEntrySourceSpans('typeset_demo_graphics_probe_v0', 'graphics_v1', graphicsArtifactFirst.entries);
-fs.writeFileSync(firstRunShaPath('graphics_v1'), `${graphicsShaFirst}\n`);
+for (const entry of graphicsArtifactFirst.entries) {
+  if (typeof entry?.resolver_path !== 'string' || entry.resolver_path.length === 0) {
+    console.error('FAIL: expected graphics_v2 entry resolver_path');
+    process.exit(1);
+  }
+  if (typeof entry?.opts !== 'object' || entry.opts === null) {
+    console.error('FAIL: expected graphics_v2 entry opts object');
+    process.exit(1);
+  }
+  if (!(entry.opts.width_pt > 0) || !(entry.opts.height_pt > 0)) {
+    console.error('FAIL: expected graphics_v2 entry positive width_pt/height_pt');
+    process.exit(1);
+  }
+}
+assertEntrySourceSpans('typeset_demo_graphics_probe_v0', 'graphics_v2', graphicsArtifactFirst.entries);
+fs.writeFileSync(firstRunShaPath('graphics_v2'), `${graphicsShaFirst}\n`);
 
 const mathSummary = JSON.parse(
   fs.readFileSync(path.join(outDir, 'typeset_demo_minimal_v0', 'summary.json'), 'utf8'),

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
@@ -72,7 +72,7 @@ const citeShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'cite_v1_fi
 const hyperrefShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'hyperref_v0_first.sha256'), 'utf8').trim();
 const pkgoptShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'pkgopt_v0_first.sha256'), 'utf8').trim();
 const packagesShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'packages_v1_first.sha256'), 'utf8').trim();
-const graphicsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'graphics_v1_first.sha256'), 'utf8').trim();
+const graphicsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'graphics_v2_first.sha256'), 'utf8').trim();
 const mathShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'math_v1_first.sha256'), 'utf8').trim();
 const tableShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'table_v1_first.sha256'), 'utf8').trim();
 
@@ -480,14 +480,14 @@ if (!graphicsArtifact || graphicsArtifact.present !== true) {
 }
 const graphicsShaSecond = graphicsArtifact.artifact_sha256;
 if (graphicsShaSecond !== graphicsShaFirst) {
-  console.error('FAIL: graphics_v1 artifact sha256 must be stable across reruns');
+  console.error('FAIL: graphics_v2 artifact sha256 must be stable across reruns');
   process.exit(1);
 }
 const graphicsArtifactSecond = JSON.parse(
-  fs.readFileSync(path.join(outDir, 'typeset_demo_graphics_probe_v0', 'graphics_v1.json'), 'utf8'),
+  fs.readFileSync(path.join(outDir, 'typeset_demo_graphics_probe_v0', 'graphics_v2.json'), 'utf8'),
 );
 if (!Array.isArray(graphicsArtifactSecond?.entries) || graphicsArtifactSecond.entries.length <= 0) {
-  console.error('FAIL: expected non-empty graphics_v1.entries after rerun');
+  console.error('FAIL: expected non-empty graphics_v2.entries after rerun');
   process.exit(1);
 }
 
@@ -594,7 +594,7 @@ console.log(`PASS: cite_v1 sha stable ${citeShaSecond}`);
 console.log(`PASS: hyperref_v0 sha stable ${hyperrefShaSecond}`);
 console.log(`PASS: pkgopt_v0 sha stable ${pkgoptShaSecond}`);
 console.log(`PASS: packages_v1 sha stable ${packagesShaSecond}`);
-console.log(`PASS: graphics_v1 sha stable ${graphicsShaSecond}`);
+console.log(`PASS: graphics_v2 sha stable ${graphicsShaSecond}`);
 console.log(`PASS: math_v1 sha stable ${mathShaSecond}`);
 console.log(`PASS: table_v1 sha stable ${tableShaSecond}`);
 console.log('PASS: report typed_artifact_sha256 map present and stable');


### PR DESCRIPTION
## Summary
- add strict `\\includegraphics[width|height|scale]` option parsing in the typeset_minimal figure subset (fail-closed)
- carry normalized placeholder dimensions through `!gimg` metadata and render sized placeholder boxes in the PDF preview
- upgrade gallery graphics typed artifact to `graphics_v2` with normalized opts, plus new width/scale fixtures and updated proof sha gates

## Proof
- `cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests`
- `cargo test --manifest-path crates/carreltex-xdv/Cargo.toml`
- `./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12`
- `./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25`
