### PR TITLE
tabular v2: strict colspec + aligned widths + table_v2 gallery

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -46,6 +46,7 @@ const REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0: &[u8] = b"!ra ";
 const EQUATION_LINE_PREFIX_MARKER_V0: &[u8] = b"!eq ";
 const BIBITEM_LINE_PREFIX_MARKER_V0: &[u8] = b"!b ";
 const CITE_LINE_PREFIX_MARKER_V0: &[u8] = b"!c ";
+const TABLE_SPEC_PREFIX_MARKER_V0: &[u8] = b"!ts ";
 const TABLE_ROW_PREFIX_MARKER_V0: &[u8] = b"!t ";
 const FIGURE_BOX_PREFIX_MARKER_V0: &[u8] = b"!gbox";
 const FIGURE_IMAGE_PREFIX_MARKER_V0: &[u8] = b"!gimg ";
@@ -77,6 +78,7 @@ const SUBSECTION_CONTROL_V0: &[u8] = b"subsection";
 const SUBSUBSECTION_CONTROL_V0: &[u8] = b"subsubsection";
 const PARAGRAPH_CONTROL_V0: &[u8] = b"paragraph";
 const SUBPARAGRAPH_CONTROL_V0: &[u8] = b"subparagraph";
+const MAX_TABULAR_COLUMNS_V0: usize = 16;
 
 #[derive(Clone)]
 struct TocEntryMetaV0 {
@@ -1380,8 +1382,14 @@ fn consume_tabular_environment_v0(
     }
 
     let (align_start, align_end, next_after_align) = consume_group_bounds(tokens, cursor)?;
-    let align_spec = parse_char_space_group_trimmed_v0(tokens, align_start, align_end)?;
-    if align_spec.as_slice() != b"lcr" {
+    let mut align_spec = Vec::<u8>::new();
+    for token in &tokens[align_start..align_end] {
+        match token {
+            TokenV0::Char(byte) if matches!(byte, b'l' | b'c' | b'r') => align_spec.push(*byte),
+            _ => return None,
+        }
+    }
+    if align_spec.is_empty() || align_spec.len() > MAX_TABULAR_COLUMNS_V0 {
         return None;
     }
     cursor = next_after_align;
@@ -1398,6 +1406,9 @@ fn consume_tabular_environment_v0(
                 return None;
             }
             push_paragraph_break(out);
+            out.extend_from_slice(TABLE_SPEC_PREFIX_MARKER_V0);
+            out.extend_from_slice(&align_spec);
+            push_newline(out);
             for row in &rows {
                 out.extend_from_slice(TABLE_ROW_PREFIX_MARKER_V0);
                 for (cell_index, cell) in row.iter().enumerate() {
@@ -1447,7 +1458,7 @@ fn consume_tabular_environment_v0(
                 None => return None,
             }
         }
-        if row.len() != 3 {
+        if row.len() != align_spec.len() {
             return None;
         }
         rows.push(row);

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -767,17 +767,36 @@ fn typeset_minimal_tabular_emits_deterministic_row_markers() {
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
     assert!(
-        text.contains("!t Left||Center||Right\n!t L2||C2||R2"),
+        text.contains("!ts lcr\n!t Left||Center||Right\n!t L2||C2||R2"),
         "body={text:?}"
     );
 }
 
 #[test]
 fn typeset_minimal_rejects_tabular_unsupported_alignment() {
-    let main = b"\\documentclass{article}\\begin{document}\\begin{tabular}{ll}A & B\\\\\\end{tabular}\\end{document}";
+    let main = b"\\documentclass{article}\\begin{document}\\begin{tabular}{lp}A & B\\\\\\end{tabular}\\end{document}";
     let result = compile_typeset(main);
     assert_eq!(result.status, CompileStatus::NotImplemented);
     assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_tabular_colspec_with_spaces() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{tabular}{l c r}A & B & C\\\\\\end{tabular}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_tabular_accepts_variable_colspec_alignment() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{tabular}{rcll}9 & Mid & Tail & End\\\\10 & More & Tail2 & End2\\\\\\end{tabular}\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("!ts rcll\n!t 9||Mid||Tail||End\n!t 10||More||Tail2||End2"),
+        "body={text:?}"
+    );
 }
 
 #[test]

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -38,13 +38,13 @@ const LINK_END_MARKER_V0: u8 = b'>';
 const FOOTNOTE_MARKER_PREFIX_V0: u8 = b'^';
 const FOOTNOTE_MARKER_FONT_SIZE_PT_V0: f32 = 8.0;
 const FOOTNOTE_MARKER_RISE_PT_V0: f32 = 4.0;
+const TABLE_SPEC_PREFIX_MARKER_V0: &[u8] = b"!ts ";
 const TABLE_ROW_PREFIX_MARKER_V0: &[u8] = b"!t ";
 const FIGURE_BOX_PREFIX_MARKER_V0: &[u8] = b"!gbox";
 const FIGURE_IMAGE_PREFIX_MARKER_V0: &[u8] = b"!gimg ";
 const FIGURE_CAPTION_PREFIX_MARKER_V0: &[u8] = b"!gcap ";
 const TOC_PLACEHOLDER_MARKER_V0: &[u8] = b"!toc";
 const TOC_ENTRY_LINE_PREFIX_MARKER_V0: &[u8] = b"!toc ";
-const TABLE_COLUMN_COUNT_V0: usize = 3;
 const TABLE_CELL_PADDING_PT_V0: f32 = 6.0;
 const TABLE_BORDER_LINE_WIDTH_PT_V0: f32 = 0.5;
 const TABLE_BORDER_TOP_OFFSET_PT_V0: f32 = 4.0;
@@ -364,6 +364,7 @@ fn is_structured_non_title_line_v0(glyphs: &[GlyphPlanV0]) -> bool {
         || has_center_prefix_v0(glyphs)
         || has_right_prefix_v0(glyphs)
         || has_noindent_prefix_v0(glyphs)
+        || has_table_spec_prefix_v0(glyphs)
         || has_table_row_prefix_v0(glyphs)
         || has_figure_box_prefix_v0(glyphs)
         || has_figure_caption_prefix_v0(glyphs)
@@ -529,6 +530,14 @@ fn has_table_row_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
             .eq(TABLE_ROW_PREFIX_MARKER_V0.iter().copied())
 }
 
+fn has_table_spec_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() >= TABLE_SPEC_PREFIX_MARKER_V0.len()
+        && glyphs[..TABLE_SPEC_PREFIX_MARKER_V0.len()]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .eq(TABLE_SPEC_PREFIX_MARKER_V0.iter().copied())
+}
+
 fn has_figure_box_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
     glyphs.len() == FIGURE_BOX_PREFIX_MARKER_V0.len()
         && glyphs
@@ -600,10 +609,27 @@ fn parse_table_row_cells_v0(glyphs: &[GlyphPlanV0]) -> Option<Vec<Vec<GlyphPlanV
         index += 1;
     }
     cells.push(trim_space_glyph_edges_v0(&current));
-    if cells.len() != TABLE_COLUMN_COUNT_V0 {
+    if cells.is_empty() || cells.iter().any(|cell| cell.is_empty()) {
         return None;
     }
     Some(cells)
+}
+
+fn parse_table_align_spec_line_v0(glyphs: &[GlyphPlanV0]) -> Option<Vec<u8>> {
+    if !has_table_spec_prefix_v0(glyphs) {
+        return None;
+    }
+    let mut spec = Vec::<u8>::new();
+    for glyph in &glyphs[TABLE_SPEC_PREFIX_MARKER_V0.len()..] {
+        if !matches!(glyph.byte, b'l' | b'c' | b'r') {
+            return None;
+        }
+        spec.push(glyph.byte);
+    }
+    if spec.is_empty() {
+        return None;
+    }
+    Some(spec)
 }
 
 fn parse_figure_caption_line_v0(glyphs: &[GlyphPlanV0]) -> Option<Vec<GlyphPlanV0>> {
@@ -758,6 +784,7 @@ fn placeholder_segments_v0(image_path: Option<&[u8]>) -> Vec<PdfStyledSegmentV0>
 
 fn emit_table_block_v0(
     out: &mut Vec<u8>,
+    align_spec: &[u8],
     rows: &[LinePlanV0],
     y: &mut f32,
     min_body_y_pt: f32,
@@ -765,11 +792,18 @@ fn emit_table_block_v0(
     if rows.is_empty() {
         return None;
     }
+    if align_spec.is_empty() {
+        return None;
+    }
+    let col_count = align_spec.len();
     let mut parsed_rows = Vec::<Vec<Vec<PdfRenderSegmentV0>>>::new();
-    let mut col_max_width_pt = [0.0f32; TABLE_COLUMN_COUNT_V0];
+    let mut col_max_width_pt = vec![0.0f32; col_count];
 
     for row in rows {
         let cells = parse_table_row_cells_v0(&row.glyphs)?;
+        if cells.len() != col_count {
+            return None;
+        }
         let mut parsed_cells = Vec::<Vec<PdfRenderSegmentV0>>::new();
         for (col_index, cell_glyphs) in cells.iter().enumerate() {
             let segments = parse_styled_segments_v0(cell_glyphs)?;
@@ -801,9 +835,9 @@ fn emit_table_block_v0(
         return None;
     }
 
-    let mut col_left_edges_pt = [0.0f32; TABLE_COLUMN_COUNT_V0];
+    let mut col_left_edges_pt = vec![0.0f32; col_count];
     let mut col_cursor_x_pt = MARGIN_PT_V0;
-    for col_index in 0..TABLE_COLUMN_COUNT_V0 {
+    for col_index in 0..col_count {
         col_left_edges_pt[col_index] = col_cursor_x_pt;
         col_cursor_x_pt += col_max_width_pt[col_index] + (TABLE_CELL_PADDING_PT_V0 * 2.0);
     }
@@ -816,16 +850,17 @@ fn emit_table_block_v0(
             return None;
         }
         let mut col_left_x = MARGIN_PT_V0;
-        for col_index in 0..TABLE_COLUMN_COUNT_V0 {
+        for col_index in 0..col_count {
             let cell_width_pt = row[col_index]
                 .iter()
                 .map(|segment| segment.advance_pt)
                 .sum::<f32>();
             let col_content_width_pt = col_max_width_pt[col_index];
-            let align_offset_pt = match col_index {
-                0 => 0.0,
-                1 => (col_content_width_pt - cell_width_pt) * 0.5,
-                _ => col_content_width_pt - cell_width_pt,
+            let align_offset_pt = match align_spec[col_index] {
+                b'l' => 0.0,
+                b'c' => (col_content_width_pt - cell_width_pt) * 0.5,
+                b'r' => col_content_width_pt - cell_width_pt,
+                _ => return None,
             };
             let x_pt = col_left_x + TABLE_CELL_PADDING_PT_V0 + align_offset_pt.max(0.0);
             emit_render_segments_with_superscript_v0(
@@ -872,7 +907,7 @@ fn emit_table_block_v0(
             .as_bytes(),
         );
     }
-    for col_index in 1..TABLE_COLUMN_COUNT_V0 {
+    for col_index in 1..col_count {
         let x_pt = col_left_edges_pt[col_index];
         out.extend_from_slice(
             format!(
@@ -1955,14 +1990,26 @@ fn build_page_content_stream_v0(
         if y < min_body_y_pt {
             return None;
         }
-        if line_index >= title_block_len && has_table_row_prefix_v0(&line.glyphs) {
-            let mut table_end = line_index;
+        if line_index >= title_block_len
+            && (has_table_spec_prefix_v0(&line.glyphs) || has_table_row_prefix_v0(&line.glyphs))
+        {
+            let mut cursor = line_index;
+            if !has_table_spec_prefix_v0(&lines[cursor].glyphs) {
+                return None;
+            }
+            let align_spec = parse_table_align_spec_line_v0(&lines[cursor].glyphs)?;
+            cursor += 1;
+            let mut table_end = cursor;
             while table_end < lines.len() && has_table_row_prefix_v0(&lines[table_end].glyphs) {
                 table_end += 1;
             }
+            if cursor == table_end {
+                return None;
+            }
             emit_table_block_v0(
                 &mut out,
-                &lines[line_index..table_end],
+                &align_spec,
+                &lines[cursor..table_end],
                 &mut y,
                 min_body_y_pt,
             )?;

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -2638,7 +2638,7 @@ fn pdf_renderer_rejects_malformed_cite_metadata_line_v0() {
 #[test]
 fn pdf_renderer_table_rows_use_stable_column_x_offsets_v0() {
     let xdv = write_dvi_v2_text_page_v0(
-        b"Before.\n\n!t Alpha||Beta||Gamma\n!t Delta||Epsilon||Zeta\n\nAfter.",
+        b"Before.\n\n!ts lcr\n!t Alpha||Beta||Gamma\n!t Delta||Epsilon||Zeta\n\nAfter.",
     )
     .expect("writer should accept table marker lines");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
@@ -2689,7 +2689,7 @@ fn pdf_renderer_table_rows_use_stable_column_x_offsets_v0() {
 #[test]
 fn pdf_renderer_table_cells_stay_within_column_bounds_v1() {
     let xdv = write_dvi_v2_text_page_v0(
-        b"Before.\n\n!t A||WideMiddle||9.9\n!t LongLeft||B||123.45\n\nAfter.",
+        b"Before.\n\n!ts lcr\n!t A||WideMiddle||9.9\n!t LongLeft||B||123.45\n\nAfter.",
     )
     .expect("writer should accept table marker lines");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
@@ -2789,8 +2789,49 @@ fn pdf_renderer_table_cells_stay_within_column_bounds_v1() {
 }
 
 #[test]
+fn pdf_renderer_table_colspec_alignment_respects_lcr_per_column_v2() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"Before.\n\n!ts rcll\n!t 9||Mid||Tail||End\n!t 10||More||Tail2||Ending\n\nAfter.",
+    )
+    .expect("writer should accept table marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let nine_x = *tm_xs_for_segment_text_v0(&pdf, "9").first().expect("9 x");
+    let ten_x = *tm_xs_for_segment_text_v0(&pdf, "10").first().expect("10 x");
+    let nine_right = nine_x + segment_width_pt_v0(b"9");
+    let ten_right = ten_x + segment_width_pt_v0(b"10");
+    assert!(
+        (nine_right - ten_right).abs() <= 0.1,
+        "right-aligned first column should share right edge: {nine_right} vs {ten_right}"
+    );
+
+    let mid_x = *tm_xs_for_segment_text_v0(&pdf, "Mid").first().expect("mid x");
+    let more_x = *tm_xs_for_segment_text_v0(&pdf, "More").first().expect("more x");
+    let mid_center = mid_x + (segment_width_pt_v0(b"Mid") * 0.5);
+    let more_center = more_x + (segment_width_pt_v0(b"More") * 0.5);
+    assert!(
+        (mid_center - more_center).abs() <= 0.2,
+        "center-aligned second column should share center: {mid_center} vs {more_center}"
+    );
+
+    let tail_x = *tm_xs_for_segment_text_v0(&pdf, "Tail").first().expect("tail x");
+    let tail2_x = *tm_xs_for_segment_text_v0(&pdf, "Tail2").first().expect("tail2 x");
+    assert!(
+        (tail_x - tail2_x).abs() <= 0.1,
+        "left-aligned third column should share left edge: {tail_x} vs {tail2_x}"
+    );
+
+    let end_x = *tm_xs_for_segment_text_v0(&pdf, "End").first().expect("end x");
+    let ending_x = *tm_xs_for_segment_text_v0(&pdf, "Ending").first().expect("ending x");
+    assert!(
+        (end_x - ending_x).abs() <= 0.1,
+        "left-aligned fourth column should share left edge: {end_x} vs {ending_x}"
+    );
+}
+
+#[test]
 fn pdf_renderer_table_grid_lines_render_deterministically_v1() {
-    let xdv = write_dvi_v2_text_page_v0(b"Before.\n\n!t A||B||C\n!t D||E||F\n\nAfter.")
+    let xdv = write_dvi_v2_text_page_v0(b"Before.\n\n!ts lcr\n!t A||B||C\n!t D||E||F\n\nAfter.")
         .expect("writer should accept table marker lines");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
     let pdf_text = String::from_utf8_lossy(&pdf);
@@ -2806,11 +2847,70 @@ fn pdf_renderer_table_grid_lines_render_deterministically_v1() {
 }
 
 #[test]
+fn pdf_renderer_table_row_height_is_stable_v2() {
+    let xdv = write_dvi_v2_text_page_v0(b"Before.\n\n!ts lcr\n!t A||B||C\n!t D||E||F\n\nAfter.")
+        .expect("writer should accept table marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let (_, row1_y) = tm_position_for_line_containing_text_v0(&pdf, "(A)")
+        .expect("row 1 y");
+    let (_, row2_y) = tm_position_for_line_containing_text_v0(&pdf, "(D)")
+        .expect("row 2 y");
+    let delta = row1_y - row2_y;
+    assert!(
+        (delta - 14.0).abs() <= 0.2,
+        "table row height should remain stable at LEADING_PT_V0: {delta}"
+    );
+}
+
+#[test]
+fn pdf_renderer_rejects_table_rows_without_spec_line_v2() {
+    let xdv = write_dvi_v2_text_page_v0(b"Before.\n\n!t A||B||C\n!t D||E||F\n\nAfter.")
+        .expect("writer should accept table marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed when !t rows are missing !ts spec line"
+    );
+}
+
+#[test]
+fn pdf_renderer_rejects_invalid_table_spec_letters_v2() {
+    let xdv = write_dvi_v2_text_page_v0(b"Before.\n\n!ts lxp\n!t A||B||C\n\nAfter.")
+        .expect("writer should accept table marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed on invalid table spec bytes"
+    );
+}
+
+#[test]
+fn pdf_renderer_rejects_table_row_column_mismatch_v2() {
+    let xdv = write_dvi_v2_text_page_v0(b"Before.\n\n!ts lc\n!t A||B||C\n\nAfter.")
+        .expect("writer should accept table marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed when table row cell count mismatches !ts col_count"
+    );
+}
+
+#[test]
+fn pdf_renderer_rejects_table_row_with_empty_cell_v2() {
+    let xdv = write_dvi_v2_text_page_v0(b"Before.\n\n!ts lcr\n!t A||||C\n\nAfter.")
+        .expect("writer should accept table marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed on empty table cell content"
+    );
+}
+
+#[test]
 fn pdf_renderer_rejects_table_width_overflow_v0() {
     let mut row = Vec::<u8>::new();
-    row.extend_from_slice(b"!t ");
+    row.extend_from_slice(b"!ts l\n!t ");
     row.extend_from_slice("W".repeat(400).as_bytes());
-    row.extend_from_slice(b"||Center||Right");
     let xdv = write_dvi_v2_text_page_with_layout_and_wrap_v0(&row, 65_536, 786_432, 5_000)
         .expect("writer should accept table marker line");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);

--- a/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex
@@ -84,9 +84,9 @@ This is a second quoted paragraph to confirm paragraph breaks are preserved insi
 The table block below is a deterministic subset of tabular rendering and should keep three fixed columns with stable alignment in the PDF preview.
 
 \begin{tabular}{lcr}
-Label & Value & Notes\\
-Alpha & 12.50 & Stable\\
-Beta & 9.00 & Check\\
+Label & Centered Value & Right Notes\\
+Alpha baseline row & 12.50 units & Stable\\
+Beta long left text for wrap planning & 9.00 units & Check\\
 \end{tabular}
 
 \subsection{Figure}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_table_mixed_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_table_mixed_probe_v0.tex
@@ -1,0 +1,8 @@
+\documentclass{article}
+\begin{document}
+\begin{tabular}{lcr}
+Label & Center & Right\\
+Short & Mid & 9\\
+Long left text value & Wide center text & 12345\\
+\end{tabular}
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_table_overflow_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_table_overflow_probe_v0.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\begin{document}
+\begin{tabular}{l}
+ThisIsAnIntentionallyVeryLongTableCellValueThatShouldOverflowTheContentWidthAndTriggerFailClosedRenderingBecauseItCannotFitWithinTheConfiguredPageMarginsInTheDeterministicPreviewPipeline\\
+\end{tabular}
+\end{document}

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -8,6 +8,18 @@
       "purpose": "Minimal supported typeset slice with title block and core typography."
     },
     {
+      "id": "typeset_demo_table_mixed_probe_v0",
+      "tags": ["typeset", "table", "tabular", "probe", "ok"],
+      "expected_status": "OK",
+      "purpose": "Exercises tabular v2 mixed l/c/r alignment so deterministic table rendering stays stable with varying cell widths."
+    },
+    {
+      "id": "typeset_demo_table_overflow_probe_v0",
+      "tags": ["typeset", "table", "tabular", "overflow", "probe", "fail"],
+      "expected_status": "FAIL",
+      "purpose": "Proves fail-closed table rendering by forcing a deterministic width overflow that must reject PDF emission."
+    },
+    {
       "id": "typeset_demo_capabilities_v0",
       "tags": ["typeset", "capabilities", "negative", "ni"],
       "expected_status": "NI",

--- a/scripts/wasm_fixture_gallery_v1/main.mjs
+++ b/scripts/wasm_fixture_gallery_v1/main.mjs
@@ -577,6 +577,16 @@ async function loadFixtureCasesV0() {
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_minimal_v0.tex',
     },
     {
+      id: 'typeset_demo_table_mixed_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_table_mixed_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_table_overflow_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_table_overflow_probe_v0.tex',
+    },
+    {
       id: 'typeset_demo_capabilities_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_capabilities_v0.tex',
@@ -1301,16 +1311,16 @@ function parseTabularRowsV1(bodyText, expectedColumnCount) {
     .map((row) => row.trim())
     .filter((row) => row.length > 0);
   if (rawRows.length === 0 || rawRows.length > MAX_TABLE_ROWS_PER_ENTRY_V0) {
-    throw new Error(`table_v1 invalid row count ${rawRows.length}`);
+    throw new Error(`table_v2 invalid row count ${rawRows.length}`);
   }
   const rows = [];
   for (const rawRow of rawRows) {
     const cells = rawRow.split('&').map(normalizeTableCellTextV0);
     if (cells.length !== expectedColumnCount) {
-      throw new Error(`table_v1 row column count mismatch: expected ${expectedColumnCount}, got ${cells.length}`);
+      throw new Error(`table_v2 row column count mismatch: expected ${expectedColumnCount}, got ${cells.length}`);
     }
     if (cells.some((cell) => cell.length === 0)) {
-      throw new Error('table_v1 row contains empty cell');
+      throw new Error('table_v2 row contains empty cell');
     }
     rows.push(cells);
   }
@@ -1334,22 +1344,20 @@ function extractTableEntriesFromSourceV1(sourceBytes) {
       alignEnd += 1;
     }
     if (alignEnd >= sourceBytes.length) {
-      throw new Error('table_v1 tabular align spec missing closing }');
+      throw new Error('table_v2 tabular align spec missing closing }');
     }
-    const alignSpec = Buffer.from(sourceBytes.slice(alignStart, alignEnd))
-      .toString('utf8')
-      .replace(/\s+/g, '');
+    const alignSpec = Buffer.from(sourceBytes.slice(alignStart, alignEnd)).toString('utf8');
     if (
       alignSpec.length === 0
       || alignSpec.length > MAX_TABLE_COLS_PER_ENTRY_V0
       || !/^[lcr]+$/.test(alignSpec)
     ) {
-      throw new Error(`table_v1 unsupported align spec '${alignSpec}'`);
+      throw new Error(`table_v2 unsupported align spec '${alignSpec}'`);
     }
     const bodyStart = alignEnd + 1;
     const endIndex = indexOfSubarrayV0(sourceBytes, endMarker, bodyStart);
     if (endIndex < 0) {
-      throw new Error('table_v1 tabular missing end marker');
+      throw new Error('table_v2 tabular missing end marker');
     }
     const bodyText = Buffer.from(sourceBytes.slice(bodyStart, endIndex)).toString('utf8');
     const rows = parseTabularRowsV1(bodyText, alignSpec.length);
@@ -1368,10 +1376,10 @@ function extractTableEntriesFromSourceV1(sourceBytes) {
       row_count: rows.length,
       column_widths_pt: columnWidthsPt,
       rows,
-      source_span: buildSourceSpanV0(sourceBytes, beginIndex, endIndex + endMarker.length, 'table_v1'),
+      source_span: buildSourceSpanV0(sourceBytes, beginIndex, endIndex + endMarker.length, 'table_v2'),
     });
     if (entries.length > MAX_TABLE_ENTRIES_V0) {
-      throw new Error(`table_v1 entries exceed cap ${MAX_TABLE_ENTRIES_V0}`);
+      throw new Error(`table_v2 entries exceed cap ${MAX_TABLE_ENTRIES_V0}`);
     }
     index = endIndex + endMarker.length;
   }
@@ -3366,11 +3374,11 @@ async function emitMathTypedArtifactV0(caseOutDir, fixtureBytes) {
 async function emitTableTypedArtifactV0(caseOutDir, fixtureBytes) {
   const payload = {
     version: TYPED_ARTIFACTS_VERSION_V0,
-    schema: 'table_v1',
+    schema: 'table_v2',
     entries: extractTableEntriesFromSourceV1(fixtureBytes),
   };
   const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
-  const relpath = 'table_v1.json';
+  const relpath = 'table_v2.json';
   const fullPath = path.join(caseOutDir, relpath);
   await writeFile(fullPath, bytes);
   return {
@@ -4368,8 +4376,11 @@ async function runWasmFixtureGalleryV1() {
   }
   await writeFile(path.join(outDir, 'report.json'), `${JSON.stringify(report, null, 2)}\n`);
 
-  if (summaries.some((summary) => summary.status === STATUS_FAIL_V0)) {
-    throw new Error('gallery contains FAIL cases');
+  const unexpectedFail = summaries.find(
+    (summary) => summary.status === STATUS_FAIL_V0 && summary.expected_status !== STATUS_FAIL_V0,
+  );
+  if (unexpectedFail) {
+    throw new Error(`gallery contains unexpected FAIL case: ${unexpectedFail.case_id}`);
   }
 
   console.log(`PASS: fixture gallery report ${path.join(outDir, 'report.json')}`);

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
@@ -634,9 +634,9 @@ if (tableSummary?.typed_artifacts?.table?.present !== true) {
   console.error('FAIL: expected table typed artifact present for minimal demo after first run');
   process.exit(1);
 }
-const tablePath = path.join(outDir, 'typeset_demo_minimal_v0', 'table_v1.json');
+const tablePath = path.join(outDir, 'typeset_demo_minimal_v0', 'table_v2.json');
 if (!fs.existsSync(tablePath)) {
-  console.error('FAIL: expected table_v1.json artifact after first run');
+  console.error('FAIL: expected table_v2.json artifact after first run');
   process.exit(1);
 }
 const tableShaFirst = tableSummary.typed_artifacts.table.artifact_sha256;
@@ -646,41 +646,59 @@ if (typeof tableShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(tableShaFirst)) 
 }
 const tableArtifactFirst = JSON.parse(fs.readFileSync(tablePath, 'utf8'));
 if (!Array.isArray(tableArtifactFirst?.entries)) {
-  console.error('FAIL: expected table_v1.entries array in first-run artifact');
+  console.error('FAIL: expected table_v2.entries array in first-run artifact');
   process.exit(1);
 }
-if (tableArtifactFirst?.schema !== 'table_v1') {
-  console.error('FAIL: expected table_v1 schema in first-run artifact');
+if (tableArtifactFirst?.schema !== 'table_v2') {
+  console.error('FAIL: expected table_v2 schema in first-run artifact');
   process.exit(1);
 }
 if (tableArtifactFirst.entries.length <= 0) {
-  console.error('FAIL: expected non-empty table_v1.entries for minimal demo');
+  console.error('FAIL: expected non-empty table_v2.entries for minimal demo');
   process.exit(1);
 }
 for (const [index, entry] of tableArtifactFirst.entries.entries()) {
   if (typeof entry?.anchor_id !== 'string' || !/^tbl[1-9]\d*$/.test(entry.anchor_id)) {
-    console.error(`FAIL: table_v1.entries[${index}] invalid anchor_id`);
+    console.error(`FAIL: table_v2.entries[${index}] invalid anchor_id`);
     process.exit(1);
   }
   if (!Number.isInteger(entry?.row_count) || entry.row_count <= 0) {
-    console.error(`FAIL: table_v1.entries[${index}] invalid row_count`);
+    console.error(`FAIL: table_v2.entries[${index}] invalid row_count`);
     process.exit(1);
   }
   if (!Number.isInteger(entry?.column_count) || entry.column_count <= 0) {
-    console.error(`FAIL: table_v1.entries[${index}] invalid column_count`);
+    console.error(`FAIL: table_v2.entries[${index}] invalid column_count`);
+    process.exit(1);
+  }
+  if (typeof entry?.align_spec !== 'string' || !/^[lcr]+$/.test(entry.align_spec)) {
+    console.error(`FAIL: table_v2.entries[${index}] invalid align_spec`);
+    process.exit(1);
+  }
+  if (entry.align_spec.length !== entry.column_count) {
+    console.error(`FAIL: table_v2.entries[${index}] align_spec length mismatch column_count`);
     process.exit(1);
   }
   if (!Array.isArray(entry?.rows) || entry.rows.length !== entry.row_count) {
-    console.error(`FAIL: table_v1.entries[${index}] rows mismatch row_count`);
+    console.error(`FAIL: table_v2.entries[${index}] rows mismatch row_count`);
     process.exit(1);
   }
+  for (const [rowIndex, row] of entry.rows.entries()) {
+    if (!Array.isArray(row) || row.length !== entry.column_count || row.some((cell) => typeof cell !== 'string' || cell.length === 0)) {
+      console.error(`FAIL: table_v2.entries[${index}].rows[${rowIndex}] invalid row payload`);
+      process.exit(1);
+    }
+  }
   if (!Array.isArray(entry?.column_widths_pt) || entry.column_widths_pt.length !== entry.column_count) {
-    console.error(`FAIL: table_v1.entries[${index}] column_widths_pt mismatch column_count`);
+    console.error(`FAIL: table_v2.entries[${index}] column_widths_pt mismatch column_count`);
+    process.exit(1);
+  }
+  if (!entry.column_widths_pt.every((value) => Number.isFinite(value) && value >= 0)) {
+    console.error(`FAIL: table_v2.entries[${index}] column_widths_pt contains invalid width`);
     process.exit(1);
   }
 }
-assertEntrySourceSpans('typeset_demo_minimal_v0', 'table_v1', tableArtifactFirst.entries);
-fs.writeFileSync(firstRunShaPath('table_v1'), `${tableShaFirst}\n`);
+assertEntrySourceSpans('typeset_demo_minimal_v0', 'table_v2', tableArtifactFirst.entries);
+fs.writeFileSync(firstRunShaPath('table_v2'), `${tableShaFirst}\n`);
 
 const report = JSON.parse(fs.readFileSync(path.join(outDir, 'report.json'), 'utf8'));
 if (report?.typed_artifacts_version !== 1) {

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
@@ -74,7 +74,7 @@ const pkgoptShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'pkgopt_v
 const packagesShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'packages_v1_first.sha256'), 'utf8').trim();
 const graphicsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'graphics_v2_first.sha256'), 'utf8').trim();
 const mathShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'math_v1_first.sha256'), 'utf8').trim();
-const tableShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'table_v1_first.sha256'), 'utf8').trim();
+const tableShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'table_v2_first.sha256'), 'utf8').trim();
 
 if (resolvedCount <= 0) {
   console.error('FAIL: expected at least one resolved resource in fixture gallery summaries');
@@ -133,6 +133,16 @@ if (!inputCycleInvalidStatus || inputCycleInvalidStatus.status !== 'INVALID') {
 const inputMissingInvalidStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_input_missing_probe_v0');
 if (!inputMissingInvalidStatus || inputMissingInvalidStatus.status !== 'INVALID') {
   console.error('FAIL: expected typeset_demo_input_missing_probe_v0 status INVALID');
+  process.exit(1);
+}
+const tableMixedStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_table_mixed_probe_v0');
+if (!tableMixedStatus || tableMixedStatus.status !== 'OK') {
+  console.error('FAIL: expected typeset_demo_table_mixed_probe_v0 status OK');
+  process.exit(1);
+}
+const tableOverflowStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_table_overflow_probe_v0');
+if (!tableOverflowStatus || tableOverflowStatus.status !== 'FAIL') {
+  console.error('FAIL: expected typeset_demo_table_overflow_probe_v0 status FAIL');
   process.exit(1);
 }
 for (const status of okStatuses) {
@@ -519,14 +529,18 @@ if (!tableArtifact || tableArtifact.present !== true) {
 }
 const tableShaSecond = tableArtifact.artifact_sha256;
 if (tableShaSecond !== tableShaFirst) {
-  console.error('FAIL: table_v1 artifact sha256 must be stable across reruns');
+  console.error('FAIL: table_v2 artifact sha256 must be stable across reruns');
   process.exit(1);
 }
 const tableArtifactSecond = JSON.parse(
-  fs.readFileSync(path.join(outDir, 'typeset_demo_minimal_v0', 'table_v1.json'), 'utf8'),
+  fs.readFileSync(path.join(outDir, 'typeset_demo_minimal_v0', 'table_v2.json'), 'utf8'),
 );
 if (!Array.isArray(tableArtifactSecond?.entries) || tableArtifactSecond.entries.length <= 0) {
-  console.error('FAIL: expected non-empty table_v1.entries after rerun');
+  console.error('FAIL: expected non-empty table_v2.entries after rerun');
+  process.exit(1);
+}
+if (tableArtifactSecond?.schema !== 'table_v2') {
+  console.error('FAIL: expected table_v2 schema after rerun');
   process.exit(1);
 }
 
@@ -596,6 +610,6 @@ console.log(`PASS: pkgopt_v0 sha stable ${pkgoptShaSecond}`);
 console.log(`PASS: packages_v1 sha stable ${packagesShaSecond}`);
 console.log(`PASS: graphics_v2 sha stable ${graphicsShaSecond}`);
 console.log(`PASS: math_v1 sha stable ${mathShaSecond}`);
-console.log(`PASS: table_v1 sha stable ${tableShaSecond}`);
+console.log(`PASS: table_v2 sha stable ${tableShaSecond}`);
 console.log('PASS: report typed_artifact_sha256 map present and stable');
 console.log('PASS: report top-level case_artifact_sha256 present');


### PR DESCRIPTION
## Summary
- implement tabular v2 colspec handling in engine: strict `{l|c|r}+` parsing, `!ts <colspec>` marker emission, variable column count, fail-closed on invalid colspec bytes
- update XDV/PDF renderer to require and consume `!ts`, enforce row/cell invariants, compute deterministic column widths from max cell widths + padding, and apply per-column l/c/r alignment
- add/expand invariants and probes: alignment/offset stability, row height stability, overflow rejection, missing spec rejection, invalid spec rejection, row mismatch rejection, empty-cell rejection
- update fixture gallery: add mixed/overflow table probes, bump table typed artifact to `table_v2`, strengthen schema checks, and allow expected FAIL cases only when declared in manifest

## Proofs
- `cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests`
- `cargo test --manifest-path crates/carreltex-xdv/Cargo.toml`
- `./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12`
- `./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25`

Closes #406
