### PR TITLE
refs v2: add \pageref page_no + page destinations

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -38,11 +38,14 @@ const FOOTNOTE_CONTROL_V0: &[u8] = b"footnote";
 const HREF_CONTROL_V0: &[u8] = b"href";
 const LABEL_CONTROL_V0: &[u8] = b"label";
 const REF_CONTROL_V0: &[u8] = b"ref";
+const PAGEREF_CONTROL_V0: &[u8] = b"pageref";
 const FOOTNOTE_LINE_PREFIX_MARKER_V0: &[u8] = b"!f ";
 const HREF_URL_LINE_PREFIX_MARKER_V0: &[u8] = b"!u ";
 const LABEL_LINE_PREFIX_MARKER_V0: &[u8] = b"!l ";
 const REF_LINE_PREFIX_MARKER_V0: &[u8] = b"!r ";
+const PAGEREF_LINE_PREFIX_MARKER_V0: &[u8] = b"!pr ";
 const REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0: &[u8] = b"!ra ";
+const PAGEREF_PAGE_LINK_LINE_PREFIX_MARKER_V0: &[u8] = b"!rp ";
 const EQUATION_LINE_PREFIX_MARKER_V0: &[u8] = b"!eq ";
 const BIBITEM_LINE_PREFIX_MARKER_V0: &[u8] = b"!b ";
 const CITE_LINE_PREFIX_MARKER_V0: &[u8] = b"!c ";
@@ -59,7 +62,10 @@ const INCLUDEGRAPHICS_ALLOWED_WIDTH_UNITS_V0: [&[u8]; 4] = [b"pt", b"mm", b"cm",
 const TOC_PLACEHOLDER_MARKER_V0: &[u8] = b"!toc";
 const TOC_ENTRY_LINE_PREFIX_MARKER_V0: &[u8] = b"!toc ";
 const REF_MARKER_PREFIX_V0: &[u8] = b"@@REF:";
+const PAGEREF_MARKER_PREFIX_V0: &[u8] = b"@@PAGEREF:";
 const REF_MARKER_SUFFIX_V0: &[u8] = b"@@";
+const PAGEREF_RENDER_MARKER_PREFIX_V0: &[u8] = b"@@PG:";
+const PAGEREF_RENDER_MARKER_SUFFIX_V0: &[u8] = b"@@";
 const CITE_MARKER_PREFIX_V0: &[u8] = b"@@CITE:";
 const CITE_MARKER_SUFFIX_V0: &[u8] = b"@@";
 const INLINE_MATH_PLACEHOLDER_V0: &[u8] = b"MATH";
@@ -120,9 +126,16 @@ struct PendingLabelTargetV0 {
 
 #[derive(Clone)]
 struct RefOccurrenceMetaV0 {
+    kind: RefKindV0,
     key: Vec<u8>,
     line_index: u32,
     resolved_anchor_id: Option<u32>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RefKindV0 {
+    Ref,
+    Pageref,
 }
 
 #[derive(Clone)]
@@ -133,6 +146,12 @@ struct HrefLinkMetaV0 {
 
 #[derive(Clone)]
 struct RefAnchorLinkMetaV0 {
+    link_id: u32,
+    anchor_id: u32,
+}
+
+#[derive(Clone)]
+struct PagerefPageLinkMetaV0 {
     link_id: u32,
     anchor_id: u32,
 }
@@ -924,6 +943,13 @@ fn consume_fragment_token_v0(
             out.extend_from_slice(REF_MARKER_SUFFIX_V0);
             Some(next)
         }
+        TokenV0::ControlSeq(name) if name.as_slice() == PAGEREF_CONTROL_V0 => {
+            let (key, next) = parse_label_or_ref_key_group_v0(tokens, index)?;
+            out.extend_from_slice(PAGEREF_MARKER_PREFIX_V0);
+            out.extend_from_slice(&key);
+            out.extend_from_slice(REF_MARKER_SUFFIX_V0);
+            Some(next)
+        }
         TokenV0::ControlSeq(name)
             if name.as_slice() == b"protect" || name.as_slice() == b"relax" =>
         {
@@ -1094,7 +1120,10 @@ fn parse_decimal_milli_v0(value: &[u8]) -> Option<u32> {
     if value.is_empty() {
         return None;
     }
-    if value.iter().any(|byte| matches!(byte, b'+' | b'-' | b'e' | b'E')) {
+    if value
+        .iter()
+        .any(|byte| matches!(byte, b'+' | b'-' | b'e' | b'E'))
+    {
         return None;
     }
     let mut dot_index = None::<usize>;
@@ -2449,14 +2478,27 @@ fn apply_crossref_pass_v1(
     artifacts: &CrossRefArtifactsV1,
     ref_occurrences: &mut Vec<RefOccurrenceMetaV0>,
     ref_link_anchor_ids: &mut Vec<u32>,
+    pageref_page_link_anchor_ids: &mut Vec<u32>,
 ) -> Option<Vec<u8>> {
     let mut out = Vec::<u8>::with_capacity(body.len());
     let mut index = 0usize;
     let mut line_index = 1u32;
 
     while index < body.len() {
-        if body[index..].starts_with(REF_MARKER_PREFIX_V0) {
-            let key_start = index + REF_MARKER_PREFIX_V0.len();
+        let (ref_kind, key_start) = if body[index..].starts_with(REF_MARKER_PREFIX_V0) {
+            (RefKindV0::Ref, index + REF_MARKER_PREFIX_V0.len())
+        } else if body[index..].starts_with(PAGEREF_MARKER_PREFIX_V0) {
+            (RefKindV0::Pageref, index + PAGEREF_MARKER_PREFIX_V0.len())
+        } else {
+            let byte = body[index];
+            out.push(byte);
+            if byte == NEWLINE_MARKER_V0 {
+                line_index = line_index.checked_add(1)?;
+            }
+            index += 1;
+            continue;
+        };
+        {
             let mut key_end = key_start;
             while key_end < body.len() {
                 if body[key_end..].starts_with(REF_MARKER_SUFFIX_V0) {
@@ -2473,12 +2515,18 @@ fn apply_crossref_pass_v1(
             let key = body[key_start..key_end].to_vec();
             let resolved_label = artifacts.labels_by_key.get(&key);
             let resolved_anchor_id = resolved_label.map(|entry| entry.anchor_id);
-            let resolved_value = resolved_label.and_then(|entry| match entry.kind {
-                LabelKindV0::Heading => Some(entry.anchor_id),
-                LabelKindV0::Figure => entry.figure_ordinal,
-                LabelKindV0::Equation => entry.equation_ordinal,
-            });
-            if resolved_anchor_id.is_some() != resolved_value.is_some() {
+            let resolved_value = if matches!(ref_kind, RefKindV0::Ref) {
+                resolved_label.and_then(|entry| match entry.kind {
+                    LabelKindV0::Heading => Some(entry.anchor_id),
+                    LabelKindV0::Figure => entry.figure_ordinal,
+                    LabelKindV0::Equation => entry.equation_ordinal,
+                })
+            } else {
+                None
+            };
+            if matches!(ref_kind, RefKindV0::Ref)
+                && resolved_anchor_id.is_some() != resolved_value.is_some()
+            {
                 return None;
             }
             if let Some(anchor_id) = resolved_anchor_id {
@@ -2495,20 +2543,43 @@ fn apply_crossref_pass_v1(
                     return None;
                 }
             }
-            if let Some(value) = resolved_value {
-                if artifacts.hyperref_enabled {
-                    out.push(LINK_START_MARKER_V0);
-                    out.extend_from_slice(value.to_string().as_bytes());
-                    out.push(LINK_END_MARKER_V0);
-                    let anchor_id = resolved_anchor_id?;
-                    ref_link_anchor_ids.push(anchor_id);
-                } else {
-                    out.extend_from_slice(value.to_string().as_bytes());
+            match ref_kind {
+                RefKindV0::Ref => {
+                    if let Some(value) = resolved_value {
+                        if artifacts.hyperref_enabled {
+                            out.push(LINK_START_MARKER_V0);
+                            out.extend_from_slice(value.to_string().as_bytes());
+                            out.push(LINK_END_MARKER_V0);
+                            let anchor_id = resolved_anchor_id?;
+                            ref_link_anchor_ids.push(anchor_id);
+                        } else {
+                            out.extend_from_slice(value.to_string().as_bytes());
+                        }
+                    } else {
+                        out.extend_from_slice(b"??");
+                    }
                 }
-            } else {
-                out.extend_from_slice(b"??");
+                RefKindV0::Pageref => {
+                    if let Some(anchor_id) = resolved_anchor_id {
+                        let mut marker = Vec::<u8>::new();
+                        marker.extend_from_slice(PAGEREF_RENDER_MARKER_PREFIX_V0);
+                        marker.extend_from_slice(anchor_id.to_string().as_bytes());
+                        marker.extend_from_slice(PAGEREF_RENDER_MARKER_SUFFIX_V0);
+                        if artifacts.hyperref_enabled {
+                            out.push(LINK_START_MARKER_V0);
+                            out.extend_from_slice(&marker);
+                            out.push(LINK_END_MARKER_V0);
+                            pageref_page_link_anchor_ids.push(anchor_id);
+                        } else {
+                            out.extend_from_slice(&marker);
+                        }
+                    } else {
+                        out.extend_from_slice(b"??");
+                    }
+                }
             }
             ref_occurrences.push(RefOccurrenceMetaV0 {
+                kind: ref_kind,
                 key,
                 line_index,
                 resolved_anchor_id,
@@ -2516,13 +2587,6 @@ fn apply_crossref_pass_v1(
             index = key_end + REF_MARKER_SUFFIX_V0.len();
             continue;
         }
-
-        let byte = body[index];
-        out.push(byte);
-        if byte == NEWLINE_MARKER_V0 {
-            line_index = line_index.checked_add(1)?;
-        }
-        index += 1;
     }
     Some(out)
 }
@@ -2531,11 +2595,18 @@ fn assign_link_metadata_v1(
     body: &[u8],
     href_urls: &[Vec<u8>],
     ref_link_anchor_ids: &[u32],
-) -> Option<(Vec<HrefLinkMetaV0>, Vec<RefAnchorLinkMetaV0>)> {
+    pageref_page_link_anchor_ids: &[u32],
+) -> Option<(
+    Vec<HrefLinkMetaV0>,
+    Vec<RefAnchorLinkMetaV0>,
+    Vec<PagerefPageLinkMetaV0>,
+)> {
     let mut href_links = Vec::<HrefLinkMetaV0>::new();
     let mut ref_links = Vec::<RefAnchorLinkMetaV0>::new();
+    let mut pageref_links = Vec::<PagerefPageLinkMetaV0>::new();
     let mut href_cursor = 0usize;
     let mut ref_cursor = 0usize;
+    let mut pageref_cursor = 0usize;
     let mut next_link_id = 1u32;
     let mut index = 0usize;
 
@@ -2560,6 +2631,15 @@ fn assign_link_metadata_v1(
                 url: href_url,
             });
             href_cursor += 1;
+        } else if segment.starts_with(PAGEREF_RENDER_MARKER_PREFIX_V0)
+            && segment.ends_with(PAGEREF_RENDER_MARKER_SUFFIX_V0)
+        {
+            let anchor_id = *pageref_page_link_anchor_ids.get(pageref_cursor)?;
+            pageref_links.push(PagerefPageLinkMetaV0 {
+                link_id: next_link_id,
+                anchor_id,
+            });
+            pageref_cursor += 1;
         } else {
             let anchor_id = *ref_link_anchor_ids.get(ref_cursor)?;
             ref_links.push(RefAnchorLinkMetaV0 {
@@ -2572,10 +2652,13 @@ fn assign_link_metadata_v1(
         index = segment_end + 1;
     }
 
-    if href_cursor != href_urls.len() || ref_cursor != ref_link_anchor_ids.len() {
+    if href_cursor != href_urls.len()
+        || ref_cursor != ref_link_anchor_ids.len()
+        || pageref_cursor != pageref_page_link_anchor_ids.len()
+    {
         return None;
     }
-    Some((href_links, ref_links))
+    Some((href_links, ref_links, pageref_links))
 }
 
 fn resolve_cite_markers_fixedpoint_v0(
@@ -2596,11 +2679,12 @@ fn resolve_cite_markers_fixedpoint_v0(
             while key_end < body.len() {
                 if body[key_end..].starts_with(CITE_MARKER_SUFFIX_V0) {
                     break;
+                } else {
+                    if !is_safe_label_key_byte_v0(body[key_end]) {
+                        return None;
+                    }
+                    key_end += 1;
                 }
-                if !is_safe_label_key_byte_v0(body[key_end]) {
-                    return None;
-                }
-                key_end += 1;
             }
             if key_end == key_start || key_end >= body.len() {
                 return None;
@@ -2688,14 +2772,38 @@ fn consume_label_command_v0(
 }
 
 fn consume_ref_command_v0(tokens: &[TokenV0], index: usize, out: &mut Vec<u8>) -> Option<usize> {
+    consume_ref_like_command_v0(tokens, index, out, REF_CONTROL_V0, REF_MARKER_PREFIX_V0)
+}
+
+fn consume_pageref_command_v0(
+    tokens: &[TokenV0],
+    index: usize,
+    out: &mut Vec<u8>,
+) -> Option<usize> {
+    consume_ref_like_command_v0(
+        tokens,
+        index,
+        out,
+        PAGEREF_CONTROL_V0,
+        PAGEREF_MARKER_PREFIX_V0,
+    )
+}
+
+fn consume_ref_like_command_v0(
+    tokens: &[TokenV0],
+    index: usize,
+    out: &mut Vec<u8>,
+    control: &[u8],
+    marker_prefix: &[u8],
+) -> Option<usize> {
     if !matches!(
         tokens.get(index),
-        Some(TokenV0::ControlSeq(name)) if name.as_slice() == REF_CONTROL_V0
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == control
     ) {
         return None;
     }
     let (key, next) = parse_label_or_ref_key_group_v0(tokens, index)?;
-    out.extend_from_slice(REF_MARKER_PREFIX_V0);
+    out.extend_from_slice(marker_prefix);
     out.extend_from_slice(&key);
     out.extend_from_slice(REF_MARKER_SUFFIX_V0);
     Some(next)
@@ -2969,6 +3077,7 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
     let mut labels_by_key = BTreeMap::<Vec<u8>, LabelEntryMetaV0>::new();
     let mut ref_occurrences = Vec::<RefOccurrenceMetaV0>::new();
     let mut ref_link_anchor_ids = Vec::<u32>::new();
+    let mut pageref_page_link_anchor_ids = Vec::<u32>::new();
     let mut cite_occurrences = Vec::<CiteOccurrenceMetaV0>::new();
     let mut next_anchor_id = 1u32;
     let mut next_figure_ordinal = 1u32;
@@ -3118,6 +3227,15 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
                 pending_label_target = None;
                 index = consume_ref_command_v0(tokens, index, &mut body)?;
             }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == PAGEREF_CONTROL_V0 => {
+                saw_body_content_after_maketitle = true;
+                maybe_emit_pending_noindent_prefix_v0(
+                    &mut body,
+                    &mut pending_noindent_after_heading,
+                );
+                pending_label_target = None;
+                index = consume_pageref_command_v0(tokens, index, &mut body)?;
+            }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == CITE_CONTROL_V0 => {
                 saw_body_content_after_maketitle = true;
                 maybe_emit_pending_noindent_prefix_v0(
@@ -3220,9 +3338,14 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
         &crossref_artifacts,
         &mut ref_occurrences,
         &mut ref_link_anchor_ids,
+        &mut pageref_page_link_anchor_ids,
     )?;
-    let (href_links, ref_anchor_links) =
-        assign_link_metadata_v1(&body, &href_urls, &ref_link_anchor_ids)?;
+    let (href_links, ref_anchor_links, pageref_page_links) = assign_link_metadata_v1(
+        &body,
+        &href_urls,
+        &ref_link_anchor_ids,
+        &pageref_page_link_anchor_ids,
+    )?;
     if saw_thebibliography_env && bibliography_render_requested {
         return None;
     }
@@ -3352,7 +3475,34 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
     if !ref_occurrences.is_empty() {
         push_paragraph_break(&mut body);
         for occurrence in &ref_occurrences {
+            if matches!(occurrence.kind, RefKindV0::Pageref) {
+                continue;
+            }
             body.extend_from_slice(REF_LINE_PREFIX_MARKER_V0);
+            body.extend_from_slice(&occurrence.key);
+            body.push(b' ');
+            body.extend_from_slice(occurrence.line_index.to_string().as_bytes());
+            body.push(b' ');
+            body.extend_from_slice(
+                occurrence
+                    .resolved_anchor_id
+                    .unwrap_or(0)
+                    .to_string()
+                    .as_bytes(),
+            );
+            push_newline(&mut body);
+        }
+    }
+    if ref_occurrences
+        .iter()
+        .any(|occurrence| matches!(occurrence.kind, RefKindV0::Pageref))
+    {
+        push_paragraph_break(&mut body);
+        for occurrence in &ref_occurrences {
+            if !matches!(occurrence.kind, RefKindV0::Pageref) {
+                continue;
+            }
+            body.extend_from_slice(PAGEREF_LINE_PREFIX_MARKER_V0);
             body.extend_from_slice(&occurrence.key);
             body.push(b' ');
             body.extend_from_slice(occurrence.line_index.to_string().as_bytes());
@@ -3371,6 +3521,16 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
         push_paragraph_break(&mut body);
         for link in &ref_anchor_links {
             body.extend_from_slice(REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0);
+            body.extend_from_slice(link.link_id.to_string().as_bytes());
+            body.push(b' ');
+            body.extend_from_slice(link.anchor_id.to_string().as_bytes());
+            push_newline(&mut body);
+        }
+    }
+    if !pageref_page_links.is_empty() {
+        push_paragraph_break(&mut body);
+        for link in &pageref_page_links {
+            body.extend_from_slice(PAGEREF_PAGE_LINK_LINE_PREFIX_MARKER_V0);
             body.extend_from_slice(link.link_id.to_string().as_bytes());
             body.push(b' ');
             body.extend_from_slice(link.anchor_id.to_string().as_bytes());

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -96,13 +96,17 @@ fn typeset_minimal_input_inlines_referenced_tex_file() {
         .collect::<Vec<Vec<u8>>>()
         .join(&b'\n');
     let rendered = String::from_utf8_lossy(&text);
-    assert!(rendered.contains("Start. Included body. End."), "text={rendered:?}");
+    assert!(
+        rendered.contains("Start. Included body. End."),
+        "text={rendered:?}"
+    );
 }
 
 #[test]
 fn typeset_minimal_include_emits_forced_page_break_before_inlined_file() {
     let main = b"\\documentclass{article}\\begin{document}PageA\\include{sections/next}PageB\\end{document}";
-    let result = compile_typeset_with_files(main, &[(b"sections/next.tex", b" Included section. ")]);
+    let result =
+        compile_typeset_with_files(main, &[(b"sections/next.tex", b" Included section. ")]);
     assert_eq!(result.status, CompileStatus::Ok);
     let layout =
         parse_dvi_v2_text_page_to_layout_v0(&result.main_xdv_bytes, 917_504).expect("layout parse");
@@ -111,7 +115,12 @@ fn typeset_minimal_include_emits_forced_page_break_before_inlined_file() {
         &layout.pages[0]
             .lines
             .iter()
-            .flat_map(|line| line.glyphs.iter().map(|glyph| glyph.byte).chain(std::iter::once(b'\n')))
+            .flat_map(|line| {
+                line.glyphs
+                    .iter()
+                    .map(|glyph| glyph.byte)
+                    .chain(std::iter::once(b'\n'))
+            })
             .collect::<Vec<u8>>(),
     )
     .to_string();
@@ -119,7 +128,12 @@ fn typeset_minimal_include_emits_forced_page_break_before_inlined_file() {
         &layout.pages[1]
             .lines
             .iter()
-            .flat_map(|line| line.glyphs.iter().map(|glyph| glyph.byte).chain(std::iter::once(b'\n')))
+            .flat_map(|line| {
+                line.glyphs
+                    .iter()
+                    .map(|glyph| glyph.byte)
+                    .chain(std::iter::once(b'\n'))
+            })
             .collect::<Vec<u8>>(),
     )
     .to_string();
@@ -147,7 +161,10 @@ fn typeset_minimal_hyperref_refs_keep_anchor_order_across_include_boundaries_v2(
     let main = b"\\documentclass{article}\\begin{document}\\section{Main}\\label{sec:main}\\include{sections/two}Refs: \\ref{sec:two}, \\ref{fig:two}, \\ref{eq:two}.\\href{https://example.com}{link}\\end{document}";
     let included = b"\\section{Included Two}\\label{sec:two}\\begin{figure}\\caption{Included figure}\\end{figure}\\label{fig:two}\\[x+y\\]\\label{eq:two}";
     let text = compile_typeset_text_with_files(main, &[(b"sections/two.tex", included)]);
-    assert!(text.contains("!l sec:main 1 heading 1 Main"), "text={text:?}");
+    assert!(
+        text.contains("!l sec:main 1 heading 1 Main"),
+        "text={text:?}"
+    );
     assert!(
         text.contains("!l sec:two 2 heading 1 Included Two"),
         "text={text:?}"
@@ -175,7 +192,10 @@ fn typeset_minimal_rejects_input_include_cycle() {
     let b = b"\\input{cycle/a}";
     let result = compile_typeset_with_files(
         main,
-        &[(b"cycle/a.tex", a.as_slice()), (b"cycle/b.tex", b.as_slice())],
+        &[
+            (b"cycle/a.tex", a.as_slice()),
+            (b"cycle/b.tex", b.as_slice()),
+        ],
     );
     assert_eq!(result.status, CompileStatus::InvalidInput);
     assert!(result.main_xdv_bytes.is_empty());
@@ -292,7 +312,9 @@ fn typeset_minimal_toc_links_keep_input_heading_anchor_order_with_hyperref_v2() 
     let main = b"\\documentclass{article}\\title{T}\\author{A}\\date{D}\\begin{document}\\maketitle\\tableofcontents\\input{sections/toc}\\section{Tail}\\href{https://example.com}{link}\\end{document}";
     let included = b"\\section{Input Section}\\subsection{Input Detail}";
     let text = compile_typeset_text_with_files(main, &[(b"sections/toc.tex", included)]);
-    let first = text.find("!toc 1 1 <Input Section>").expect("first toc entry");
+    let first = text
+        .find("!toc 1 1 <Input Section>")
+        .expect("first toc entry");
     let second = text
         .find("!toc 2 2 <Input Detail>")
         .expect("second toc entry");
@@ -474,6 +496,40 @@ fn typeset_minimal_crossref_pass_v1_wraps_resolved_refs_as_links_when_hyperref_i
     assert!(text.contains("!r sec:missing 3 0"), "body={text:?}");
     assert!(text.contains("!ra 1 1"), "body={text:?}");
     assert!(text.contains("!u 2 https://example.com"), "body={text:?}");
+}
+
+#[test]
+fn typeset_minimal_pageref_resolves_to_render_marker_and_emits_page_link_metadata_v2() {
+    let main = b"\\documentclass{article}\\begin{document}\\section{Intro}\\label{sec:intro}See pages \\pageref{sec:intro} and \\pageref{sec:missing} with \\href{https://example.com}{link}.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("~ See pages <@@PG:1@@> and ?? with <{link}>."),
+        "body={text:?}"
+    );
+    assert!(text.contains("!pr sec:intro 3 1"), "body={text:?}");
+    assert!(text.contains("!pr sec:missing 3 0"), "body={text:?}");
+    assert!(text.contains("!rp 1 1"), "body={text:?}");
+    assert!(text.contains("!u 2 https://example.com"), "body={text:?}");
+    assert!(
+        !text.contains("!r sec:intro "),
+        "pageref should not be emitted as regular ref metadata: body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_pageref_resolves_across_include_boundary_with_hyperref_v2() {
+    let main = b"\\documentclass{article}\\begin{document}\\include{sections/two}Page ref: \\pageref{sec:two}.\\href{https://example.com}{link}\\end{document}";
+    let included = b"\\section{Included Two}\\label{sec:two}\\begin{figure}\\caption{Included figure}\\end{figure}\\label{fig:two}\\[x+y\\]\\label{eq:two}";
+    let text = compile_typeset_text_with_files(main, &[(b"sections/two.tex", included)]);
+    assert!(text.contains("@S {Included Two}"), "text={text:?}");
+    assert!(text.contains("Page ref: <@@PG:1@@>."), "text={text:?}");
+    assert!(
+        text.contains("!l sec:two 1 heading 1 Included Two"),
+        "text={text:?}"
+    );
+    assert!(text.contains("!pr sec:two "), "text={text:?}");
+    assert!(text.contains("!rp 1 1"), "text={text:?}");
 }
 
 #[test]
@@ -813,7 +869,9 @@ fn typeset_minimal_figure_stub_emits_placeholder_and_caption_markers() {
     let body = extract_typeset_body(main);
     let text = String::from_utf8(body).expect("body should be valid utf8");
     assert!(
-        text.contains("Before.\n\n!gbox\n!gcap Figure 1: Demo figure caption with [emphasis].\n\nAfter."),
+        text.contains(
+            "Before.\n\n!gbox\n!gcap Figure 1: Demo figure caption with [emphasis].\n\nAfter."
+        ),
         "body={text:?}"
     );
 }
@@ -1256,7 +1314,10 @@ fn typeset_minimal_display_math_emits_equation_metadata_and_ref_resolution_v1() 
     assert!(text.contains("!eq 1 1"), "body={text:?}");
     assert!(text.contains("!eq 2 2"), "body={text:?}");
     assert!(text.contains("!l eq:first 1 equation 1 -"), "body={text:?}");
-    assert!(text.contains("!l eq:second 2 equation 2 -"), "body={text:?}");
+    assert!(
+        text.contains("!l eq:second 2 equation 2 -"),
+        "body={text:?}"
+    );
 }
 
 #[test]

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -1,6 +1,6 @@
 use crate::{
-    parse_dvi_v2_text_page_to_layout_v0, GlyphPlanV0, LinePlanV0, PagePlanV0,
-    DEFAULT_LINE_ADVANCE_SP_V0,
+    layout_v0::glyph_width_sp_v0, parse_dvi_v2_text_page_to_layout_v0, GlyphPlanV0, LinePlanV0,
+    PagePlanV0, DEFAULT_LINE_ADVANCE_SP_V0,
 };
 use std::collections::BTreeMap;
 
@@ -28,7 +28,9 @@ const FOOTNOTE_LINE_PREFIX_MARKER_V0: &[u8] = b"!f ";
 const HREF_URL_LINE_PREFIX_MARKER_V0: &[u8] = b"!u ";
 const LABEL_LINE_PREFIX_MARKER_V0: &[u8] = b"!l ";
 const REF_LINE_PREFIX_MARKER_V0: &[u8] = b"!r ";
+const PAGEREF_LINE_PREFIX_MARKER_V0: &[u8] = b"!pr ";
 const REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0: &[u8] = b"!ra ";
+const PAGEREF_PAGE_LINK_LINE_PREFIX_MARKER_V0: &[u8] = b"!rp ";
 const EQUATION_LINE_PREFIX_MARKER_V0: &[u8] = b"!eq ";
 const BIBITEM_LINE_PREFIX_MARKER_V0: &[u8] = b"!b ";
 const CITE_LINE_PREFIX_MARKER_V0: &[u8] = b"!c ";
@@ -65,6 +67,8 @@ const SUBSECTION_HEADING_PREFIX_MARKER_V0: &[u8] = b"@s ";
 const DISPLAY_MATH_PLACEHOLDER_SHORT_V0: &[u8] = b"MATH DISPLAY";
 const DISPLAY_MATH_PLACEHOLDER_MEDIUM_V0: &[u8] = b"MATH DISPLAY MEDIUM";
 const DISPLAY_MATH_PLACEHOLDER_LONG_V0: &[u8] = b"MATH DISPLAY LONG FORM";
+const PAGEREF_RENDER_MARKER_PREFIX_V0: &[u8] = b"@@PG:";
+const PAGEREF_RENDER_MARKER_SUFFIX_V0: &[u8] = b"@@";
 const ITALIC_START_MARKER_V0: u8 = b'[';
 const ITALIC_END_MARKER_V0: u8 = b']';
 const BOLD_START_MARKER_V0: u8 = b'{';
@@ -175,6 +179,7 @@ struct PdfLinkAnnotationV0 {
 enum PdfLinkTargetV0 {
     Uri(Vec<u8>),
     Anchor(u32),
+    AnchorPage(u32),
 }
 
 #[derive(Clone)]
@@ -198,6 +203,12 @@ struct EquationMetadataV0 {
 
 #[derive(Clone)]
 struct RefAnchorLinkMetadataV0 {
+    link_id: u32,
+    anchor_id: u32,
+}
+
+#[derive(Clone)]
+struct PagerefPageLinkMetadataV0 {
     link_id: u32,
     anchor_id: u32,
 }
@@ -377,7 +388,9 @@ fn is_structured_non_title_line_v0(glyphs: &[GlyphPlanV0]) -> bool {
         || has_href_url_line_prefix_v0(glyphs)
         || has_label_line_prefix_v0(glyphs)
         || has_ref_line_prefix_v0(glyphs)
+        || has_pageref_line_prefix_v0(glyphs)
         || has_ref_anchor_link_line_prefix_v0(glyphs)
+        || has_pageref_page_link_line_prefix_v0(glyphs)
         || has_equation_line_prefix_v0(glyphs)
         || has_bibitem_line_prefix_v0(glyphs)
         || has_cite_line_prefix_v0(glyphs)
@@ -477,7 +490,10 @@ fn is_display_math_placeholder_line_v0(glyphs: &[GlyphPlanV0]) -> bool {
     if !has_center_prefix_v0(glyphs) {
         return false;
     }
-    let payload = glyphs[2..].iter().map(|glyph| glyph.byte).collect::<Vec<u8>>();
+    let payload = glyphs[2..]
+        .iter()
+        .map(|glyph| glyph.byte)
+        .collect::<Vec<u8>>();
     payload.as_slice() == DISPLAY_MATH_PLACEHOLDER_SHORT_V0
         || payload.as_slice() == DISPLAY_MATH_PLACEHOLDER_MEDIUM_V0
         || payload.as_slice() == DISPLAY_MATH_PLACEHOLDER_LONG_V0
@@ -937,7 +953,8 @@ fn emit_figure_block_v0(
         return None;
     }
 
-    let placeholder_segments = placeholder_segments_v0(image_metadata.map(|meta| meta.image_path.as_slice()));
+    let placeholder_segments =
+        placeholder_segments_v0(image_metadata.map(|meta| meta.image_path.as_slice()));
     let placeholder_render_segments = split_superscript_segments_v0(&placeholder_segments);
     let placeholder_text_width_pt = placeholder_render_segments
         .iter()
@@ -949,9 +966,8 @@ fn emit_figure_block_v0(
     let placeholder_box_height_pt = image_metadata
         .map(|meta| meta.height_pt)
         .unwrap_or(DEFAULT_FIGURE_PLACEHOLDER_HEIGHT_PT_V0);
-    let placeholder_width_pt = placeholder_box_width_pt.max(
-        placeholder_text_width_pt + (FIGURE_PLACEHOLDER_LABEL_INSET_PT_V0 * 2.0),
-    );
+    let placeholder_width_pt = placeholder_box_width_pt
+        .max(placeholder_text_width_pt + (FIGURE_PLACEHOLDER_LABEL_INSET_PT_V0 * 2.0));
     if placeholder_width_pt > MAX_FIGURE_PLACEHOLDER_WIDTH_PT_V0 {
         return None;
     }
@@ -1259,12 +1275,28 @@ fn has_ref_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
             .eq(REF_LINE_PREFIX_MARKER_V0.iter().copied())
 }
 
+fn has_pageref_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() >= PAGEREF_LINE_PREFIX_MARKER_V0.len()
+        && glyphs[..PAGEREF_LINE_PREFIX_MARKER_V0.len()]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .eq(PAGEREF_LINE_PREFIX_MARKER_V0.iter().copied())
+}
+
 fn has_ref_anchor_link_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
     glyphs.len() >= REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0.len()
         && glyphs[..REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0.len()]
             .iter()
             .map(|glyph| glyph.byte)
             .eq(REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0.iter().copied())
+}
+
+fn has_pageref_page_link_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() >= PAGEREF_PAGE_LINK_LINE_PREFIX_MARKER_V0.len()
+        && glyphs[..PAGEREF_PAGE_LINK_LINE_PREFIX_MARKER_V0.len()]
+            .iter()
+            .map(|glyph| glyph.byte)
+            .eq(PAGEREF_PAGE_LINK_LINE_PREFIX_MARKER_V0.iter().copied())
 }
 
 fn has_equation_line_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
@@ -1422,6 +1454,32 @@ fn parse_ref_line_v0(glyphs: &[GlyphPlanV0]) -> Option<()> {
     Some(())
 }
 
+fn parse_pageref_line_v0(glyphs: &[GlyphPlanV0]) -> Option<()> {
+    if glyphs.len() < PAGEREF_LINE_PREFIX_MARKER_V0.len() {
+        return None;
+    }
+    let bytes: Vec<u8> = glyphs.iter().map(|glyph| glyph.byte).collect();
+    if !bytes.starts_with(PAGEREF_LINE_PREFIX_MARKER_V0) {
+        return None;
+    }
+    let line = String::from_utf8(bytes).ok()?;
+    let mut parts = line.splitn(4, ' ');
+    let prefix = parts.next()?;
+    if prefix != "!pr" {
+        return None;
+    }
+    let key = parts.next()?.trim();
+    let line_index = parts.next()?.trim().parse::<u32>().ok()?;
+    let resolved_anchor_id = parts.next()?.trim().parse::<u32>().ok()?;
+    if key.is_empty() || line_index == 0 {
+        return None;
+    }
+    if resolved_anchor_id == 0 {
+        return Some(());
+    }
+    Some(())
+}
+
 fn parse_ref_anchor_link_line_v0(glyphs: &[GlyphPlanV0]) -> Option<RefAnchorLinkMetadataV0> {
     if glyphs.len() < REF_ANCHOR_LINK_LINE_PREFIX_MARKER_V0.len() {
         return None;
@@ -1442,6 +1500,111 @@ fn parse_ref_anchor_link_line_v0(glyphs: &[GlyphPlanV0]) -> Option<RefAnchorLink
         return None;
     }
     Some(RefAnchorLinkMetadataV0 { link_id, anchor_id })
+}
+
+fn parse_pageref_page_link_line_v0(glyphs: &[GlyphPlanV0]) -> Option<PagerefPageLinkMetadataV0> {
+    if glyphs.len() < PAGEREF_PAGE_LINK_LINE_PREFIX_MARKER_V0.len() {
+        return None;
+    }
+    let bytes: Vec<u8> = glyphs.iter().map(|glyph| glyph.byte).collect();
+    if !bytes.starts_with(PAGEREF_PAGE_LINK_LINE_PREFIX_MARKER_V0) {
+        return None;
+    }
+    let line = String::from_utf8(bytes).ok()?;
+    let mut parts = line.splitn(3, ' ');
+    let prefix = parts.next()?;
+    if prefix != "!rp" {
+        return None;
+    }
+    let link_id = parts.next()?.trim().parse::<u32>().ok()?;
+    let anchor_id = parts.next()?.trim().parse::<u32>().ok()?;
+    if link_id == 0 || anchor_id == 0 {
+        return None;
+    }
+    Some(PagerefPageLinkMetadataV0 { link_id, anchor_id })
+}
+
+fn infer_line_glyph_advance_sp_v0(glyphs: &[GlyphPlanV0]) -> Option<i32> {
+    for glyph in glyphs {
+        if glyph.advance_sp <= 0 {
+            continue;
+        }
+        if !matches!(
+            glyph.byte,
+            b' ' | b'.'
+                | b','
+                | b';'
+                | b':'
+                | b'!'
+                | b'?'
+                | b'\''
+                | b'"'
+                | b'i'
+                | b'l'
+                | b'I'
+                | b'|'
+                | b'm'
+                | b'w'
+                | b'M'
+                | b'W'
+        ) {
+            return Some(glyph.advance_sp);
+        }
+    }
+    glyphs
+        .iter()
+        .find(|glyph| glyph.advance_sp > 0)
+        .map(|glyph| glyph.advance_sp)
+}
+
+fn parse_pageref_render_marker_v0(bytes: &[u8], index: usize) -> Option<(u32, usize)> {
+    if index + PAGEREF_RENDER_MARKER_PREFIX_V0.len() >= bytes.len()
+        || !bytes[index..].starts_with(PAGEREF_RENDER_MARKER_PREFIX_V0)
+    {
+        return None;
+    }
+    let mut cursor = index + PAGEREF_RENDER_MARKER_PREFIX_V0.len();
+    let mut anchor_id = 0u32;
+    let mut saw_digit = false;
+    while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+        saw_digit = true;
+        anchor_id = anchor_id
+            .checked_mul(10)?
+            .checked_add(u32::from(bytes[cursor] - b'0'))?;
+        cursor += 1;
+    }
+    if !saw_digit
+        || anchor_id == 0
+        || cursor + PAGEREF_RENDER_MARKER_SUFFIX_V0.len() > bytes.len()
+        || !bytes[cursor..].starts_with(PAGEREF_RENDER_MARKER_SUFFIX_V0)
+    {
+        return None;
+    }
+    Some((anchor_id, cursor + PAGEREF_RENDER_MARKER_SUFFIX_V0.len()))
+}
+
+fn replace_pageref_render_markers_v0(
+    glyphs: &[GlyphPlanV0],
+    page_numbers_by_anchor_id: &BTreeMap<u32, u32>,
+) -> Option<Vec<GlyphPlanV0>> {
+    let bytes = bytes_from_glyphs_v0(glyphs);
+    let mut out = Vec::<GlyphPlanV0>::with_capacity(glyphs.len());
+    let glyph_advance_sp = infer_line_glyph_advance_sp_v0(glyphs).unwrap_or(65_536);
+    let mut index = 0usize;
+    while index < glyphs.len() {
+        if let Some((anchor_id, next_index)) = parse_pageref_render_marker_v0(&bytes, index) {
+            let page_no = page_numbers_by_anchor_id.get(&anchor_id).copied()?;
+            for byte in page_no.to_string().bytes() {
+                let advance_sp = glyph_width_sp_v0(byte, glyph_advance_sp)?;
+                out.push(GlyphPlanV0 { byte, advance_sp });
+            }
+            index = next_index;
+            continue;
+        }
+        out.push(glyphs[index].clone());
+        index += 1;
+    }
+    Some(out)
 }
 
 fn parse_bibitem_line_v0(glyphs: &[GlyphPlanV0]) -> Option<()> {
@@ -1737,7 +1900,9 @@ fn split_body_and_metadata_lines_v0(
                 || has_toc_entry_line_prefix_v0(&line.glyphs)
                 || has_label_line_prefix_v0(&line.glyphs)
                 || has_ref_line_prefix_v0(&line.glyphs)
+                || has_pageref_line_prefix_v0(&line.glyphs)
                 || has_ref_anchor_link_line_prefix_v0(&line.glyphs)
+                || has_pageref_page_link_line_prefix_v0(&line.glyphs)
                 || has_equation_line_prefix_v0(&line.glyphs)
                 || has_bibitem_line_prefix_v0(&line.glyphs)
                 || has_cite_line_prefix_v0(&line.glyphs)
@@ -1879,6 +2044,19 @@ fn parse_metadata_lines_v0(
             current_footnote_id = None;
             continue;
         }
+        if let Some(pageref_link) = parse_pageref_page_link_line_v0(&line.glyphs) {
+            if link_targets_by_id
+                .insert(
+                    pageref_link.link_id,
+                    PdfLinkTargetV0::AnchorPage(pageref_link.anchor_id),
+                )
+                .is_some()
+            {
+                return None;
+            }
+            current_footnote_id = None;
+            continue;
+        }
         if let Some(equation) = parse_equation_line_v0(&line.glyphs) {
             if equation_ordinals_by_anchor_id
                 .insert(equation.anchor_id, equation.ordinal)
@@ -1905,6 +2083,10 @@ fn parse_metadata_lines_v0(
             continue;
         }
         if parse_ref_line_v0(&line.glyphs).is_some() {
+            current_footnote_id = None;
+            continue;
+        }
+        if parse_pageref_line_v0(&line.glyphs).is_some() {
             current_footnote_id = None;
             continue;
         }
@@ -1940,6 +2122,7 @@ fn build_page_content_stream_v0(
     lines: &[LinePlanV0],
     footnote_defs_by_id: &BTreeMap<u32, Vec<Vec<GlyphPlanV0>>>,
     link_targets_by_id: &BTreeMap<u32, PdfLinkTargetV0>,
+    page_numbers_by_anchor_id: &BTreeMap<u32, u32>,
     toc_entries: &[TocEntryMetadataV0],
     equation_ordinals_by_anchor_id: &BTreeMap<u32, u32>,
     next_link_id: &mut u32,
@@ -1988,6 +2171,8 @@ fn build_page_content_stream_v0(
     let mut line_index = 0usize;
     while line_index < lines.len() {
         let line = &lines[line_index];
+        let resolved_line_glyphs =
+            replace_pageref_render_markers_v0(&line.glyphs, page_numbers_by_anchor_id)?;
         if y < MARGIN_PT_V0 {
             break;
         }
@@ -1995,13 +2180,14 @@ fn build_page_content_stream_v0(
             return None;
         }
         if line_index >= title_block_len
-            && (has_table_spec_prefix_v0(&line.glyphs) || has_table_row_prefix_v0(&line.glyphs))
+            && (has_table_spec_prefix_v0(&resolved_line_glyphs)
+                || has_table_row_prefix_v0(&resolved_line_glyphs))
         {
             let mut cursor = line_index;
-            if !has_table_spec_prefix_v0(&lines[cursor].glyphs) {
+            if !has_table_spec_prefix_v0(&resolved_line_glyphs) {
                 return None;
             }
-            let align_spec = parse_table_align_spec_line_v0(&lines[cursor].glyphs)?;
+            let align_spec = parse_table_align_spec_line_v0(&resolved_line_glyphs)?;
             cursor += 1;
             let mut table_end = cursor;
             while table_end < lines.len() && has_table_row_prefix_v0(&lines[table_end].glyphs) {
@@ -2024,7 +2210,7 @@ fn build_page_content_stream_v0(
             line_index = table_end;
             continue;
         }
-        if line_index >= title_block_len && has_figure_box_prefix_v0(&line.glyphs) {
+        if line_index >= title_block_len && has_figure_box_prefix_v0(&resolved_line_glyphs) {
             let figure_anchor_id = *next_anchor_id;
             *next_anchor_id = next_anchor_id.checked_add(1)?;
             if anchor_destinations
@@ -2064,13 +2250,13 @@ fn build_page_content_stream_v0(
             line_index = cursor + 1;
             continue;
         }
-        if line_index >= title_block_len && has_figure_image_prefix_v0(&line.glyphs) {
+        if line_index >= title_block_len && has_figure_image_prefix_v0(&resolved_line_glyphs) {
             return None;
         }
-        if line_index >= title_block_len && has_figure_caption_prefix_v0(&line.glyphs) {
+        if line_index >= title_block_len && has_figure_caption_prefix_v0(&resolved_line_glyphs) {
             return None;
         }
-        if line_index >= title_block_len && has_toc_placeholder_line_v0(&line.glyphs) {
+        if line_index >= title_block_len && has_toc_placeholder_line_v0(&resolved_line_glyphs) {
             emit_toc_block_v0(
                 &mut out,
                 toc_entries,
@@ -2085,52 +2271,52 @@ fn build_page_content_stream_v0(
             line_index += 1;
             continue;
         }
-        if line_index >= title_block_len && has_toc_entry_line_prefix_v0(&line.glyphs) {
+        if line_index >= title_block_len && has_toc_entry_line_prefix_v0(&resolved_line_glyphs) {
             return None;
         }
         let quote_prefix_advance_pt = if line_index >= title_block_len {
-            detect_quote_prefix_advance_pt_v0(&line.glyphs)
+            detect_quote_prefix_advance_pt_v0(&resolved_line_glyphs)
         } else {
             None
         };
         let center_prefixed = line_index >= title_block_len
             && quote_prefix_advance_pt.is_none()
-            && has_center_prefix_v0(&line.glyphs);
+            && has_center_prefix_v0(&resolved_line_glyphs);
         let right_prefixed = line_index >= title_block_len
             && quote_prefix_advance_pt.is_none()
             && !center_prefixed
-            && has_right_prefix_v0(&line.glyphs);
+            && has_right_prefix_v0(&resolved_line_glyphs);
         let noindent_prefixed = line_index >= title_block_len
             && quote_prefix_advance_pt.is_none()
             && !center_prefixed
             && !right_prefixed
-            && has_noindent_prefix_v0(&line.glyphs);
+            && has_noindent_prefix_v0(&resolved_line_glyphs);
         let heading_kind = if line_index >= title_block_len
             && quote_prefix_advance_pt.is_none()
             && !center_prefixed
             && !right_prefixed
             && !noindent_prefixed
         {
-            detect_heading_prefix_v0(&line.glyphs)
+            detect_heading_prefix_v0(&resolved_line_glyphs)
         } else {
             None
         };
         let display_math_line = line_index >= title_block_len
             && quote_prefix_advance_pt.is_none()
             && center_prefixed
-            && is_display_math_placeholder_line_v0(&line.glyphs);
+            && is_display_math_placeholder_line_v0(&resolved_line_glyphs);
         let render_glyphs_base: &[GlyphPlanV0] = if quote_prefix_advance_pt.is_some() {
-            &line.glyphs[2..]
+            &resolved_line_glyphs[2..]
         } else if center_prefixed {
-            &line.glyphs[2..]
+            &resolved_line_glyphs[2..]
         } else if right_prefixed {
-            &line.glyphs[2..]
+            &resolved_line_glyphs[2..]
         } else if noindent_prefixed {
-            &line.glyphs[2..]
+            &resolved_line_glyphs[2..]
         } else if let Some(kind) = heading_kind {
-            &line.glyphs[heading_prefix_len_v0(kind)..]
+            &resolved_line_glyphs[heading_prefix_len_v0(kind)..]
         } else {
-            &line.glyphs
+            &resolved_line_glyphs
         };
         let list_prefix = if line_index >= title_block_len
             && quote_prefix_advance_pt.is_none()
@@ -2292,7 +2478,8 @@ fn build_page_content_stream_v0(
             }
             if let Some(ordinal) = equation_ordinal {
                 let equation_number = format!("({ordinal})").into_bytes();
-                let equation_number_width_pt = (equation_number.len() as f32) * (FONT_SIZE_PT_V0 * 0.6);
+                let equation_number_width_pt =
+                    (equation_number.len() as f32) * (FONT_SIZE_PT_V0 * 0.6);
                 let equation_number_x =
                     (PAGE_WIDTH_PT_V0 - MARGIN_PT_V0 - equation_number_width_pt).max(MARGIN_PT_V0);
                 let equation_segments = [PdfRenderSegmentV0 {
@@ -2378,12 +2565,21 @@ fn build_page_content_stream_v0(
 
 fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
     let (body_pages, metadata_lines) = split_body_and_metadata_lines_v0(pages);
-    let Some((footnote_defs_by_id, link_targets_by_id, toc_entries, equation_ordinals_by_anchor_id)) =
-        parse_metadata_lines_v0(&metadata_lines)
+    let Some((
+        footnote_defs_by_id,
+        link_targets_by_id,
+        toc_entries,
+        equation_ordinals_by_anchor_id,
+    )) = parse_metadata_lines_v0(&metadata_lines)
     else {
         return Vec::new();
     };
     let Some(nominal_anchor_destinations) = collect_nominal_anchor_destinations_v0(&body_pages)
+    else {
+        return Vec::new();
+    };
+    let Some(page_numbers_by_anchor_id) =
+        build_page_numbers_by_anchor_id_v0(&nominal_anchor_destinations)
     else {
         return Vec::new();
     };
@@ -2397,6 +2593,7 @@ fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
             body_lines,
             &footnote_defs_by_id,
             &link_targets_by_id,
+            &page_numbers_by_anchor_id,
             &toc_entries,
             &equation_ordinals_by_anchor_id,
             &mut next_link_id,
@@ -2416,10 +2613,13 @@ fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
         return Vec::new();
     }
     for target in link_targets_by_id.values() {
-        if let PdfLinkTargetV0::Anchor(anchor_id) = target {
-            if !anchor_destinations.contains_key(anchor_id) {
-                return Vec::new();
+        match target {
+            PdfLinkTargetV0::Anchor(anchor_id) | PdfLinkTargetV0::AnchorPage(anchor_id) => {
+                if !anchor_destinations.contains_key(anchor_id) {
+                    return Vec::new();
+                }
             }
+            PdfLinkTargetV0::Uri(_) => {}
         }
     }
 
@@ -2569,6 +2769,28 @@ fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
                         annot_body.as_bytes(),
                     ));
                 }
+                PdfLinkTargetV0::AnchorPage(anchor_id) => {
+                    let Some(destination) = anchor_destinations.get(anchor_id).copied() else {
+                        return Vec::new();
+                    };
+                    let destination_page_id =
+                        first_page_id + u32::try_from(destination.page_index).unwrap_or(0);
+                    if destination_page_id >= first_stream_id {
+                        return Vec::new();
+                    }
+                    let annot_body = format!(
+                        "<< /Type /Annot /Subtype /Link /Rect [{:.2} {:.2} {:.2} {:.2}] /Border [0 0 0] /Dest [{destination_page_id} 0 R /Fit] >>",
+                        annotation.rect[0],
+                        annotation.rect[1],
+                        annotation.rect[2],
+                        annotation.rect[3],
+                    );
+                    offsets.push(write_pdf_obj(
+                        &mut out,
+                        annotation_id,
+                        annot_body.as_bytes(),
+                    ));
+                }
             }
             annotation_counter += 1;
         }
@@ -2610,6 +2832,19 @@ fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
     out.extend_from_slice(b"\n");
     out.extend_from_slice(PDF_EOF);
     out
+}
+
+fn build_page_numbers_by_anchor_id_v0(
+    anchor_destinations: &BTreeMap<u32, AnchorDestinationV0>,
+) -> Option<BTreeMap<u32, u32>> {
+    let mut out = BTreeMap::<u32, u32>::new();
+    for (anchor_id, destination) in anchor_destinations {
+        let page_no = u32::try_from(destination.page_index).ok()?.checked_add(1)?;
+        if out.insert(*anchor_id, page_no).is_some() {
+            return None;
+        }
+    }
+    Some(out)
 }
 
 /// Render a deterministic, single-font PDF preview for a v0 DVI-v2 text page.

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -2271,15 +2271,15 @@ fn pdf_renderer_display_math_placeholder_line_is_centered_v0() {
 
 #[test]
 fn pdf_renderer_display_math_long_placeholder_is_wider_and_left_shifted_v2() {
-    let xdv =
-        write_dvi_v2_text_page_v0(b"Before.\n\n^ MATH DISPLAY\n\n^ MATH DISPLAY LONG FORM\n\nAfter.")
-            .expect("writer should accept display math placeholder marker lines");
+    let xdv = write_dvi_v2_text_page_v0(
+        b"Before.\n\n^ MATH DISPLAY\n\n^ MATH DISPLAY LONG FORM\n\nAfter.",
+    )
+    .expect("writer should accept display math placeholder marker lines");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
     let (short_x, _) = tm_position_for_line_containing_text_v0(&pdf, "(MATH DISPLAY)")
         .expect("short display placeholder x coordinate");
-    let (long_x, _) =
-        tm_position_for_line_containing_text_v0(&pdf, "(MATH DISPLAY LONG FORM)")
-            .expect("long display placeholder x coordinate");
+    let (long_x, _) = tm_position_for_line_containing_text_v0(&pdf, "(MATH DISPLAY LONG FORM)")
+        .expect("long display placeholder x coordinate");
     assert!(
         long_x < short_x,
         "long placeholder should center from a wider line and shift left: short_x={short_x}, long_x={long_x}"
@@ -2377,7 +2377,11 @@ fn pdf_renderer_emits_figref_annotation_targeting_figure_anchor_v0() {
     );
     let page_one = parse_pdf_object_body_v0(&pdf, 3).expect("page object");
     let annots = parse_pdf_ref_ids_v0(&page_one, "/Annots");
-    assert_eq!(annots.len(), 1, "expected one internal figure ref annotation");
+    assert_eq!(
+        annots.len(),
+        1,
+        "expected one internal figure ref annotation"
+    );
     let annotation = parse_pdf_object_body_v0(&pdf, annots[0]).expect("annotation");
     assert!(
         annotation.contains("/Dest ["),
@@ -2405,7 +2409,11 @@ fn pdf_renderer_emits_eqref_annotation_targeting_equation_anchor_v1() {
 
     let page_one = parse_pdf_object_body_v0(&pdf, 3).expect("page object");
     let annots = parse_pdf_ref_ids_v0(&page_one, "/Annots");
-    assert_eq!(annots.len(), 1, "expected one internal equation ref annotation");
+    assert_eq!(
+        annots.len(),
+        1,
+        "expected one internal equation ref annotation"
+    );
     let annotation = parse_pdf_object_body_v0(&pdf, annots[0]).expect("annotation");
     assert!(
         annotation.contains("/Dest ["),
@@ -2415,6 +2423,52 @@ fn pdf_renderer_emits_eqref_annotation_targeting_equation_anchor_v1() {
         parse_pdf_annotation_dest_page_id_v0(&annotation),
         Some(3),
         "equation ref destination should target page containing equation anchor"
+    );
+}
+
+#[test]
+fn pdf_renderer_resolves_pageref_marker_and_emits_page_destination_link_v2() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"Prelude.\n\n@S {Intro}\x0cSee <@@PG:1@@>.\n\n!l sec:intro 1 heading 1 Intro\n!pr sec:intro 3 1\n!rp 1 1",
+    )
+    .expect("writer should accept pageref marker and metadata lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    assert!(
+        pdf_text.contains("(See ) Tj") && pdf_text.contains("(1) Tj"),
+        "pageref should render resolved destination page number: {pdf_text}"
+    );
+    assert!(
+        !pdf_text.contains("@@PG:"),
+        "internal pageref marker must not leak into rendered pdf text: {pdf_text}"
+    );
+
+    let page_two = parse_pdf_object_body_v0(&pdf, 4).expect("second page object");
+    let annots = parse_pdf_ref_ids_v0(&page_two, "/Annots");
+    assert_eq!(
+        annots.len(),
+        1,
+        "expected one pageref annotation on page two"
+    );
+    let annotation = parse_pdf_object_body_v0(&pdf, annots[0]).expect("annotation");
+    assert!(
+        annotation.contains("/Dest [3 0 R /Fit]"),
+        "pageref annotation must target stable page destination with /Fit: {annotation}"
+    );
+    assert!(
+        !annotation.contains("/XYZ"),
+        "pageref page destination must not use incidental /XYZ coordinates: {annotation}"
+    );
+}
+
+#[test]
+fn pdf_renderer_rejects_pageref_marker_with_unknown_anchor_v2() {
+    let xdv = write_dvi_v2_text_page_v0(b"See <@@PG:9@@>.\n\n!pr sec:missing 1 9\n!rp 1 9")
+        .expect("writer should accept pageref marker and metadata lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed when pageref marker targets a missing anchor"
     );
 }
 
@@ -2822,8 +2876,12 @@ fn pdf_renderer_table_colspec_alignment_respects_lcr_per_column_v2() {
         "right-aligned first column should share right edge: {nine_right} vs {ten_right}"
     );
 
-    let mid_x = *tm_xs_for_segment_text_v0(&pdf, "Mid").first().expect("mid x");
-    let more_x = *tm_xs_for_segment_text_v0(&pdf, "More").first().expect("more x");
+    let mid_x = *tm_xs_for_segment_text_v0(&pdf, "Mid")
+        .first()
+        .expect("mid x");
+    let more_x = *tm_xs_for_segment_text_v0(&pdf, "More")
+        .first()
+        .expect("more x");
     let mid_center = mid_x + (segment_width_pt_v0(b"Mid") * 0.5);
     let more_center = more_x + (segment_width_pt_v0(b"More") * 0.5);
     assert!(
@@ -2831,15 +2889,23 @@ fn pdf_renderer_table_colspec_alignment_respects_lcr_per_column_v2() {
         "center-aligned second column should share center: {mid_center} vs {more_center}"
     );
 
-    let tail_x = *tm_xs_for_segment_text_v0(&pdf, "Tail").first().expect("tail x");
-    let tail2_x = *tm_xs_for_segment_text_v0(&pdf, "Tail2").first().expect("tail2 x");
+    let tail_x = *tm_xs_for_segment_text_v0(&pdf, "Tail")
+        .first()
+        .expect("tail x");
+    let tail2_x = *tm_xs_for_segment_text_v0(&pdf, "Tail2")
+        .first()
+        .expect("tail2 x");
     assert!(
         (tail_x - tail2_x).abs() <= 0.1,
         "left-aligned third column should share left edge: {tail_x} vs {tail2_x}"
     );
 
-    let end_x = *tm_xs_for_segment_text_v0(&pdf, "End").first().expect("end x");
-    let ending_x = *tm_xs_for_segment_text_v0(&pdf, "Ending").first().expect("ending x");
+    let end_x = *tm_xs_for_segment_text_v0(&pdf, "End")
+        .first()
+        .expect("end x");
+    let ending_x = *tm_xs_for_segment_text_v0(&pdf, "Ending")
+        .first()
+        .expect("ending x");
     assert!(
         (end_x - ending_x).abs() <= 0.1,
         "left-aligned fourth column should share left edge: {end_x} vs {ending_x}"
@@ -2868,10 +2934,8 @@ fn pdf_renderer_table_row_height_is_stable_v2() {
     let xdv = write_dvi_v2_text_page_v0(b"Before.\n\n!ts lcr\n!t A||B||C\n!t D||E||F\n\nAfter.")
         .expect("writer should accept table marker lines");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
-    let (_, row1_y) = tm_position_for_line_containing_text_v0(&pdf, "(A)")
-        .expect("row 1 y");
-    let (_, row2_y) = tm_position_for_line_containing_text_v0(&pdf, "(D)")
-        .expect("row 2 y");
+    let (_, row1_y) = tm_position_for_line_containing_text_v0(&pdf, "(A)").expect("row 1 y");
+    let (_, row2_y) = tm_position_for_line_containing_text_v0(&pdf, "(D)").expect("row 2 y");
     let delta = row1_y - row2_y;
     assert!(
         (delta - 14.0).abs() <= 0.2,
@@ -3010,9 +3074,11 @@ fn pdf_renderer_figure_metadata_width_affects_placeholder_alignment_v2() {
     .expect("writer should accept figure marker lines");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
 
-    let (narrow_x, _) =
-        tm_position_for_line_containing_text_v0(&pdf, "([ Figure placeholder: figures/narrow.png ])")
-            .expect("narrow placeholder position");
+    let (narrow_x, _) = tm_position_for_line_containing_text_v0(
+        &pdf,
+        "([ Figure placeholder: figures/narrow.png ])",
+    )
+    .expect("narrow placeholder position");
     let (wide_x, _) =
         tm_position_for_line_containing_text_v0(&pdf, "([ Figure placeholder: figures/wide.png ])")
             .expect("wide placeholder position");
@@ -3158,8 +3224,7 @@ fn pdf_renderer_toc_annotation_destination_order_is_stable_v2() {
         .collect::<Vec<_>>();
     for (page_id, _, _) in &destinations {
         assert_eq!(
-            *page_id,
-            3,
+            *page_id, 3,
             "toc annotations should target page containing heading anchors"
         );
     }

--- a/scripts/texlive_smoke/fixtures/typeset_demo_pageref_include_probe_v2.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_pageref_include_probe_v2.tex
@@ -1,0 +1,7 @@
+\documentclass{article}
+\usepackage{hyperref}
+\begin{document}
+\include{sections/two}
+Page ref to included heading: \pageref{sec:two}.
+\href{https://example.com/pageref-include}{Include pageref link}
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_pageref_probe_v2.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_pageref_probe_v2.tex
@@ -1,0 +1,8 @@
+\documentclass{article}
+\usepackage{hyperref}
+\begin{document}
+\section{Intro}
+\label{sec:intro}
+See page \pageref{sec:intro} and unresolved \pageref{sec:missing}.
+\href{https://example.com/pageref}{Pageref link}
+\end{document}

--- a/scripts/texlive_smoke/fixtures/typeset_demo_pageref_unresolved_probe_v2.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_pageref_unresolved_probe_v2.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\usepackage{hyperref}
+\begin{document}
+Unresolved only: \pageref{sec:missing}.
+\href{https://example.com/pageref-unresolved}{Unresolved pageref link}
+\end{document}

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -182,6 +182,24 @@
       "purpose": "Exercises deterministic ref target mapping across include page boundaries for heading/figure/equation anchors."
     },
     {
+      "id": "typeset_demo_pageref_probe_v2",
+      "tags": ["typeset", "hyperref", "pageref", "labels", "refs", "probe", "ok"],
+      "expected_status": "OK",
+      "purpose": "Exercises pageref resolution to deterministic page numbers with one resolved and one unresolved target."
+    },
+    {
+      "id": "typeset_demo_pageref_include_probe_v2",
+      "tags": ["typeset", "hyperref", "pageref", "include", "labels", "probe", "ok"],
+      "expected_status": "OK",
+      "purpose": "Exercises pageref target-page resolution when the label is defined in include-expanded content."
+    },
+    {
+      "id": "typeset_demo_pageref_unresolved_probe_v2",
+      "tags": ["typeset", "hyperref", "pageref", "unresolved", "probe", "ok"],
+      "expected_status": "OK",
+      "purpose": "Exercises unresolved pageref rendering to ?? with deterministic unresolved typed-artifact entries."
+    },
+    {
       "id": "typeset_demo_hyperref_toc_input_probe_v0",
       "tags": ["typeset", "hyperref", "toc", "input", "probe", "ok"],
       "expected_status": "OK",

--- a/scripts/wasm_fixture_gallery_v1/main.mjs
+++ b/scripts/wasm_fixture_gallery_v1/main.mjs
@@ -23,7 +23,7 @@ const STATUS_FAIL_V0 = 'FAIL';
 const STATUS_MISMATCH_V0 = 'MISMATCH';
 const EXPECTED_STATUS_VALUES_V0 = new Set([STATUS_OK_V0, STATUS_NI_V0, STATUS_INVALID_V0, STATUS_FAIL_V0]);
 const DEFAULT_ONDEMAND_FIXEDPOINT_MAX_ITERS_V1 = 3;
-const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'refs', 'bib', 'cite', 'bibitems', 'cites', 'hyperref', 'pkgopt', 'packages', 'graphics', 'input', 'math', 'table'];
+const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'refs', 'pageref', 'bib', 'cite', 'bibitems', 'cites', 'hyperref', 'pkgopt', 'packages', 'graphics', 'input', 'math', 'table'];
 const TYPED_ARTIFACTS_VERSION_V0 = 1;
 const MAX_TOC_ENTRIES_V0 = 256;
 const MAX_TOC_TITLE_BYTES_V0 = 256;
@@ -31,6 +31,8 @@ const MAX_LABEL_ENTRIES_V0 = 256;
 const MAX_LABEL_VALUE_BYTES_V0 = 256;
 const MAX_REF_ENTRIES_V0 = 256;
 const MAX_REF_OCCURRENCES_PER_KEY_V0 = 256;
+const MAX_PAGEREF_ENTRIES_V2 = 256;
+const MAX_PAGEREF_OCCURRENCES_PER_KEY_V2 = 256;
 const MAX_BIB_ENTRIES_V0 = 256;
 const MAX_BIB_VALUE_BYTES_V0 = 256;
 const MAX_PKGOPT_ENTRIES_V0 = 256;
@@ -721,6 +723,21 @@ async function loadFixtureCasesV0() {
       id: 'typeset_demo_hyperref_include_label_probe_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_hyperref_include_label_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_pageref_probe_v2',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_pageref_probe_v2.tex',
+    },
+    {
+      id: 'typeset_demo_pageref_include_probe_v2',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_pageref_include_probe_v2.tex',
+    },
+    {
+      id: 'typeset_demo_pageref_unresolved_probe_v2',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_pageref_unresolved_probe_v2.tex',
     },
     {
       id: 'typeset_demo_hyperref_toc_input_probe_v0',
@@ -3132,6 +3149,276 @@ function extractLabelsAndRefsFromSourceV1(sourceBytes) {
   };
 }
 
+function traversePagerefSourceV2(sourcePath, sourceBytes, sourcesByPath, state, pagerefByKey) {
+  if (state.visiting.has(sourcePath)) {
+    throw new Error(`pageref_v2 include cycle at ${sourcePath}`);
+  }
+  state.visiting.add(sourcePath);
+  try {
+    let index = 0;
+    while (index < sourceBytes.length) {
+      if (sourceBytes[index] !== 0x5c) {
+        index += 1;
+        continue;
+      }
+      let commandIndex = index + 1;
+      while (commandIndex < sourceBytes.length && isAsciiLetterByteV0(sourceBytes[commandIndex])) {
+        commandIndex += 1;
+      }
+      if (commandIndex === index + 1) {
+        index += 1;
+        continue;
+      }
+
+      const command = Buffer.from(sourceBytes.slice(index + 1, commandIndex)).toString('ascii');
+      if (command === 'begin') {
+        const envGroup = readBracedGroupV0(sourceBytes, commandIndex);
+        if (!envGroup.ok) {
+          index = commandIndex;
+          state.pendingLabelTarget = null;
+          continue;
+        }
+        const envName = envGroup.value.trim();
+        if (envName === 'figure') {
+          state.inFigure = true;
+        }
+        state.pendingLabelTarget = null;
+        index = envGroup.next;
+        continue;
+      }
+      if (command === 'end') {
+        const envGroup = readBracedGroupV0(sourceBytes, commandIndex);
+        if (!envGroup.ok) {
+          index = commandIndex;
+          state.pendingLabelTarget = null;
+          continue;
+        }
+        const envName = envGroup.value.trim();
+        if (envName === 'figure') {
+          state.inFigure = false;
+        }
+        state.pendingLabelTarget = null;
+        index = envGroup.next;
+        continue;
+      }
+      if (command === 'section' || command === 'subsection') {
+        const titleGroup = readBracedGroupV0(sourceBytes, commandIndex);
+        if (!titleGroup.ok) {
+          index = commandIndex;
+          state.pendingLabelTarget = null;
+          continue;
+        }
+        state.pendingLabelTarget = {
+          anchor_id: state.nextAnchorId,
+          page_no: state.currentPageNo,
+        };
+        state.nextAnchorId += 1;
+        index = titleGroup.next;
+        continue;
+      }
+      if (command === 'caption' && state.inFigure) {
+        const captionGroup = readBracedGroupV0(sourceBytes, commandIndex);
+        if (!captionGroup.ok) {
+          index = commandIndex;
+          state.pendingLabelTarget = null;
+          continue;
+        }
+        state.pendingLabelTarget = {
+          anchor_id: state.nextAnchorId,
+          page_no: state.currentPageNo,
+        };
+        state.nextAnchorId += 1;
+        index = captionGroup.next;
+        continue;
+      }
+      if (command === 'label') {
+        const keyGroup = readBracedGroupV0(sourceBytes, commandIndex);
+        if (!keyGroup.ok) {
+          index = commandIndex;
+          state.pendingLabelTarget = null;
+          continue;
+        }
+        const key = keyGroup.value.trim();
+        if (state.pendingLabelTarget && isSafeLabelRefKeyValueV1(key) && !state.labelsByKey.has(key)) {
+          const keyBytes = Buffer.from(key, 'utf8');
+          if (keyBytes.length > MAX_LABEL_VALUE_BYTES_V0) {
+            throw new Error(`pageref_v2 label key exceeds cap ${MAX_LABEL_VALUE_BYTES_V0}`);
+          }
+          state.labelsByKey.set(key, {
+            anchor_id: state.pendingLabelTarget.anchor_id,
+            page_no: state.pendingLabelTarget.page_no,
+          });
+        }
+        state.pendingLabelTarget = null;
+        index = keyGroup.next;
+        continue;
+      }
+      if (command === 'pageref') {
+        const keyGroup = readBracedGroupV0(sourceBytes, commandIndex);
+        if (!keyGroup.ok) {
+          index = commandIndex;
+          state.pendingLabelTarget = null;
+          continue;
+        }
+        const key = keyGroup.value.trim();
+        if (isSafeLabelRefKeyValueV1(key)) {
+          let entry = pagerefByKey.get(key);
+          if (!entry) {
+            entry = {
+              key,
+              resolved: false,
+              anchor_id: null,
+              page_no: null,
+              source_path: sourcePath,
+              source_span: buildSourceSpanV0(sourceBytes, index, keyGroup.next, 'pageref_v2'),
+              occurrences: [],
+            };
+            pagerefByKey.set(key, entry);
+          }
+          entry.occurrences.push({
+            source_path: sourcePath,
+            line_index: lineIndexForByteOffsetV1(sourceBytes, index),
+            page_no: null,
+          });
+          if (entry.occurrences.length > MAX_PAGEREF_OCCURRENCES_PER_KEY_V2) {
+            throw new Error(`pageref_v2 occurrences exceed cap ${MAX_PAGEREF_OCCURRENCES_PER_KEY_V2} for key ${key}`);
+          }
+        }
+        state.pendingLabelTarget = null;
+        index = keyGroup.next;
+        continue;
+      }
+      if (command === 'input' || command === 'include') {
+        const group = readBracedGroupV0(sourceBytes, commandIndex);
+        if (!group.ok || group.value.length === 0) {
+          index = commandIndex;
+          state.pendingLabelTarget = null;
+          continue;
+        }
+        const values = splitCommaValuesV0(group.value);
+        for (const rawValue of values) {
+          const mountPath = normalizeInputIncludeMountPathV1(rawValue);
+          if (!mountPath) {
+            continue;
+          }
+          const nestedBytes = sourcesByPath.get(mountPath);
+          if (!nestedBytes) {
+            continue;
+          }
+          if (command === 'include') {
+            state.currentPageNo += 1;
+          }
+          traversePagerefSourceV2(mountPath, nestedBytes, sourcesByPath, state, pagerefByKey);
+        }
+        state.pendingLabelTarget = null;
+        index = group.next;
+        continue;
+      }
+
+      state.pendingLabelTarget = null;
+      index = commandIndex;
+    }
+  } finally {
+    state.visiting.delete(sourcePath);
+  }
+}
+
+function extractPagerefEntriesFromSourcesV2(mainSourceBytes, mountedFiles = []) {
+  const sourcesByPath = new Map();
+  sourcesByPath.set('main.tex', toUint8ArrayV0(mainSourceBytes));
+  for (const [mountPath, mountBytes] of mountedFiles) {
+    sourcesByPath.set(mountPath, toUint8ArrayV0(mountBytes));
+  }
+
+  const state = {
+    nextAnchorId: 1,
+    currentPageNo: 1,
+    inFigure: false,
+    pendingLabelTarget: null,
+    labelsByKey: new Map(),
+    visiting: new Set(),
+  };
+  const pagerefByKey = new Map();
+  traversePagerefSourceV2('main.tex', toUint8ArrayV0(mainSourceBytes), sourcesByPath, state, pagerefByKey);
+
+  const entries = [...pagerefByKey.values()].sort((left, right) => left.key.localeCompare(right.key));
+  for (const entry of entries) {
+    const resolved = state.labelsByKey.get(entry.key);
+    if (!resolved) {
+      continue;
+    }
+    entry.resolved = true;
+    entry.anchor_id = resolved.anchor_id;
+    entry.page_no = resolved.page_no;
+    for (const occurrence of entry.occurrences) {
+      occurrence.page_no = resolved.page_no;
+    }
+  }
+  if (entries.length > MAX_PAGEREF_ENTRIES_V2) {
+    throw new Error(`pageref_v2 entries exceed cap ${MAX_PAGEREF_ENTRIES_V2}`);
+  }
+  return entries;
+}
+
+async function augmentPagerefMountedFilesWithFixtureSourceV2(caseOutDir, mainSourceBytes, mountedFiles = []) {
+  const mountedByPath = new Map();
+  for (const [mountPath, mountBytes] of mountedFiles) {
+    mountedByPath.set(mountPath, toUint8ArrayV0(mountBytes));
+  }
+  const fixtureSourceTexRoot = path.join(`${path.dirname(caseOutDir)}_fixture_source_v0`, 'xetex', 'tex');
+  const sourceBytesByPath = new Map();
+  sourceBytesByPath.set('main.tex', toUint8ArrayV0(mainSourceBytes));
+  for (const [mountPath, mountBytes] of mountedByPath.entries()) {
+    sourceBytesByPath.set(mountPath, mountBytes);
+  }
+
+  const queue = ['main.tex'];
+  const visited = new Set();
+  while (queue.length > 0) {
+    const sourcePath = queue.shift();
+    if (visited.has(sourcePath)) {
+      continue;
+    }
+    visited.add(sourcePath);
+    const sourceBytes = sourceBytesByPath.get(sourcePath);
+    if (!(sourceBytes instanceof Uint8Array)) {
+      continue;
+    }
+    const directives = extractInputIncludeDirectivesFromSourceV1(sourceBytes, sourcePath);
+    for (const directive of directives) {
+      const mountPath = directive.value;
+      if (mountedByPath.has(mountPath)) {
+        if (!visited.has(mountPath)) {
+          queue.push(mountPath);
+        }
+        continue;
+      }
+      const aliasPath = mountPath.replaceAll('/', '__');
+      const candidatePaths = aliasPath === mountPath
+        ? [mountPath]
+        : [aliasPath, mountPath];
+      let loadedBytes = null;
+      for (const candidatePath of candidatePaths) {
+        const candidateFile = path.join(fixtureSourceTexRoot, candidatePath);
+        try {
+          loadedBytes = toUint8ArrayV0(await readFile(candidateFile));
+          break;
+        } catch {
+          // ignore and continue trying candidate paths
+        }
+      }
+      if (!(loadedBytes instanceof Uint8Array)) {
+        continue;
+      }
+      mountedByPath.set(mountPath, loadedBytes);
+      sourceBytesByPath.set(mountPath, loadedBytes);
+      queue.push(mountPath);
+    }
+  }
+
+  return [...mountedByPath.entries()].sort(([leftPath], [rightPath]) => leftPath.localeCompare(rightPath));
+}
+
 async function emitLabelsTypedArtifactV0(caseOutDir, fixtureBytes) {
   const extracted = extractLabelsAndRefsFromSourceV1(fixtureBytes);
   const payload = {
@@ -3160,6 +3447,29 @@ async function emitRefsTypedArtifactV0(caseOutDir, fixtureBytes) {
   };
   const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
   const relpath = 'refs_v1.json';
+  const fullPath = path.join(caseOutDir, relpath);
+  await writeFile(fullPath, bytes);
+  return {
+    present: true,
+    items: payload.entries.length,
+    artifact_relpath: relpath,
+    artifact_sha256: sha256HexV0(bytes),
+  };
+}
+
+async function emitPagerefTypedArtifactV2(caseOutDir, fixtureBytes, mountedFiles) {
+  const pagerefMountedFiles = await augmentPagerefMountedFilesWithFixtureSourceV2(
+    caseOutDir,
+    fixtureBytes,
+    mountedFiles,
+  );
+  const payload = {
+    version: TYPED_ARTIFACTS_VERSION_V0,
+    schema: 'pageref_v2',
+    entries: extractPagerefEntriesFromSourcesV2(fixtureBytes, pagerefMountedFiles),
+  };
+  const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  const relpath = 'pageref_v2.json';
   const fullPath = path.join(caseOutDir, relpath);
   await writeFile(fullPath, bytes);
   return {
@@ -3416,6 +3726,7 @@ async function emitTypedArtifactsV0(
   caseOutDir,
   typedArtifacts,
   fixtureBytes,
+  mountedFiles = [],
   inputEntries = [],
 ) {
   if (caseSpec.id === 'typeset_demo_toc_probe_v0') {
@@ -3424,6 +3735,17 @@ async function emitTypedArtifactsV0(
   if (caseSpec.id === 'typeset_demo_labels_probe_v0') {
     typedArtifacts.labels = await emitLabelsTypedArtifactV0(caseOutDir, fixtureBytes);
     typedArtifacts.refs = await emitRefsTypedArtifactV0(caseOutDir, fixtureBytes);
+  }
+  if (
+    caseSpec.id === 'typeset_demo_pageref_probe_v2'
+    || caseSpec.id === 'typeset_demo_pageref_include_probe_v2'
+    || caseSpec.id === 'typeset_demo_pageref_unresolved_probe_v2'
+  ) {
+    typedArtifacts.pageref = await emitPagerefTypedArtifactV2(
+      caseOutDir,
+      fixtureBytes,
+      mountedFiles,
+    );
   }
   if (caseSpec.id === 'typeset_demo_bib_probe_v0') {
     const extractedBib = extractBibitemsAndCitesFromSourceV1(fixtureBytes);
@@ -4048,6 +4370,7 @@ async function runCaseV0(
     caseOutDir,
     summary.typed_artifacts,
     fixtureBytes,
+    inputInclusionGraph.mounted_files,
     inputInclusionGraph.entries,
   );
   const typedArtifactRequests = await collectResolverRequestsFromResourceHintsV0(

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
@@ -82,6 +82,106 @@ if (refsArtifactFirst.entries.length <= 0) {
 assertEntrySourceSpans('typeset_demo_labels_probe_v0', 'refs_v1', refsArtifactFirst.entries);
 fs.writeFileSync(firstRunShaPath('refs_v1'), `${refsShaFirst}\n`);
 
+const pagerefProbeSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_pageref_probe_v2', 'summary.json'), 'utf8'),
+);
+if (pagerefProbeSummary?.typed_artifacts?.pageref?.present !== true) {
+  console.error('FAIL: expected pageref typed artifact present for pageref probe after first run');
+  process.exit(1);
+}
+const pagerefIncludeSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_pageref_include_probe_v2', 'summary.json'), 'utf8'),
+);
+if (pagerefIncludeSummary?.typed_artifacts?.pageref?.present !== true) {
+  console.error('FAIL: expected pageref typed artifact present for pageref include probe after first run');
+  process.exit(1);
+}
+const pagerefUnresolvedSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_pageref_unresolved_probe_v2', 'summary.json'), 'utf8'),
+);
+if (pagerefUnresolvedSummary?.typed_artifacts?.pageref?.present !== true) {
+  console.error('FAIL: expected pageref typed artifact present for pageref unresolved probe after first run');
+  process.exit(1);
+}
+const pagerefPath = path.join(outDir, 'typeset_demo_pageref_probe_v2', 'pageref_v2.json');
+if (!fs.existsSync(pagerefPath)) {
+  console.error('FAIL: expected pageref_v2.json artifact after first run');
+  process.exit(1);
+}
+const pagerefShaFirst = pagerefProbeSummary.typed_artifacts.pageref.artifact_sha256;
+if (typeof pagerefShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(pagerefShaFirst)) {
+  console.error('FAIL: expected pageref artifact sha256 in first summary');
+  process.exit(1);
+}
+const pagerefArtifactFirst = JSON.parse(fs.readFileSync(pagerefPath, 'utf8'));
+if (!Array.isArray(pagerefArtifactFirst?.entries)) {
+  console.error('FAIL: expected pageref_v2.entries array in first-run artifact');
+  process.exit(1);
+}
+if (pagerefArtifactFirst?.schema !== 'pageref_v2') {
+  console.error('FAIL: expected pageref_v2 schema in first-run artifact');
+  process.exit(1);
+}
+if (pagerefArtifactFirst.entries.length <= 0) {
+  console.error('FAIL: expected non-empty pageref_v2.entries for pageref probe');
+  process.exit(1);
+}
+for (const [index, entry] of pagerefArtifactFirst.entries.entries()) {
+  if (typeof entry?.key !== 'string' || entry.key.length === 0) {
+    console.error(`FAIL: pageref_v2.entries[${index}] missing key`);
+    process.exit(1);
+  }
+  if (typeof entry?.resolved !== 'boolean') {
+    console.error(`FAIL: pageref_v2.entries[${index}] missing resolved boolean`);
+    process.exit(1);
+  }
+  if (!(entry.anchor_id === null || (Number.isInteger(entry.anchor_id) && entry.anchor_id > 0))) {
+    console.error(`FAIL: pageref_v2.entries[${index}] invalid anchor_id`);
+    process.exit(1);
+  }
+  if (!(entry.page_no === null || (Number.isInteger(entry.page_no) && entry.page_no > 0))) {
+    console.error(`FAIL: pageref_v2.entries[${index}] invalid page_no`);
+    process.exit(1);
+  }
+  if (!Array.isArray(entry?.occurrences) || entry.occurrences.length <= 0) {
+    console.error(`FAIL: pageref_v2.entries[${index}] missing occurrences`);
+    process.exit(1);
+  }
+}
+assertEntrySourceSpans('typeset_demo_pageref_probe_v2', 'pageref_v2', pagerefArtifactFirst.entries);
+const pagerefIncludeArtifactFirst = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_pageref_include_probe_v2', 'pageref_v2.json'), 'utf8'),
+);
+if (!Array.isArray(pagerefIncludeArtifactFirst?.entries) || pagerefIncludeArtifactFirst.entries.length <= 0) {
+  console.error('FAIL: expected non-empty pageref_v2.entries for pageref include probe');
+  process.exit(1);
+}
+const pagerefIncludeEntryFirst = pagerefIncludeArtifactFirst.entries.find((entry) => entry.key === 'sec:two');
+if (!pagerefIncludeEntryFirst) {
+  console.error('FAIL: expected pageref include probe to include key sec:two');
+  process.exit(1);
+}
+if (pagerefIncludeEntryFirst.resolved === false) {
+  if (pagerefIncludeEntryFirst.page_no !== null || pagerefIncludeEntryFirst.anchor_id !== null) {
+    console.error('FAIL: unresolved first-run pageref include entry must keep null page_no/anchor_id');
+    process.exit(1);
+  }
+}
+assertEntrySourceSpans('typeset_demo_pageref_include_probe_v2', 'pageref_v2', pagerefIncludeArtifactFirst.entries);
+const pagerefUnresolvedArtifactFirst = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_pageref_unresolved_probe_v2', 'pageref_v2.json'), 'utf8'),
+);
+if (!Array.isArray(pagerefUnresolvedArtifactFirst?.entries) || pagerefUnresolvedArtifactFirst.entries.length <= 0) {
+  console.error('FAIL: expected non-empty pageref_v2.entries for pageref unresolved probe');
+  process.exit(1);
+}
+if (!pagerefUnresolvedArtifactFirst.entries.some((entry) => entry.resolved === false && entry.page_no === null)) {
+  console.error('FAIL: expected pageref unresolved probe to include unresolved entry');
+  process.exit(1);
+}
+assertEntrySourceSpans('typeset_demo_pageref_unresolved_probe_v2', 'pageref_v2', pagerefUnresolvedArtifactFirst.entries);
+fs.writeFileSync(firstRunShaPath('pageref_v2'), `${pagerefShaFirst}\n`);
+
 const tocSummary = JSON.parse(
   fs.readFileSync(path.join(outDir, 'typeset_demo_toc_probe_v0', 'summary.json'), 'utf8'),
 );
@@ -792,7 +892,7 @@ if (!typedArtifactShaMap || typeof typedArtifactShaMap !== 'object') {
   console.error('FAIL: expected report.typed_artifact_sha256 map after first run');
   process.exit(1);
 }
-const typedKeys = ['toc', 'labels', 'bib', 'cite', 'hyperref', 'pkgopt', 'packages', 'graphics', 'input', 'math', 'table'];
+const typedKeys = ['toc', 'labels', 'bib', 'cite', 'pageref', 'hyperref', 'pkgopt', 'packages', 'graphics', 'input', 'math', 'table'];
 for (const key of typedKeys) {
   const value = typedArtifactShaMap[key];
   if (typeof value !== 'string' || !/^[0-9a-f]{64}$/.test(value)) {

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
@@ -63,9 +63,10 @@ if (resourceHintsShaSecond !== resourceHintsShaFirst) {
   console.error('FAIL: report.resource_hints_v0 must be stable across reruns');
   process.exit(1);
 }
-const requiredTypedKeys = ['toc', 'labels', 'refs', 'bib', 'cite', 'hyperref', 'pkgopt', 'packages', 'graphics', 'input', 'math', 'table'];
+const requiredTypedKeys = ['toc', 'labels', 'refs', 'pageref', 'bib', 'cite', 'hyperref', 'pkgopt', 'packages', 'graphics', 'input', 'math', 'table'];
 const labelsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'labels_v1_first.sha256'), 'utf8').trim();
 const refsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'refs_v1_first.sha256'), 'utf8').trim();
+const pagerefShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'pageref_v2_first.sha256'), 'utf8').trim();
 const tocShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'toc_v1_first.sha256'), 'utf8').trim();
 const bibShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'bib_v1_first.sha256'), 'utf8').trim();
 const citeShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'cite_v1_first.sha256'), 'utf8').trim();
@@ -158,6 +159,21 @@ if (!mathLongStatus || mathLongStatus.status !== 'OK') {
 const mathInvalidStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_math_invalid_payload_probe_v0');
 if (!mathInvalidStatus || mathInvalidStatus.status !== 'NI') {
   console.error('FAIL: expected typeset_demo_math_invalid_payload_probe_v0 status NI');
+  process.exit(1);
+}
+const pagerefStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_pageref_probe_v2');
+if (!pagerefStatus || pagerefStatus.status !== 'OK') {
+  console.error('FAIL: expected typeset_demo_pageref_probe_v2 status OK');
+  process.exit(1);
+}
+const pagerefIncludeStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_pageref_include_probe_v2');
+if (!pagerefIncludeStatus || pagerefIncludeStatus.status !== 'OK') {
+  console.error('FAIL: expected typeset_demo_pageref_include_probe_v2 status OK');
+  process.exit(1);
+}
+const pagerefUnresolvedStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_pageref_unresolved_probe_v2');
+if (!pagerefUnresolvedStatus || pagerefUnresolvedStatus.status !== 'OK') {
+  console.error('FAIL: expected typeset_demo_pageref_unresolved_probe_v2 status OK');
   process.exit(1);
 }
 for (const status of okStatuses) {
@@ -324,6 +340,52 @@ const refsArtifactSecond = JSON.parse(
 );
 if (!Array.isArray(refsArtifactSecond?.entries) || refsArtifactSecond.entries.length <= 0) {
   console.error('FAIL: expected non-empty refs_v1.entries after rerun');
+  process.exit(1);
+}
+const pagerefSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_pageref_probe_v2', 'summary.json'), 'utf8'),
+);
+const pagerefArtifact = pagerefSummary?.typed_artifacts?.pageref;
+if (!pagerefArtifact || pagerefArtifact.present !== true) {
+  console.error('FAIL: expected pageref typed artifact present after second run');
+  process.exit(1);
+}
+const pagerefShaSecond = pagerefArtifact.artifact_sha256;
+if (pagerefShaSecond !== pagerefShaFirst) {
+  console.error('FAIL: pageref_v2 artifact sha256 must be stable across reruns');
+  process.exit(1);
+}
+const pagerefArtifactSecond = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_pageref_probe_v2', 'pageref_v2.json'), 'utf8'),
+);
+if (!Array.isArray(pagerefArtifactSecond?.entries) || pagerefArtifactSecond.entries.length <= 0) {
+  console.error('FAIL: expected non-empty pageref_v2.entries after rerun');
+  process.exit(1);
+}
+if (pagerefArtifactSecond?.schema !== 'pageref_v2') {
+  console.error('FAIL: expected pageref_v2 schema after rerun');
+  process.exit(1);
+}
+const pagerefIncludeArtifactSecond = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_pageref_include_probe_v2', 'pageref_v2.json'), 'utf8'),
+);
+if (!Array.isArray(pagerefIncludeArtifactSecond?.entries) || pagerefIncludeArtifactSecond.entries.length <= 0) {
+  console.error('FAIL: expected non-empty pageref_v2 entries for include probe after rerun');
+  process.exit(1);
+}
+if (!pagerefIncludeArtifactSecond.entries.some((entry) => entry.key === 'sec:two' && entry.resolved === true)) {
+  console.error('FAIL: expected pageref include probe to keep resolved sec:two entry after rerun');
+  process.exit(1);
+}
+const pagerefUnresolvedArtifactSecond = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_pageref_unresolved_probe_v2', 'pageref_v2.json'), 'utf8'),
+);
+if (!Array.isArray(pagerefUnresolvedArtifactSecond?.entries) || pagerefUnresolvedArtifactSecond.entries.length <= 0) {
+  console.error('FAIL: expected non-empty pageref_v2 entries for unresolved probe after rerun');
+  process.exit(1);
+}
+if (!pagerefUnresolvedArtifactSecond.entries.some((entry) => entry.resolved === false && entry.page_no === null)) {
+  console.error('FAIL: expected unresolved pageref entry to remain unresolved after rerun');
   process.exit(1);
 }
 
@@ -621,6 +683,7 @@ console.log(`PASS: resource_hints_v0 sha stable ${resourceHintsShaSecond}`);
 console.log('PASS: resource_hints_v0 excludes ok_demo_v0');
 console.log(`PASS: labels_v1 sha stable ${labelsShaSecond}`);
 console.log(`PASS: refs_v1 sha stable ${refsShaSecond}`);
+console.log(`PASS: pageref_v2 sha stable ${pagerefShaSecond}`);
 console.log(`PASS: toc_v1 sha stable ${tocShaSecond}`);
 console.log(`PASS: bib_v1 sha stable ${bibShaSecond}`);
 console.log(`PASS: cite_v1 sha stable ${citeShaSecond}`);


### PR DESCRIPTION
Closes #410

## Summary
- implement `\\pageref{...}` in `typeset_minimal_v0` with deterministic page-number resolution and fail-closed unresolved handling
- add hyperref-aware page-destination link metadata and renderer support for stable page `/Fit` destinations
- add pageref fixtures (short/include/unresolved) and `pageref_v2` typed artifact plumbing
- extend fixture gallery schema/proof gates for `pageref_v2`, including rerun-stability checks

## Proofs
- `cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests`
- `cargo test --manifest-path crates/carreltex-xdv/Cargo.toml`
- `./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12`
- `./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25`
