### PR TITLE
math v2: strict display payload + width-sensitive placeholder + typed artifacts

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -63,7 +63,11 @@ const REF_MARKER_SUFFIX_V0: &[u8] = b"@@";
 const CITE_MARKER_PREFIX_V0: &[u8] = b"@@CITE:";
 const CITE_MARKER_SUFFIX_V0: &[u8] = b"@@";
 const INLINE_MATH_PLACEHOLDER_V0: &[u8] = b"MATH";
-const DISPLAY_MATH_PLACEHOLDER_V0: &[u8] = b"MATH DISPLAY";
+const DISPLAY_MATH_PLACEHOLDER_SHORT_V0: &[u8] = b"MATH DISPLAY";
+const DISPLAY_MATH_PLACEHOLDER_MEDIUM_V0: &[u8] = b"MATH DISPLAY MEDIUM";
+const DISPLAY_MATH_PLACEHOLDER_LONG_V0: &[u8] = b"MATH DISPLAY LONG FORM";
+const DISPLAY_MATH_SHORT_MAX_PAYLOAD_BYTES_V0: usize = 24;
+const DISPLAY_MATH_MEDIUM_MAX_PAYLOAD_BYTES_V0: usize = 72;
 const LINK_START_MARKER_V0: u8 = b'<';
 const LINK_END_MARKER_V0: u8 = b'>';
 const NOINDENT_PREFIX_MARKER_V0: &[u8] = b"~ ";
@@ -512,6 +516,32 @@ fn is_safe_math_payload_char_v0(byte: u8) -> bool {
         )
 }
 
+fn is_ascii_alpha_bytes_v0(bytes: &[u8]) -> bool {
+    !bytes.is_empty()
+        && bytes
+            .iter()
+            .copied()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_uppercase())
+}
+
+fn is_safe_display_math_payload_char_v0(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric()
+        || matches!(
+            byte,
+            b'+' | b'-' | b'/' | b'*' | b'=' | b'(' | b')' | b'^' | b'_' | b'{' | b'}'
+        )
+}
+
+fn display_math_placeholder_for_payload_v0(payload: &[u8]) -> &'static [u8] {
+    if payload.len() <= DISPLAY_MATH_SHORT_MAX_PAYLOAD_BYTES_V0 {
+        DISPLAY_MATH_PLACEHOLDER_SHORT_V0
+    } else if payload.len() <= DISPLAY_MATH_MEDIUM_MAX_PAYLOAD_BYTES_V0 {
+        DISPLAY_MATH_PLACEHOLDER_MEDIUM_V0
+    } else {
+        DISPLAY_MATH_PLACEHOLDER_LONG_V0
+    }
+}
+
 fn consume_inline_math_command_v0(
     tokens: &[TokenV0],
     index: usize,
@@ -571,15 +601,20 @@ fn consume_display_math_command_v0(
                 }
                 push_paragraph_break(out);
                 out.extend_from_slice(b"^ ");
-                out.extend_from_slice(DISPLAY_MATH_PLACEHOLDER_V0);
+                out.extend_from_slice(display_math_placeholder_for_payload_v0(&payload));
                 push_paragraph_break(out);
                 return Some(cursor + 1);
+            }
+            Some(TokenV0::ControlSeq(name)) if is_ascii_alpha_bytes_v0(name.as_slice()) => {
+                payload.push(b'\\');
+                payload.extend_from_slice(name.as_slice());
+                cursor += 1;
             }
             Some(TokenV0::Char(byte)) if *byte == NEWLINE_MARKER_V0 => {
                 push_space(&mut payload);
                 cursor += 1;
             }
-            Some(TokenV0::Char(byte)) if is_safe_math_payload_char_v0(*byte) => {
+            Some(TokenV0::Char(byte)) if is_safe_display_math_payload_char_v0(*byte) => {
                 payload.push(*byte);
                 cursor += 1;
             }

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -1228,6 +1228,25 @@ fn typeset_minimal_display_math_emits_centered_placeholder_block() {
 }
 
 #[test]
+fn typeset_minimal_display_math_placeholder_width_category_tracks_payload_length_v2() {
+    let main = b"\\documentclass{article}\\begin{document}\\[x+y\\]\\[x^2 + y^2 + z^2 + a^2 + b^2 + c^2\\]\\[x^2 + y^2 + z^2 + a^2 + b^2 + c^2 + d^2 + e^2 + f^2 + g^2 + h^2 + i^2 + j^2 + k^2 + l^2 + m^2 + n^2 + o^2 + p^2\\]\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("^ MATH DISPLAY\n\n^ MATH DISPLAY MEDIUM\n\n^ MATH DISPLAY LONG FORM"),
+        "body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_display_math_accepts_backslash_letter_commands_v2() {
+    let main = b"\\documentclass{article}\\begin{document}\\[\\alpha + x^2\\]\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(text.contains("^ MATH DISPLAY"), "body={text:?}");
+}
+
+#[test]
 fn typeset_minimal_display_math_emits_equation_metadata_and_ref_resolution_v1() {
     let main = b"\\documentclass{article}\\begin{document}\\[x+y\\]\\label{eq:first}\\[a+b\\]\\label{eq:second}Refs: \\ref{eq:first}, \\ref{eq:second}.\\end{document}";
     let body = extract_typeset_body(main);
@@ -1269,6 +1288,14 @@ fn typeset_minimal_rejects_unterminated_inline_math() {
 #[test]
 fn typeset_minimal_rejects_unterminated_display_math() {
     let main = b"\\documentclass{article}\\begin{document}A \\[x+y\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_display_math_with_unsupported_payload_byte_v2() {
+    let main = b"\\documentclass{article}\\begin{document}\\[x&y\\]\\end{document}";
     let result = compile_typeset(main);
     assert_eq!(result.status, CompileStatus::NotImplemented);
     assert!(result.main_xdv_bytes.is_empty());

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -62,7 +62,9 @@ const TOC_TITLE_FONT_SIZE_PT_V0: f32 = 14.0;
 const TOC_ENTRY_INDENT_STEP_PT_V0: f32 = 18.0;
 const SECTION_HEADING_PREFIX_MARKER_V0: &[u8] = b"@S ";
 const SUBSECTION_HEADING_PREFIX_MARKER_V0: &[u8] = b"@s ";
-const DISPLAY_MATH_PLACEHOLDER_V0: &[u8] = b"MATH DISPLAY";
+const DISPLAY_MATH_PLACEHOLDER_SHORT_V0: &[u8] = b"MATH DISPLAY";
+const DISPLAY_MATH_PLACEHOLDER_MEDIUM_V0: &[u8] = b"MATH DISPLAY MEDIUM";
+const DISPLAY_MATH_PLACEHOLDER_LONG_V0: &[u8] = b"MATH DISPLAY LONG FORM";
 const ITALIC_START_MARKER_V0: u8 = b'[';
 const ITALIC_END_MARKER_V0: u8 = b']';
 const BOLD_START_MARKER_V0: u8 = b'{';
@@ -472,11 +474,13 @@ fn has_center_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
 }
 
 fn is_display_math_placeholder_line_v0(glyphs: &[GlyphPlanV0]) -> bool {
-    has_center_prefix_v0(glyphs)
-        && glyphs[2..]
-            .iter()
-            .map(|glyph| glyph.byte)
-            .eq(DISPLAY_MATH_PLACEHOLDER_V0.iter().copied())
+    if !has_center_prefix_v0(glyphs) {
+        return false;
+    }
+    let payload = glyphs[2..].iter().map(|glyph| glyph.byte).collect::<Vec<u8>>();
+    payload.as_slice() == DISPLAY_MATH_PLACEHOLDER_SHORT_V0
+        || payload.as_slice() == DISPLAY_MATH_PLACEHOLDER_MEDIUM_V0
+        || payload.as_slice() == DISPLAY_MATH_PLACEHOLDER_LONG_V0
 }
 
 fn has_right_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -2270,6 +2270,23 @@ fn pdf_renderer_display_math_placeholder_line_is_centered_v0() {
 }
 
 #[test]
+fn pdf_renderer_display_math_long_placeholder_is_wider_and_left_shifted_v2() {
+    let xdv =
+        write_dvi_v2_text_page_v0(b"Before.\n\n^ MATH DISPLAY\n\n^ MATH DISPLAY LONG FORM\n\nAfter.")
+            .expect("writer should accept display math placeholder marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let (short_x, _) = tm_position_for_line_containing_text_v0(&pdf, "(MATH DISPLAY)")
+        .expect("short display placeholder x coordinate");
+    let (long_x, _) =
+        tm_position_for_line_containing_text_v0(&pdf, "(MATH DISPLAY LONG FORM)")
+            .expect("long display placeholder x coordinate");
+    assert!(
+        long_x < short_x,
+        "long placeholder should center from a wider line and shift left: short_x={short_x}, long_x={long_x}"
+    );
+}
+
+#[test]
 fn pdf_renderer_display_math_with_equation_metadata_renders_right_number_v1() {
     let xdv = write_dvi_v2_text_page_v0(b"Before.\n\n^ MATH DISPLAY\n\nAfter.\n\n!eq 1 1")
         .expect("writer should accept equation metadata line");

--- a/scripts/texlive_smoke/fixtures/typeset_demo_math_invalid_payload_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_math_invalid_payload_probe_v0.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\begin{document}
+\[
+x&y
+\]
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_math_long_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_math_long_probe_v0.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\begin{document}
+\[
+\alpha + x^2 + y^2 + z^2 + a^2 + b^2 + c^2 + d^2 + e^2 + f^2 + g^2 + h^2 + i^2
+\]
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_math_short_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_math_short_probe_v0.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\begin{document}
+\[
+x+y
+\]
+\end{document}

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -62,6 +62,24 @@
       "purpose": "Probes amsmath package seam for on-demand package request generation."
     },
     {
+      "id": "typeset_demo_math_short_probe_v0",
+      "tags": ["typeset", "math", "display", "short", "probe", "ok"],
+      "expected_status": "OK",
+      "purpose": "Exercises short display-math payload parsing and deterministic centered placeholder category."
+    },
+    {
+      "id": "typeset_demo_math_long_probe_v0",
+      "tags": ["typeset", "math", "display", "long", "probe", "ok"],
+      "expected_status": "OK",
+      "purpose": "Exercises long display-math payload parsing so placeholder width category deterministically expands."
+    },
+    {
+      "id": "typeset_demo_math_invalid_payload_probe_v0",
+      "tags": ["typeset", "math", "display", "invalid", "probe", "ni"],
+      "expected_status": "NI",
+      "purpose": "Proves fail-closed rejection for display-math payload bytes outside the strict v2 subset."
+    },
+    {
       "id": "typeset_demo_fixedpoint_graphics_probe_v0",
       "tags": ["typeset", "graphics", "fixedpoint", "probe", "ni"],
       "expected_status": "NI",

--- a/scripts/wasm_fixture_gallery_v1/main.mjs
+++ b/scripts/wasm_fixture_gallery_v1/main.mjs
@@ -50,6 +50,7 @@ const MAX_INPUT_ENTRIES_V1 = 512;
 const MAX_INPUT_INCLUDE_DEPTH_V1 = 32;
 const MAX_MATH_ENTRIES_V0 = 256;
 const MAX_MATH_PAYLOAD_BYTES_V0 = 1024;
+const MAX_MATH_PAYLOAD_PREVIEW_BYTES_V2 = 96;
 const MAX_TABLE_ENTRIES_V0 = 64;
 const MAX_TABLE_ROWS_PER_ENTRY_V0 = 64;
 const MAX_TABLE_COLS_PER_ENTRY_V0 = 16;
@@ -622,6 +623,21 @@ async function loadFixtureCasesV0() {
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_math_probe_v0.tex',
     },
     {
+      id: 'typeset_demo_math_short_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_math_short_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_math_long_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_math_long_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_math_invalid_payload_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_math_invalid_payload_probe_v0.tex',
+    },
+    {
       id: 'typeset_demo_fixedpoint_graphics_probe_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_fixedpoint_graphics_probe_v0.tex',
@@ -1092,17 +1108,24 @@ function isMathPayloadWhitespaceByteV0(byte) {
   return byte === 0x20 || byte === 0x09 || byte === 0x0a || byte === 0x0d;
 }
 
-function isSafeMathPayloadByteV0(byte) {
-  return byte >= 0x20
-    && byte <= 0x7e
-    && byte !== 0x24
-    && byte !== 0x5c
-    && byte !== 0x5b
-    && byte !== 0x5d
-    && byte !== 0x7b
-    && byte !== 0x7d
-    && byte !== 0x3c
-    && byte !== 0x3e;
+function isAsciiAlphaByteV2(byte) {
+  return (byte >= 0x41 && byte <= 0x5a) || (byte >= 0x61 && byte <= 0x7a);
+}
+
+function isSafeMathV2LiteralByte(byte) {
+  return isAsciiAlphaByteV2(byte)
+    || (byte >= 0x30 && byte <= 0x39)
+    || byte === 0x2b // +
+    || byte === 0x2d // -
+    || byte === 0x2f // /
+    || byte === 0x2a // *
+    || byte === 0x3d // =
+    || byte === 0x28 // (
+    || byte === 0x29 // )
+    || byte === 0x5e // ^
+    || byte === 0x5f // _
+    || byte === 0x7b // {
+    || byte === 0x7d; // }
 }
 
 function pushMathPayloadSpaceV0(payloadBytes) {
@@ -1117,99 +1140,49 @@ function trimMathPayloadTrailingSpaceV0(payloadBytes) {
   }
 }
 
-function addMathEntryV1(entries, kind, payloadBytes, lineIndex, sourceBytes, startByte, endByte) {
+function sanitizeMathPayloadPreviewV2(payloadBytes) {
+  const normalized = Buffer.from(payloadBytes).toString('utf8').replace(/\s+/g, ' ').trim();
+  const normalizedBytes = Buffer.from(normalized, 'utf8');
+  if (normalizedBytes.length <= MAX_MATH_PAYLOAD_PREVIEW_BYTES_V2) {
+    return normalized;
+  }
+  return `${normalizedBytes.subarray(0, MAX_MATH_PAYLOAD_PREVIEW_BYTES_V2).toString('utf8')}...`;
+}
+
+function addMathEntryV2(entries, payloadBytes, sourceBytes, startByte, endByte) {
   trimMathPayloadTrailingSpaceV0(payloadBytes);
   if (payloadBytes.length === 0) {
-    throw new Error('math_v1 payload must be non-empty');
+    throw new Error('math_v2 payload must be non-empty');
   }
   if (payloadBytes.length > MAX_MATH_PAYLOAD_BYTES_V0) {
-    throw new Error(`math_v1 payload exceeds cap ${MAX_MATH_PAYLOAD_BYTES_V0}`);
+    throw new Error(`math_v2 payload exceeds cap ${MAX_MATH_PAYLOAD_BYTES_V0}`);
   }
-  if (!Number.isInteger(lineIndex) || lineIndex <= 0) {
-    throw new Error('math_v1 line_index must be a positive integer');
-  }
-  const payload = Uint8Array.from(payloadBytes);
+  const ordinal = entries.length + 1;
   entries.push({
-    kind,
-    payload_sha256: sha256HexV0(payload),
-    line_index: lineIndex,
-    source_span: buildSourceSpanV0(sourceBytes, startByte, endByte, 'math_v1'),
+    ordinal,
+    payload_preview: sanitizeMathPayloadPreviewV2(payloadBytes),
+    anchor_id: `eq${ordinal}`,
+    source_span: buildSourceSpanV0(sourceBytes, startByte, endByte, 'math_v2'),
   });
   if (entries.length > MAX_MATH_ENTRIES_V0) {
-    throw new Error(`math_v1 entries exceed cap ${MAX_MATH_ENTRIES_V0}`);
+    throw new Error(`math_v2 entries exceed cap ${MAX_MATH_ENTRIES_V0}`);
   }
 }
 
-function extractMathEntriesFromSourceV1(sourceBytes) {
+function extractMathEntriesFromSourceV2(sourceBytes) {
   const entries = [];
   let index = 0;
-  let lineIndex = 1;
   while (index < sourceBytes.length) {
     const byte = sourceBytes[index];
 
-    if (byte === 0x0a) {
-      lineIndex += 1;
-      index += 1;
-      continue;
-    }
-    if (byte === 0x0d) {
-      if (index + 1 < sourceBytes.length && sourceBytes[index + 1] === 0x0a) {
-        index += 1;
-      }
-      lineIndex += 1;
-      index += 1;
-      continue;
-    }
-
-    if (byte === 0x24) {
-      const startByte = index;
-      const startLineIndex = lineIndex;
-      const payloadBytes = [];
-      let cursor = index + 1;
-      let closed = false;
-      while (cursor < sourceBytes.length) {
-        const current = sourceBytes[cursor];
-        if (current === 0x24) {
-          addMathEntryV1(entries, 'inline', payloadBytes, startLineIndex, sourceBytes, startByte, cursor + 1);
-          cursor += 1;
-          index = cursor;
-          closed = true;
-          break;
-        }
-        if (isMathPayloadWhitespaceByteV0(current)) {
-          pushMathPayloadSpaceV0(payloadBytes);
-          if (current === 0x0a) {
-            lineIndex += 1;
-          } else if (current === 0x0d) {
-            if (cursor + 1 < sourceBytes.length && sourceBytes[cursor + 1] === 0x0a) {
-              cursor += 1;
-            }
-            lineIndex += 1;
-          }
-          cursor += 1;
-          continue;
-        }
-        if (!isSafeMathPayloadByteV0(current)) {
-          throw new Error(`math_v1 inline payload has unsupported byte 0x${current.toString(16).padStart(2, '0')}`);
-        }
-        payloadBytes.push(current);
-        cursor += 1;
-      }
-      if (!closed) {
-        throw new Error('math_v1 inline payload missing closing $ delimiter');
-      }
-      continue;
-    }
-
     if (byte === 0x5c && index + 1 < sourceBytes.length && sourceBytes[index + 1] === 0x5b) {
       const startByte = index;
-      const startLineIndex = lineIndex;
       const payloadBytes = [];
       let cursor = index + 2;
       let closed = false;
       while (cursor < sourceBytes.length) {
         if (sourceBytes[cursor] === 0x5c && cursor + 1 < sourceBytes.length && sourceBytes[cursor + 1] === 0x5d) {
-          addMathEntryV1(entries, 'display', payloadBytes, startLineIndex, sourceBytes, startByte, cursor + 2);
+          addMathEntryV2(entries, payloadBytes, sourceBytes, startByte, cursor + 2);
           cursor += 2;
           index = cursor;
           closed = true;
@@ -1218,25 +1191,33 @@ function extractMathEntriesFromSourceV1(sourceBytes) {
         const current = sourceBytes[cursor];
         if (isMathPayloadWhitespaceByteV0(current)) {
           pushMathPayloadSpaceV0(payloadBytes);
-          if (current === 0x0a) {
-            lineIndex += 1;
-          } else if (current === 0x0d) {
-            if (cursor + 1 < sourceBytes.length && sourceBytes[cursor + 1] === 0x0a) {
-              cursor += 1;
-            }
-            lineIndex += 1;
-          }
           cursor += 1;
           continue;
         }
-        if (!isSafeMathPayloadByteV0(current)) {
-          throw new Error(`math_v1 display payload has unsupported byte 0x${current.toString(16).padStart(2, '0')}`);
+        if (current === 0x5c) {
+          const commandStart = cursor + 1;
+          let commandEnd = commandStart;
+          while (commandEnd < sourceBytes.length && isAsciiAlphaByteV2(sourceBytes[commandEnd])) {
+            commandEnd += 1;
+          }
+          if (commandEnd === commandStart) {
+            throw new Error('math_v2 display payload has invalid backslash command');
+          }
+          payloadBytes.push(0x5c);
+          for (let i = commandStart; i < commandEnd; i += 1) {
+            payloadBytes.push(sourceBytes[i]);
+          }
+          cursor = commandEnd;
+          continue;
+        }
+        if (!isSafeMathV2LiteralByte(current)) {
+          throw new Error(`math_v2 display payload has unsupported byte 0x${current.toString(16).padStart(2, '0')}`);
         }
         payloadBytes.push(current);
         cursor += 1;
       }
       if (!closed) {
-        throw new Error('math_v1 display payload missing closing \\] delimiter');
+        throw new Error('math_v2 display payload missing closing \\] delimiter');
       }
       continue;
     }
@@ -3356,11 +3337,11 @@ async function emitGraphicsTypedArtifactV0(caseOutDir, fixtureBytes) {
 async function emitMathTypedArtifactV0(caseOutDir, fixtureBytes) {
   const payload = {
     version: TYPED_ARTIFACTS_VERSION_V0,
-    schema: 'math_v1',
-    entries: extractMathEntriesFromSourceV1(fixtureBytes),
+    schema: 'math_v2',
+    entries: extractMathEntriesFromSourceV2(fixtureBytes),
   };
   const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
-  const relpath = 'math_v1.json';
+  const relpath = 'math_v2.json';
   const fullPath = path.join(caseOutDir, relpath);
   await writeFile(fullPath, bytes);
   return {

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
@@ -587,9 +587,9 @@ if (mathSummary?.typed_artifacts?.math?.present !== true) {
   console.error('FAIL: expected math typed artifact present for minimal demo after first run');
   process.exit(1);
 }
-const mathPath = path.join(outDir, 'typeset_demo_minimal_v0', 'math_v1.json');
+const mathPath = path.join(outDir, 'typeset_demo_minimal_v0', 'math_v2.json');
 if (!fs.existsSync(mathPath)) {
-  console.error('FAIL: expected math_v1.json artifact after first run');
+  console.error('FAIL: expected math_v2.json artifact after first run');
   process.exit(1);
 }
 const mathShaFirst = mathSummary.typed_artifacts.math.artifact_sha256;
@@ -599,33 +599,45 @@ if (typeof mathShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(mathShaFirst)) {
 }
 const mathArtifactFirst = JSON.parse(fs.readFileSync(mathPath, 'utf8'));
 if (!Array.isArray(mathArtifactFirst?.entries)) {
-  console.error('FAIL: expected math_v1.entries array in first-run artifact');
+  console.error('FAIL: expected math_v2.entries array in first-run artifact');
   process.exit(1);
 }
-if (mathArtifactFirst?.schema !== 'math_v1') {
-  console.error('FAIL: expected math_v1 schema in first-run artifact');
+if (mathArtifactFirst?.schema !== 'math_v2') {
+  console.error('FAIL: expected math_v2 schema in first-run artifact');
   process.exit(1);
 }
 if (mathArtifactFirst.entries.length <= 0) {
-  console.error('FAIL: expected non-empty math_v1.entries for minimal demo');
+  console.error('FAIL: expected non-empty math_v2.entries for minimal demo');
   process.exit(1);
 }
 for (const [index, entry] of mathArtifactFirst.entries.entries()) {
-  if (entry?.kind !== 'inline' && entry?.kind !== 'display') {
-    console.error(`FAIL: math_v1.entries[${index}] has invalid kind`);
+  if (!Number.isInteger(entry?.ordinal) || entry.ordinal <= 0) {
+    console.error(`FAIL: math_v2.entries[${index}] has invalid ordinal`);
     process.exit(1);
   }
-  if (!Number.isInteger(entry?.line_index) || entry.line_index <= 0) {
-    console.error(`FAIL: math_v1.entries[${index}] has invalid line_index`);
+  if (entry.ordinal !== index + 1) {
+    console.error(`FAIL: math_v2.entries[${index}] ordinal is not stable sequence`);
     process.exit(1);
   }
-  if (typeof entry?.payload_sha256 !== 'string' || !/^[0-9a-f]{64}$/.test(entry.payload_sha256)) {
-    console.error(`FAIL: math_v1.entries[${index}] has invalid payload_sha256`);
+  if (typeof entry?.payload_preview !== 'string' || entry.payload_preview.trim().length === 0) {
+    console.error(`FAIL: math_v2.entries[${index}] has invalid payload_preview`);
+    process.exit(1);
+  }
+  if (!/^[\x20-\x7e]+$/.test(entry.payload_preview)) {
+    console.error(`FAIL: math_v2.entries[${index}] payload_preview must be ASCII printable`);
+    process.exit(1);
+  }
+  if (typeof entry?.anchor_id !== 'string' || !/^eq[1-9]\d*$/.test(entry.anchor_id)) {
+    console.error(`FAIL: math_v2.entries[${index}] has invalid anchor_id`);
+    process.exit(1);
+  }
+  if (entry.anchor_id !== `eq${entry.ordinal}`) {
+    console.error(`FAIL: math_v2.entries[${index}] anchor_id/ordinal mismatch`);
     process.exit(1);
   }
 }
-assertEntrySourceSpans('typeset_demo_minimal_v0', 'math_v1', mathArtifactFirst.entries);
-fs.writeFileSync(firstRunShaPath('math_v1'), `${mathShaFirst}\n`);
+assertEntrySourceSpans('typeset_demo_minimal_v0', 'math_v2', mathArtifactFirst.entries);
+fs.writeFileSync(firstRunShaPath('math_v2'), `${mathShaFirst}\n`);
 
 const tableSummary = JSON.parse(
   fs.readFileSync(path.join(outDir, 'typeset_demo_minimal_v0', 'summary.json'), 'utf8'),

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
@@ -73,7 +73,7 @@ const hyperrefShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'hyperr
 const pkgoptShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'pkgopt_v0_first.sha256'), 'utf8').trim();
 const packagesShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'packages_v1_first.sha256'), 'utf8').trim();
 const graphicsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'graphics_v2_first.sha256'), 'utf8').trim();
-const mathShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'math_v1_first.sha256'), 'utf8').trim();
+const mathShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'math_v2_first.sha256'), 'utf8').trim();
 const tableShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'table_v2_first.sha256'), 'utf8').trim();
 
 if (resolvedCount <= 0) {
@@ -143,6 +143,21 @@ if (!tableMixedStatus || tableMixedStatus.status !== 'OK') {
 const tableOverflowStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_table_overflow_probe_v0');
 if (!tableOverflowStatus || tableOverflowStatus.status !== 'FAIL') {
   console.error('FAIL: expected typeset_demo_table_overflow_probe_v0 status FAIL');
+  process.exit(1);
+}
+const mathShortStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_math_short_probe_v0');
+if (!mathShortStatus || mathShortStatus.status !== 'OK') {
+  console.error('FAIL: expected typeset_demo_math_short_probe_v0 status OK');
+  process.exit(1);
+}
+const mathLongStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_math_long_probe_v0');
+if (!mathLongStatus || mathLongStatus.status !== 'OK') {
+  console.error('FAIL: expected typeset_demo_math_long_probe_v0 status OK');
+  process.exit(1);
+}
+const mathInvalidStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_math_invalid_payload_probe_v0');
+if (!mathInvalidStatus || mathInvalidStatus.status !== 'NI') {
+  console.error('FAIL: expected typeset_demo_math_invalid_payload_probe_v0 status NI');
   process.exit(1);
 }
 for (const status of okStatuses) {
@@ -511,14 +526,18 @@ if (!mathArtifact || mathArtifact.present !== true) {
 }
 const mathShaSecond = mathArtifact.artifact_sha256;
 if (mathShaSecond !== mathShaFirst) {
-  console.error('FAIL: math_v1 artifact sha256 must be stable across reruns');
+  console.error('FAIL: math_v2 artifact sha256 must be stable across reruns');
   process.exit(1);
 }
 const mathArtifactSecond = JSON.parse(
-  fs.readFileSync(path.join(outDir, 'typeset_demo_minimal_v0', 'math_v1.json'), 'utf8'),
+  fs.readFileSync(path.join(outDir, 'typeset_demo_minimal_v0', 'math_v2.json'), 'utf8'),
 );
 if (!Array.isArray(mathArtifactSecond?.entries) || mathArtifactSecond.entries.length <= 0) {
-  console.error('FAIL: expected non-empty math_v1.entries after rerun');
+  console.error('FAIL: expected non-empty math_v2.entries after rerun');
+  process.exit(1);
+}
+if (mathArtifactSecond?.schema !== 'math_v2') {
+  console.error('FAIL: expected math_v2 schema after rerun');
   process.exit(1);
 }
 
@@ -609,7 +628,7 @@ console.log(`PASS: hyperref_v0 sha stable ${hyperrefShaSecond}`);
 console.log(`PASS: pkgopt_v0 sha stable ${pkgoptShaSecond}`);
 console.log(`PASS: packages_v1 sha stable ${packagesShaSecond}`);
 console.log(`PASS: graphics_v2 sha stable ${graphicsShaSecond}`);
-console.log(`PASS: math_v1 sha stable ${mathShaSecond}`);
+console.log(`PASS: math_v2 sha stable ${mathShaSecond}`);
 console.log(`PASS: table_v2 sha stable ${tableShaSecond}`);
 console.log('PASS: report typed_artifact_sha256 map present and stable');
 console.log('PASS: report top-level case_artifact_sha256 present');


### PR DESCRIPTION
## Summary
- extend `typeset_minimal` display-math parsing to a strict subset and fail-closed on unsupported payload bytes
- allow display payload `\\command` tokens only when command names are `[A-Za-z]+`
- make display-math placeholder width-sensitive via deterministic short/medium/long categories while keeping centered layout and equation metadata flow
- keep equation numbering/eqref/hyperref anchor behavior intact by recognizing all math-v2 placeholder variants in renderer metadata pairing
- introduce typed artifact `math_v2` with entries `{ordinal, payload_preview, anchor_id, source_span}` and migrate gallery/proof sha gates from `math_v1` to `math_v2`
- add fixtures for short payload, long payload, and invalid payload rejection probe; wire them into manifest + gallery case discovery

## Proofs
- `cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests`
- `cargo test --manifest-path crates/carreltex-xdv/Cargo.toml`
- `./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12`
- `./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25`

Closes #408
