### PR TITLE
TOC page numbers v2: anchor-derived page_no + page-destination links

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -62,6 +62,8 @@ const FIGURE_PLACEHOLDER_TO_CAPTION_GAP_PT_V0: f32 = 8.0;
 const TOC_TITLE_TEXT_V0: &[u8] = b"Contents";
 const TOC_TITLE_FONT_SIZE_PT_V0: f32 = 14.0;
 const TOC_ENTRY_INDENT_STEP_PT_V0: f32 = 18.0;
+const TOC_PAGE_NO_COLUMN_WIDTH_PT_V2: f32 = 48.0;
+const TOC_PAGE_NO_COLUMN_GAP_PT_V2: f32 = 12.0;
 const SECTION_HEADING_PREFIX_MARKER_V0: &[u8] = b"@S ";
 const SUBSECTION_HEADING_PREFIX_MARKER_V0: &[u8] = b"@s ";
 const DISPLAY_MATH_PLACEHOLDER_SHORT_V0: &[u8] = b"MATH DISPLAY";
@@ -1036,6 +1038,8 @@ fn emit_figure_block_v0(
 fn emit_toc_block_v0(
     out: &mut Vec<u8>,
     toc_entries: &[TocEntryMetadataV0],
+    page_numbers_by_anchor_id: &BTreeMap<u32, u32>,
+    page_count: usize,
     y: &mut f32,
     min_body_y_pt: f32,
     annotations: &mut Vec<PdfLinkAnnotationV0>,
@@ -1075,22 +1079,78 @@ fn emit_toc_block_v0(
         if *y < min_body_y_pt {
             return None;
         }
+        let page_no = *page_numbers_by_anchor_id.get(&entry.anchor_id)?;
+        if page_no == 0 || usize::try_from(page_no).ok()? > page_count {
+            return None;
+        }
         let base_segments = parse_styled_segments_v0(&entry.title_glyphs)?;
         let render_segments = split_superscript_segments_v0(&base_segments);
         if render_segments.iter().any(|segment| segment.superscript) {
             return None;
         }
+        let title_width_pt = render_segments.iter().map(|segment| segment.advance_pt).sum::<f32>();
         let indent_steps = f32::from(entry.level.saturating_sub(1));
         let x_pt = MARGIN_PT_V0 + (indent_steps * TOC_ENTRY_INDENT_STEP_PT_V0);
-        let mut toc_annotations = collect_toc_anchor_annotations_for_line_v0(
+        let mut toc_annotations = collect_toc_link_annotations_for_line_v0(
             &render_segments,
             x_pt,
             *y,
             FONT_SIZE_PT_V0,
-            entry.anchor_id,
+            PdfLinkTargetV0::Anchor(entry.anchor_id),
         )?;
         annotations.append(&mut toc_annotations);
         emit_render_segments_with_superscript_v0(out, &render_segments, x_pt, *y, FONT_SIZE_PT_V0);
+
+        let page_no_glyphs = page_no
+            .to_string()
+            .bytes()
+            .map(|byte| {
+                Some(GlyphPlanV0 {
+                    byte,
+                    advance_sp: glyph_width_sp_v0(byte, 65_536)?,
+                })
+            })
+            .collect::<Option<Vec<GlyphPlanV0>>>()?;
+        if page_no_glyphs.is_empty() {
+            return None;
+        }
+        let page_no_width_pt = glyphs_advance_pt_v0(&page_no_glyphs);
+        if page_no_width_pt <= 0.0 || page_no_width_pt > TOC_PAGE_NO_COLUMN_WIDTH_PT_V2 {
+            return None;
+        }
+        let page_no_right_pt = PAGE_WIDTH_PT_V0 - MARGIN_PT_V0;
+        let page_no_column_left_pt = page_no_right_pt - TOC_PAGE_NO_COLUMN_WIDTH_PT_V2;
+        let page_no_x_pt = page_no_right_pt - page_no_width_pt;
+        if page_no_x_pt < page_no_column_left_pt
+            || page_no_x_pt <= x_pt + title_width_pt + TOC_PAGE_NO_COLUMN_GAP_PT_V2
+        {
+            return None;
+        }
+        let title_links_enabled = render_segments.iter().any(|segment| segment.is_link);
+        let page_no_segments = vec![PdfRenderSegmentV0 {
+            style: PdfTextStyleV0::Regular,
+            bytes: bytes_from_glyphs_v0(&page_no_glyphs),
+            advance_pt: page_no_width_pt,
+            is_link: title_links_enabled,
+            superscript: false,
+        }];
+        if title_links_enabled {
+            let mut page_no_annotations = collect_toc_link_annotations_for_line_v0(
+                &page_no_segments,
+                page_no_x_pt,
+                *y,
+                FONT_SIZE_PT_V0,
+                PdfLinkTargetV0::AnchorPage(entry.anchor_id),
+            )?;
+            annotations.append(&mut page_no_annotations);
+        }
+        emit_render_segments_with_superscript_v0(
+            out,
+            &page_no_segments,
+            page_no_x_pt,
+            *y,
+            FONT_SIZE_PT_V0,
+        );
         out.extend_from_slice(b"\n");
         *y -= LEADING_PT_V0;
     }
@@ -1788,12 +1848,12 @@ fn collect_link_annotations_for_line_v0(
     Some(annotations)
 }
 
-fn collect_toc_anchor_annotations_for_line_v0(
+fn collect_toc_link_annotations_for_line_v0(
     segments: &[PdfRenderSegmentV0],
     line_x_pt: f32,
     line_y_pt: f32,
     font_size_pt: f32,
-    anchor_id: u32,
+    target: PdfLinkTargetV0,
 ) -> Option<Vec<PdfLinkAnnotationV0>> {
     let mut annotations = Vec::<PdfLinkAnnotationV0>::new();
     let mut cursor_x = line_x_pt;
@@ -1822,7 +1882,7 @@ fn collect_toc_anchor_annotations_for_line_v0(
                 return None;
             }
             annotations.push(PdfLinkAnnotationV0 {
-                target: PdfLinkTargetV0::Anchor(anchor_id),
+                target: target.clone(),
                 rect,
             });
         }
@@ -1842,10 +1902,7 @@ fn collect_toc_anchor_annotations_for_line_v0(
         if rect[2] <= rect[0] || rect[3] <= rect[1] {
             return None;
         }
-        annotations.push(PdfLinkAnnotationV0 {
-            target: PdfLinkTargetV0::Anchor(anchor_id),
-            rect,
-        });
+        annotations.push(PdfLinkAnnotationV0 { target, rect });
     }
 
     Some(annotations)
@@ -2123,6 +2180,7 @@ fn build_page_content_stream_v0(
     footnote_defs_by_id: &BTreeMap<u32, Vec<Vec<GlyphPlanV0>>>,
     link_targets_by_id: &BTreeMap<u32, PdfLinkTargetV0>,
     page_numbers_by_anchor_id: &BTreeMap<u32, u32>,
+    page_count: usize,
     toc_entries: &[TocEntryMetadataV0],
     equation_ordinals_by_anchor_id: &BTreeMap<u32, u32>,
     next_link_id: &mut u32,
@@ -2260,6 +2318,8 @@ fn build_page_content_stream_v0(
             emit_toc_block_v0(
                 &mut out,
                 toc_entries,
+                page_numbers_by_anchor_id,
+                page_count,
                 &mut y,
                 min_body_y_pt,
                 &mut annotations,
@@ -2594,6 +2654,7 @@ fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
             &footnote_defs_by_id,
             &link_targets_by_id,
             &page_numbers_by_anchor_id,
+            body_pages.len(),
             &toc_entries,
             &equation_ordinals_by_anchor_id,
             &mut next_link_id,

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -3115,7 +3115,7 @@ fn pdf_renderer_rejects_malformed_figure_image_metadata_line_v0() {
 #[test]
 fn pdf_renderer_renders_toc_block_with_level_indentation_v0() {
     let xdv = write_dvi_v2_text_page_v0(
-        b"Before paragraph.\n\n!toc\n\nAfter paragraph.\n\n!toc 1 1 Intro entry\n!toc 2 2 Detail entry",
+        b"Before paragraph.\n\n!toc\n\nAfter paragraph.\n\n@S {Anchor section one}\n\n@s {Anchor subsection two}\n\n!toc 1 1 Intro toc entry\n!toc 2 2 Detail toc entry",
     )
     .expect("writer should accept toc marker lines");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
@@ -3134,18 +3134,22 @@ fn pdf_renderer_renders_toc_block_with_level_indentation_v0() {
         "toc title should render"
     );
     assert!(
-        pdf_text.contains("(Intro entry) Tj"),
+        pdf_text.contains("(Intro toc entry) Tj"),
         "toc level 1 entry should render"
     );
     assert!(
-        pdf_text.contains("(Detail entry) Tj"),
+        pdf_text.contains("(Detail toc entry) Tj"),
         "toc level 2 entry should render"
     );
+    assert!(
+        pdf_text.contains("(1) Tj"),
+        "toc entries should render page number column values"
+    );
 
-    let intro_x =
-        tm_x_for_line_containing_text_v0(&pdf, "(Intro entry)").expect("toc level 1 position");
-    let detail_x =
-        tm_x_for_line_containing_text_v0(&pdf, "(Detail entry)").expect("toc level 2 position");
+    let intro_x = tm_x_for_line_containing_text_v0(&pdf, "(Intro toc entry)")
+        .expect("toc level 1 position");
+    let detail_x = tm_x_for_line_containing_text_v0(&pdf, "(Detail toc entry)")
+        .expect("toc level 2 position");
     assert!(
         detail_x > intro_x + 8.0,
         "toc level 2 should be indented from level 1: {intro_x} vs {detail_x}"
@@ -3155,7 +3159,7 @@ fn pdf_renderer_renders_toc_block_with_level_indentation_v0() {
 #[test]
 fn pdf_renderer_emits_toc_link_annotations_targeting_heading_anchors_v0() {
     let xdv = write_dvi_v2_text_page_v0(
-        b"Prelude.\n\n!toc\n\n@S {Intro section}\n\n@s {Detail section}\n\n!toc 1 1 <Intro section>\n!toc 2 2 <Detail section>",
+        b"Prelude.\n\n!toc\n\n@S {Intro section}\x0c@s {Detail section}\n\n!toc 1 1 <Intro section>\n!toc 2 2 <Detail section>",
     )
     .expect("writer should accept toc metadata and heading lines");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
@@ -3171,8 +3175,14 @@ fn pdf_renderer_emits_toc_link_annotations_targeting_heading_anchors_v0() {
 
     let page_one = parse_pdf_object_body_v0(&pdf, 3).expect("page object");
     let annots = parse_pdf_ref_ids_v0(&page_one, "/Annots");
-    assert_eq!(annots.len(), 2, "toc block should emit two annotations");
+    assert_eq!(
+        annots.len(),
+        4,
+        "toc block should emit title and page-number annotations for each entry"
+    );
 
+    let mut xyz_pages = Vec::<u32>::new();
+    let mut fit_pages = Vec::<u32>::new();
     for annotation_id in annots {
         let annotation = parse_pdf_object_body_v0(&pdf, annotation_id).expect("annotation body");
         assert!(
@@ -3183,11 +3193,20 @@ fn pdf_renderer_emits_toc_link_annotations_targeting_heading_anchors_v0() {
             !annotation.contains("/A "),
             "toc links should not use URI actions: {annotation}"
         );
-        assert_eq!(
-            parse_pdf_annotation_dest_page_id_v0(&annotation),
-            Some(3),
-            "toc links should target page containing heading anchors"
-        );
+        let Some(page_id) = parse_pdf_annotation_dest_page_id_v0(&annotation) else {
+            panic!("toc annotation should include destination page id: {annotation}");
+        };
+        if annotation.contains("/XYZ") {
+            xyz_pages.push(page_id);
+        } else if annotation.contains("/Fit]") {
+            fit_pages.push(page_id);
+            assert!(
+                !annotation.contains("/XYZ"),
+                "toc page-number links should target /Fit page destinations only: {annotation}"
+            );
+        } else {
+            panic!("unexpected toc annotation destination shape: {annotation}");
+        }
         let rect = parse_pdf_annotation_rect_v0(&annotation).expect("annotation rect");
         assert!(
             rect[2] > rect[0],
@@ -3202,38 +3221,89 @@ fn pdf_renderer_emits_toc_link_annotations_targeting_heading_anchors_v0() {
             "annotation rect must stay within page bounds: {rect:?}"
         );
     }
+    xyz_pages.sort_unstable();
+    fit_pages.sort_unstable();
+    assert_eq!(
+        xyz_pages,
+        vec![3, 4],
+        "toc title links should target heading anchor pages in document order"
+    );
+    assert_eq!(
+        fit_pages,
+        vec![3, 4],
+        "toc page-number links should target page destinations in document order"
+    );
 }
 
 #[test]
 fn pdf_renderer_toc_annotation_destination_order_is_stable_v2() {
     let xdv = write_dvi_v2_text_page_v0(
-        b"Prelude.\n\n!toc\n\n@S {Intro section}\n\n@s {Detail section}\n\n!toc 1 1 <Intro section>\n!toc 2 2 <Detail section>",
+        b"Prelude.\n\n!toc\n\n@S {Intro section}\x0c@s {Detail section}\n\n!toc 1 1 <Intro section>\n!toc 2 2 <Detail section>",
     ).expect("writer should accept toc metadata and heading lines");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
 
     let page_one = parse_pdf_object_body_v0(&pdf, 3).expect("page object");
     let annots = parse_pdf_ref_ids_v0(&page_one, "/Annots");
-    assert_eq!(annots.len(), 2, "expected two toc annotations");
+    assert_eq!(annots.len(), 4, "expected title+page toc annotations");
 
-    let destinations = annots
-        .iter()
-        .map(|id| {
-            let body = parse_pdf_object_body_v0(&pdf, *id).expect("annotation body");
-            parse_pdf_annotation_dest_xyz_v0(&body).expect("annotation destination")
-        })
-        .collect::<Vec<_>>();
-    for (page_id, _, _) in &destinations {
-        assert_eq!(
-            *page_id, 3,
-            "toc annotations should target page containing heading anchors"
-        );
+    let mut xyz_destinations = Vec::<(u32, f32, f32)>::new();
+    let mut fit_page_ids = Vec::<u32>::new();
+    for id in annots {
+        let body = parse_pdf_object_body_v0(&pdf, id).expect("annotation body");
+        if body.contains("/XYZ") {
+            xyz_destinations.push(parse_pdf_annotation_dest_xyz_v0(&body).expect("xyz destination"));
+        } else if body.contains("/Fit]") {
+            fit_page_ids.push(
+                parse_pdf_annotation_dest_page_id_v0(&body).expect("fit destination page id"),
+            );
+        } else {
+            panic!("unexpected toc annotation destination shape: {body}");
+        }
     }
+    assert_eq!(
+        xyz_destinations.len(),
+        2,
+        "expected one heading-anchor link per toc title"
+    );
+    assert_eq!(
+        fit_page_ids.len(),
+        2,
+        "expected one page-destination link per toc page number"
+    );
+    assert_eq!(
+        xyz_destinations.iter().map(|dest| dest.0).collect::<Vec<_>>(),
+        vec![3, 4],
+        "toc title link destinations should remain stable and ordered"
+    );
+    assert_eq!(
+        fit_page_ids,
+        vec![3, 4],
+        "toc page-number link destinations should remain stable and ordered"
+    );
+}
 
-    let (_, _, section_y) = destinations[0];
-    let (_, _, subsection_y) = destinations[1];
+#[test]
+fn pdf_renderer_renders_toc_page_numbers_with_mixed_values_v2() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"Prelude.\n\n!toc\n\n@S {First anchor}\x0c@S {Second anchor}\n\n!toc 1 1 First toc entry\n!toc 1 2 Second toc entry",
+    )
+    .expect("writer should accept toc marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
     assert!(
-        section_y > subsection_y,
-        "section anchor should appear above subsection anchor: {destinations:?}"
+        pdf_text.contains("(First toc entry) Tj") && pdf_text.contains("(Second toc entry) Tj"),
+        "toc entry titles should render: {pdf_text}"
+    );
+    assert!(
+        pdf_text.contains("(1) Tj") && pdf_text.contains("(2) Tj"),
+        "toc page-number column should render mixed values: {pdf_text}"
+    );
+
+    let (one_x, _) = tm_position_for_segment_substring_v0(&pdf, "(1)").expect("page one number x");
+    let (two_x, _) = tm_position_for_segment_substring_v0(&pdf, "(2)").expect("page two number x");
+    assert!(
+        one_x >= 492.0 && two_x >= 492.0,
+        "toc page numbers should be right-column aligned: one_x={one_x}, two_x={two_x}"
     );
 }
 
@@ -3262,7 +3332,7 @@ fn pdf_renderer_rejects_toc_entries_with_unsupported_level_v0() {
 #[test]
 fn pdf_renderer_toc_block_renders_between_surrounding_paragraphs_v0() {
     let xdv = write_dvi_v2_text_page_v0(
-        b"Before block.\n\n!toc\n\nAfter block.\n\n!toc 1 1 Intro\n!toc 2 2 Detail",
+        b"Before block.\n\n!toc\n\nAfter block.\n\n@S {Anchor One}\n\n@s {Anchor Two}\n\n!toc 1 1 Intro toc line\n!toc 2 2 Detail toc line",
     )
     .expect("writer should accept toc marker lines");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
@@ -3271,9 +3341,9 @@ fn pdf_renderer_toc_block_renders_between_surrounding_paragraphs_v0() {
     let (toc_title_x, toc_title_y) =
         tm_position_for_line_containing_text_v0(&pdf, "(Contents)").expect("toc title");
     let (_, toc_intro_y) =
-        tm_position_for_line_containing_text_v0(&pdf, "(Intro)").expect("toc intro");
+        tm_position_for_line_containing_text_v0(&pdf, "(Intro toc line)").expect("toc intro");
     let (_, toc_detail_y) =
-        tm_position_for_line_containing_text_v0(&pdf, "(Detail)").expect("toc detail");
+        tm_position_for_line_containing_text_v0(&pdf, "(Detail toc line)").expect("toc detail");
     let (after_x, after_y) =
         tm_position_for_line_containing_text_v0(&pdf, "(After block.)").expect("after");
 

--- a/scripts/texlive_smoke/fixtures/typeset_demo_toc_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_toc_probe_v0.tex
@@ -11,4 +11,12 @@
 
 \section{Intro}
 This fixture probes table-of-contents extraction support.
+
+\subsection{Intro detail}
+This subsection stays on page one.
+
+\pagebreak
+
+\section{Second page heading}
+This heading must land on page two so TOC page numbers include mixed values.
 \end{document}

--- a/scripts/wasm_fixture_gallery_v1/main.mjs
+++ b/scripts/wasm_fixture_gallery_v1/main.mjs
@@ -59,6 +59,43 @@ const MAX_TABLE_COLS_PER_ENTRY_V0 = 16;
 const MAX_RESOURCE_HINT_ENTRIES_V0 = 512;
 const MAX_RESOURCE_HINT_VALUE_BYTES_V0 = 256;
 const RESOURCE_HINTS_V0_VERSION = 1;
+const DVI_PRE_OPCODE_V2 = 247;
+const DVI_BOP_OPCODE_V2 = 139;
+const DVI_EOP_OPCODE_V2 = 140;
+const DVI_POST_OPCODE_V2 = 248;
+const DVI_POSTPOST_OPCODE_V2 = 249;
+const DVI_FNT_DEF1_OPCODE_V2 = 243;
+const DVI_FNT_NUM_0_OPCODE_V2 = 171;
+const DVI_RIGHT3_OPCODE_V2 = 145;
+const DVI_DOWN3_OPCODE_V2 = 160;
+const DVI_ID_V2 = 2;
+const DVI_TRAILER_BYTE_V2 = 223;
+const DVI_NUM_V2 = 25_400_000;
+const DVI_DEN_V2 = 473_628_672;
+const DVI_MAG_V2 = 1000;
+const DVI_FONT_NAME_V2 = 'carreltex-v0';
+const TOC_PLACEHOLDER_MARKER_V2 = '!toc';
+const TOC_ENTRY_LINE_PREFIX_V2 = '!toc ';
+const SECTION_HEADING_PREFIX_V2 = '@S ';
+const SUBSECTION_HEADING_PREFIX_V2 = '@s ';
+const FIGURE_BOX_LINE_V2 = '!gbox';
+const FOOTNOTE_LINE_PREFIX_V2 = '!f ';
+const HREF_URL_LINE_PREFIX_V2 = '!u ';
+const LABEL_LINE_PREFIX_V2 = '!l ';
+const REF_LINE_PREFIX_V2 = '!r ';
+const PAGEREF_LINE_PREFIX_V2 = '!pr ';
+const REF_ANCHOR_LINK_LINE_PREFIX_V2 = '!ra ';
+const PAGEREF_PAGE_LINK_LINE_PREFIX_V2 = '!rp ';
+const EQUATION_LINE_PREFIX_V2 = '!eq ';
+const BIBITEM_LINE_PREFIX_V2 = '!b ';
+const CITE_LINE_PREFIX_V2 = '!c ';
+const TABLE_SPEC_LINE_PREFIX_V2 = '!ts ';
+const TABLE_ROW_LINE_PREFIX_V2 = '!t ';
+const FIGURE_CAPTION_LINE_PREFIX_V2 = '!gcap ';
+const FIGURE_IMAGE_LINE_PREFIX_V2 = '!gimg ';
+const DISPLAY_MATH_PLACEHOLDER_SHORT_V2 = 'MATH DISPLAY';
+const DISPLAY_MATH_PLACEHOLDER_MEDIUM_V2 = 'MATH DISPLAY MEDIUM';
+const DISPLAY_MATH_PLACEHOLDER_LONG_V2 = 'MATH DISPLAY LONG FORM';
 const DELTA_POLICY_V1_SCHEMA = 'wasm_fixture_gallery_delta_policy_v1';
 const DELTA_POLICY_V1_VERSION = 1;
 const BASELINE_CMP_CLASS_MATCH_V1 = 'MATCH';
@@ -1101,24 +1138,518 @@ function extractTocEntriesFromSourceV0(sourceBytes) {
     if (titleGroup.value.length > 0) {
       const titleBytes = Buffer.from(titleGroup.value, 'utf8');
       if (titleBytes.length > MAX_TOC_TITLE_BYTES_V0) {
-        throw new Error(`toc_v1 title exceeds cap ${MAX_TOC_TITLE_BYTES_V0}`);
+        throw new Error(`toc_v2 title exceeds cap ${MAX_TOC_TITLE_BYTES_V0}`);
       }
       const anchorId = `h${entries.length + 1}`;
       entries.push({
         level,
         title: titleGroup.value,
         anchor_id: anchorId,
-        page: null,
-        source_span: buildSourceSpanV0(sourceBytes, index, titleGroup.next, 'toc_v1'),
+        source_span: buildSourceSpanV0(sourceBytes, index, titleGroup.next, 'toc_v2'),
       });
       if (entries.length > MAX_TOC_ENTRIES_V0) {
-        throw new Error(`toc_v1 entries exceed cap ${MAX_TOC_ENTRIES_V0}`);
+        throw new Error(`toc_v2 entries exceed cap ${MAX_TOC_ENTRIES_V0}`);
       }
     }
 
     index = titleGroup.next;
   }
   return entries;
+}
+
+function parseTocAnchorIdTagV2(anchorId) {
+  if (typeof anchorId !== 'string') {
+    return null;
+  }
+  const match = /^h([1-9]\d*)$/.exec(anchorId);
+  if (!match) {
+    return null;
+  }
+  const parsed = Number.parseInt(match[1], 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return null;
+  }
+  return parsed;
+}
+
+function normalizeTocLinkWrappedTitleV2(title) {
+  if (typeof title !== 'string') {
+    return '';
+  }
+  const trimmed = title.trim();
+  if (trimmed.startsWith('<') && trimmed.endsWith('>') && trimmed.length >= 2) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+function isStyleMarkerByteV2(byte) {
+  return byte === 0x5b
+    || byte === 0x5d
+    || byte === 0x7b
+    || byte === 0x7d
+    || byte === 0x3c
+    || byte === 0x3e;
+}
+
+function readU8V2(bytes, state) {
+  if (state.index >= bytes.length) {
+    throw new Error('toc_v2 dvi parse overflow (u8)');
+  }
+  const value = bytes[state.index];
+  state.index += 1;
+  return value;
+}
+
+function readI24V2(bytes, state) {
+  if (state.index + 3 > bytes.length) {
+    throw new Error('toc_v2 dvi parse overflow (i24)');
+  }
+  const b0 = bytes[state.index];
+  const b1 = bytes[state.index + 1];
+  const b2 = bytes[state.index + 2];
+  state.index += 3;
+  const raw = (b0 << 16) | (b1 << 8) | b2;
+  return (raw & 0x80_0000) !== 0 ? (raw | ~0x00ff_ffff) : raw;
+}
+
+function readI32V2(bytes, state) {
+  if (state.index + 4 > bytes.length) {
+    throw new Error('toc_v2 dvi parse overflow (i32)');
+  }
+  const value = (bytes[state.index] << 24)
+    | (bytes[state.index + 1] << 16)
+    | (bytes[state.index + 2] << 8)
+    | bytes[state.index + 3];
+  state.index += 4;
+  return value;
+}
+
+function readU32V2(bytes, state) {
+  if (state.index + 4 > bytes.length) {
+    throw new Error('toc_v2 dvi parse overflow (u32)');
+  }
+  const value = ((bytes[state.index] * 0x1000000) >>> 0)
+    + (bytes[state.index + 1] << 16)
+    + (bytes[state.index + 2] << 8)
+    + bytes[state.index + 3];
+  state.index += 4;
+  return value >>> 0;
+}
+
+function expectByteV2(bytes, state, expected, context) {
+  const got = readU8V2(bytes, state);
+  if (got !== expected) {
+    throw new Error(`toc_v2 dvi parse expected ${context}=${expected}, got ${got}`);
+  }
+}
+
+function expectU32V2(bytes, state, expected, context) {
+  const got = readU32V2(bytes, state);
+  if (got !== expected) {
+    throw new Error(`toc_v2 dvi parse expected ${context}=${expected}, got ${got}`);
+  }
+}
+
+function parseDviTextPagesForTocV2(xdvBytes) {
+  const bytes = toUint8ArrayV0(xdvBytes);
+  if (bytes.length === 0 || bytes.length % 4 !== 0) {
+    throw new Error('toc_v2 requires non-empty 4-byte aligned main.xdv');
+  }
+  const state = { index: 0 };
+  expectByteV2(bytes, state, DVI_PRE_OPCODE_V2, 'PRE');
+  expectByteV2(bytes, state, DVI_ID_V2, 'DVI_ID');
+  expectU32V2(bytes, state, DVI_NUM_V2, 'NUM');
+  expectU32V2(bytes, state, DVI_DEN_V2, 'DEN');
+  expectU32V2(bytes, state, DVI_MAG_V2, 'MAG');
+  const commentLen = readU8V2(bytes, state);
+  if (commentLen !== 0) {
+    throw new Error('toc_v2 expects empty DVI comment');
+  }
+
+  const pages = [];
+  let previousBopOffset = null;
+  let pageCount = 0;
+  let lastBopOffset = 0;
+
+  while (state.index < bytes.length) {
+    const opcode = bytes[state.index];
+    if (opcode === DVI_POST_OPCODE_V2) {
+      break;
+    }
+    if (opcode !== DVI_BOP_OPCODE_V2) {
+      throw new Error(`toc_v2 dvi parse expected BOP, got opcode=${opcode}`);
+    }
+    const bopOffset = state.index;
+    lastBopOffset = bopOffset >>> 0;
+    state.index += 1;
+    for (let counter = 0; counter < 10; counter += 1) {
+      if (readI32V2(bytes, state) !== 0) {
+        throw new Error('toc_v2 dvi parse expects zero bop counters');
+      }
+    }
+    const prevBop = readI32V2(bytes, state);
+    if (previousBopOffset === null) {
+      if (prevBop !== -1) {
+        throw new Error(`toc_v2 dvi parse expected first prev_bop=-1, got ${prevBop}`);
+      }
+    } else if (prevBop !== previousBopOffset) {
+      throw new Error(`toc_v2 dvi parse expected prev_bop=${previousBopOffset}, got ${prevBop}`);
+    }
+
+    expectByteV2(bytes, state, DVI_FNT_DEF1_OPCODE_V2, 'FNT_DEF1');
+    expectByteV2(bytes, state, 0, 'FONT_ID');
+    expectU32V2(bytes, state, 0, 'FONT_CHECKSUM');
+    expectU32V2(bytes, state, 0, 'FONT_SCALE');
+    expectU32V2(bytes, state, 0, 'FONT_DESIGN');
+    expectByteV2(bytes, state, 0, 'FONT_AREA_LEN');
+    const fontNameLen = readU8V2(bytes, state);
+    if (fontNameLen !== DVI_FONT_NAME_V2.length) {
+      throw new Error(`toc_v2 dvi parse expected font name length ${DVI_FONT_NAME_V2.length}`);
+    }
+    if (state.index + fontNameLen > bytes.length) {
+      throw new Error('toc_v2 dvi parse overflow (font name)');
+    }
+    const fontName = Buffer.from(bytes.slice(state.index, state.index + fontNameLen)).toString('utf8');
+    state.index += fontNameLen;
+    if (fontName !== DVI_FONT_NAME_V2) {
+      throw new Error(`toc_v2 dvi parse expected font ${DVI_FONT_NAME_V2}, got ${fontName}`);
+    }
+    expectByteV2(bytes, state, DVI_FNT_NUM_0_OPCODE_V2, 'FNT_NUM_0');
+
+    const lines = [];
+    let currentLine = [];
+    let expectWidthRightAfterChar = false;
+    let expectDownAfterReset = false;
+    let pendingByte = 0;
+    let pageH = 0;
+
+    while (state.index < bytes.length) {
+      const op = bytes[state.index];
+      if (op === DVI_EOP_OPCODE_V2) {
+        if (expectWidthRightAfterChar || expectDownAfterReset) {
+          throw new Error('toc_v2 dvi parse reached EOP with pending line state');
+        }
+        lines.push(currentLine);
+        state.index += 1;
+        break;
+      }
+      if (expectWidthRightAfterChar) {
+        if (op !== DVI_RIGHT3_OPCODE_V2) {
+          throw new Error(`toc_v2 dvi parse expected RIGHT3 after char, got ${op}`);
+        }
+        state.index += 1;
+        const amount = readI24V2(bytes, state);
+        if (amount < 0) {
+          throw new Error('toc_v2 dvi parse found negative RIGHT3 width after char');
+        }
+        if (isStyleMarkerByteV2(pendingByte)) {
+          if (amount !== 0) {
+            throw new Error('toc_v2 dvi parse style marker must have zero advance');
+          }
+        } else if (amount === 0) {
+          throw new Error('toc_v2 dvi parse printable glyph must have non-zero advance');
+        } else {
+          pageH += amount;
+        }
+        currentLine.push(pendingByte);
+        expectWidthRightAfterChar = false;
+        continue;
+      }
+      if (op === DVI_RIGHT3_OPCODE_V2) {
+        state.index += 1;
+        const amount = readI24V2(bytes, state);
+        if (amount >= 0) {
+          throw new Error('toc_v2 dvi parse expects negative RIGHT3 reset');
+        }
+        const back = -amount;
+        if (back <= 0 || back > pageH) {
+          throw new Error('toc_v2 dvi parse invalid RIGHT3 reset amount');
+        }
+        pageH -= back;
+        expectDownAfterReset = true;
+        continue;
+      }
+      if (op === DVI_DOWN3_OPCODE_V2) {
+        state.index += 1;
+        const amount = readI24V2(bytes, state);
+        if (amount <= 0) {
+          throw new Error('toc_v2 dvi parse DOWN3 must be positive');
+        }
+        if (pageH !== 0) {
+          throw new Error('toc_v2 dvi parse DOWN3 requires zero horizontal cursor');
+        }
+        if (expectDownAfterReset) {
+          expectDownAfterReset = false;
+        }
+        lines.push(currentLine);
+        currentLine = [];
+        continue;
+      }
+      if (op > 127 || op < 0x20 || op > 0x7e || expectDownAfterReset) {
+        throw new Error(`toc_v2 dvi parse found unsupported opcode/text byte ${op}`);
+      }
+      pendingByte = op;
+      state.index += 1;
+      expectWidthRightAfterChar = true;
+    }
+
+    if (lines.length === 0) {
+      throw new Error('toc_v2 dvi parse produced empty page');
+    }
+    pages.push(lines.map((line) => Uint8Array.from(line)));
+    previousBopOffset = bopOffset;
+    pageCount += 1;
+  }
+
+  if (pageCount <= 0) {
+    throw new Error('toc_v2 dvi parse found no pages');
+  }
+  expectByteV2(bytes, state, DVI_POST_OPCODE_V2, 'POST');
+  expectU32V2(bytes, state, lastBopOffset >>> 0, 'POST_LAST_BOP');
+  expectU32V2(bytes, state, DVI_NUM_V2, 'POST_NUM');
+  expectU32V2(bytes, state, DVI_DEN_V2, 'POST_DEN');
+  expectU32V2(bytes, state, DVI_MAG_V2, 'POST_MAG');
+  readU32V2(bytes, state); // max_h
+  readU32V2(bytes, state); // max_v
+  const stackDepth = (readU8V2(bytes, state) << 8) | readU8V2(bytes, state);
+  if (stackDepth !== 0) {
+    throw new Error(`toc_v2 dvi parse expected stack depth 0, got ${stackDepth}`);
+  }
+  const declaredPages = (readU8V2(bytes, state) << 8) | readU8V2(bytes, state);
+  if (declaredPages !== pageCount) {
+    throw new Error(`toc_v2 dvi parse page count mismatch ${declaredPages} vs ${pageCount}`);
+  }
+  expectByteV2(bytes, state, DVI_POSTPOST_OPCODE_V2, 'POSTPOST');
+  const postPointer = readU32V2(bytes, state);
+  if (postPointer >= bytes.length) {
+    throw new Error('toc_v2 dvi parse post pointer out of bounds');
+  }
+  expectByteV2(bytes, state, DVI_ID_V2, 'POSTPOST_DVI_ID');
+  if (bytes.length - state.index < 4) {
+    throw new Error('toc_v2 dvi parse trailer too short');
+  }
+  for (let index = state.index; index < bytes.length; index += 1) {
+    if (bytes[index] !== DVI_TRAILER_BYTE_V2) {
+      throw new Error('toc_v2 dvi parse trailer byte mismatch');
+    }
+  }
+
+  return pages;
+}
+
+function lineStartsWithAsciiV2(lineBytes, prefix) {
+  const prefixBytes = Buffer.from(prefix, 'ascii');
+  if (!lineBytes || lineBytes.length < prefixBytes.length) {
+    return false;
+  }
+  for (let index = 0; index < prefixBytes.length; index += 1) {
+    if (lineBytes[index] !== prefixBytes[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function lineEqualsAsciiV2(lineBytes, value) {
+  const valueBytes = Buffer.from(value, 'ascii');
+  if (!lineBytes || lineBytes.length !== valueBytes.length) {
+    return false;
+  }
+  for (let index = 0; index < valueBytes.length; index += 1) {
+    if (lineBytes[index] !== valueBytes[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function detectListPrefixLineV2(lineBytes) {
+  let leading = 0;
+  while (leading < lineBytes.length && lineBytes[leading] === 0x20) {
+    leading += 1;
+  }
+  if (leading + 2 <= lineBytes.length && lineBytes[leading] === 0x2d && lineBytes[leading + 1] === 0x20) {
+    return true;
+  }
+  let cursor = leading;
+  let sawDigit = false;
+  while (cursor < lineBytes.length && lineBytes[cursor] >= 0x30 && lineBytes[cursor] <= 0x39) {
+    sawDigit = true;
+    cursor += 1;
+  }
+  return sawDigit
+    && cursor + 1 < lineBytes.length
+    && lineBytes[cursor] === 0x2e
+    && lineBytes[cursor + 1] === 0x20;
+}
+
+function isStructuredNonTitleLineV2(lineBytes) {
+  return lineStartsWithAsciiV2(lineBytes, SECTION_HEADING_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, SUBSECTION_HEADING_PREFIX_V2)
+    || detectListPrefixLineV2(lineBytes)
+    || lineStartsWithAsciiV2(lineBytes, '> ')
+    || lineStartsWithAsciiV2(lineBytes, '^ ')
+    || lineStartsWithAsciiV2(lineBytes, '| ')
+    || lineStartsWithAsciiV2(lineBytes, '~ ')
+    || lineStartsWithAsciiV2(lineBytes, TABLE_SPEC_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, TABLE_ROW_LINE_PREFIX_V2)
+    || lineEqualsAsciiV2(lineBytes, FIGURE_BOX_LINE_V2)
+    || lineStartsWithAsciiV2(lineBytes, FIGURE_CAPTION_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, FIGURE_IMAGE_LINE_PREFIX_V2)
+    || lineEqualsAsciiV2(lineBytes, TOC_PLACEHOLDER_MARKER_V2)
+    || lineStartsWithAsciiV2(lineBytes, TOC_ENTRY_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, FOOTNOTE_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, HREF_URL_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, LABEL_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, REF_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, PAGEREF_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, REF_ANCHOR_LINK_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, PAGEREF_PAGE_LINK_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, EQUATION_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, BIBITEM_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, CITE_LINE_PREFIX_V2);
+}
+
+function detectTitleBlockLenV2(lines) {
+  let index = 0;
+  while (index < lines.length && lines[index].length > 0 && !isStructuredNonTitleLineV2(lines[index])) {
+    index += 1;
+  }
+  return index > 0 && index < lines.length ? index : 0;
+}
+
+function hasMetadataPrefixLineV2(lineBytes) {
+  return lineStartsWithAsciiV2(lineBytes, FOOTNOTE_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, HREF_URL_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, TOC_ENTRY_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, LABEL_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, REF_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, PAGEREF_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, REF_ANCHOR_LINK_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, PAGEREF_PAGE_LINK_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, EQUATION_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, BIBITEM_LINE_PREFIX_V2)
+    || lineStartsWithAsciiV2(lineBytes, CITE_LINE_PREFIX_V2);
+}
+
+function splitBodyAndMetadataLinesV2(pages) {
+  const bodyPages = pages.map(() => []);
+  const metadataLines = [];
+  let inMetadata = false;
+  for (let pageIndex = 0; pageIndex < pages.length; pageIndex += 1) {
+    const lines = pages[pageIndex];
+    for (const lineBytes of lines) {
+      if (hasMetadataPrefixLineV2(lineBytes)) {
+        inMetadata = true;
+      }
+      if (inMetadata) {
+        metadataLines.push(lineBytes);
+      } else {
+        bodyPages[pageIndex].push(lineBytes);
+      }
+    }
+  }
+  while (bodyPages.length > 1 && bodyPages[bodyPages.length - 1].length === 0) {
+    bodyPages.pop();
+  }
+  return { bodyPages, metadataLines };
+}
+
+function isDisplayMathPlaceholderLineV2(lineBytes) {
+  if (!lineStartsWithAsciiV2(lineBytes, '^ ')) {
+    return false;
+  }
+  const payload = Buffer.from(lineBytes.slice(2)).toString('ascii');
+  return payload === DISPLAY_MATH_PLACEHOLDER_SHORT_V2
+    || payload === DISPLAY_MATH_PLACEHOLDER_MEDIUM_V2
+    || payload === DISPLAY_MATH_PLACEHOLDER_LONG_V2;
+}
+
+function parseTocEntriesFromMetadataLinesV2(metadataLines) {
+  const entries = [];
+  const seenAnchors = new Set();
+  for (const lineBytes of metadataLines) {
+    if (!lineStartsWithAsciiV2(lineBytes, TOC_ENTRY_LINE_PREFIX_V2)) {
+      continue;
+    }
+    const raw = Buffer.from(lineBytes).toString('utf8');
+    const match = /^!toc ([12]) ([1-9]\d*) (.+)$/.exec(raw);
+    if (!match) {
+      throw new Error(`toc_v2 encountered malformed toc metadata line: ${raw}`);
+    }
+    const level = Number.parseInt(match[1], 10);
+    const anchorId = Number.parseInt(match[2], 10);
+    const title = match[3].trim();
+    if (!Number.isInteger(level) || (level !== 1 && level !== 2)) {
+      throw new Error(`toc_v2 encountered unsupported level in metadata: ${raw}`);
+    }
+    if (!Number.isInteger(anchorId) || anchorId <= 0) {
+      throw new Error(`toc_v2 encountered invalid anchor id in metadata: ${raw}`);
+    }
+    if (title.length === 0) {
+      throw new Error(`toc_v2 encountered empty title in metadata: ${raw}`);
+    }
+    if (seenAnchors.has(anchorId)) {
+      throw new Error(`toc_v2 encountered duplicate toc anchor metadata: ${anchorId}`);
+    }
+    seenAnchors.add(anchorId);
+    entries.push({ level, anchor_id: anchorId, title });
+  }
+  entries.sort((left, right) => left.anchor_id - right.anchor_id);
+  return entries;
+}
+
+function collectNominalAnchorPageNumbersFromBodyPagesV2(bodyPages) {
+  const pageNumbersByAnchorId = new Map();
+  let nextAnchorId = 1;
+  for (let pageIndex = 0; pageIndex < bodyPages.length; pageIndex += 1) {
+    const lines = bodyPages[pageIndex];
+    const titleBlockLen = pageIndex === 0 ? detectTitleBlockLenV2(lines) : 0;
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+      if (lineIndex < titleBlockLen) {
+        continue;
+      }
+      const lineBytes = lines[lineIndex];
+      const hasAnchor = lineEqualsAsciiV2(lineBytes, FIGURE_BOX_LINE_V2)
+        || isDisplayMathPlaceholderLineV2(lineBytes)
+        || lineStartsWithAsciiV2(lineBytes, SECTION_HEADING_PREFIX_V2)
+        || lineStartsWithAsciiV2(lineBytes, SUBSECTION_HEADING_PREFIX_V2);
+      if (!hasAnchor) {
+        continue;
+      }
+      if (pageNumbersByAnchorId.has(nextAnchorId)) {
+        throw new Error(`toc_v2 encountered duplicate nominal anchor id ${nextAnchorId}`);
+      }
+      pageNumbersByAnchorId.set(nextAnchorId, pageIndex + 1);
+      nextAnchorId += 1;
+    }
+  }
+  return pageNumbersByAnchorId;
+}
+
+function collectTocOutputSnapshotV2(xdvBytes) {
+  const pages = parseDviTextPagesForTocV2(xdvBytes);
+  const { bodyPages, metadataLines } = splitBodyAndMetadataLinesV2(pages);
+  if (bodyPages.length <= 0) {
+    throw new Error('toc_v2 requires at least one body page');
+  }
+  const tocEntries = parseTocEntriesFromMetadataLinesV2(metadataLines);
+  const pageNumbersByAnchorId = collectNominalAnchorPageNumbersFromBodyPagesV2(bodyPages);
+  for (const entry of tocEntries) {
+    const pageNo = pageNumbersByAnchorId.get(entry.anchor_id);
+    if (!Number.isInteger(pageNo)) {
+      throw new Error(`toc_v2 missing destination for anchor ${entry.anchor_id}`);
+    }
+    if (pageNo <= 0 || pageNo > bodyPages.length) {
+      throw new Error(`toc_v2 destination page out of range for anchor ${entry.anchor_id}: ${pageNo}`);
+    }
+  }
+  return {
+    tocEntries,
+    pageNumbersByAnchorId,
+    pageCount: bodyPages.length,
+  };
 }
 
 function isMathPayloadWhitespaceByteV0(byte) {
@@ -3480,14 +4011,61 @@ async function emitPagerefTypedArtifactV2(caseOutDir, fixtureBytes, mountedFiles
   };
 }
 
-async function emitTocTypedArtifactV0(caseOutDir, fixtureBytes) {
+async function emitTocTypedArtifactV2(caseOutDir, fixtureBytes, xdvBytes) {
+  const sourceEntries = extractTocEntriesFromSourceV0(fixtureBytes);
+  const outputSnapshot = collectTocOutputSnapshotV2(xdvBytes);
+  const outputByAnchorId = new Map();
+  for (const entry of outputSnapshot.tocEntries) {
+    outputByAnchorId.set(entry.anchor_id, entry);
+  }
+
+  const sourceAnchorIds = new Set();
+  for (const sourceEntry of sourceEntries) {
+    const anchorId = parseTocAnchorIdTagV2(sourceEntry.anchor_id);
+    if (!anchorId) {
+      throw new Error(`toc_v2 invalid source anchor tag: ${sourceEntry.anchor_id}`);
+    }
+    sourceAnchorIds.add(anchorId);
+  }
+
+  if (sourceAnchorIds.size !== outputByAnchorId.size) {
+    throw new Error(
+      `toc_v2 source/output anchor count mismatch (${sourceAnchorIds.size} vs ${outputByAnchorId.size})`,
+    );
+  }
+
+  const entries = [];
+  for (const sourceEntry of sourceEntries) {
+    const anchorId = parseTocAnchorIdTagV2(sourceEntry.anchor_id);
+    if (!anchorId) {
+      throw new Error(`toc_v2 invalid source anchor tag: ${sourceEntry.anchor_id}`);
+    }
+    const outputEntry = outputByAnchorId.get(anchorId);
+    if (!outputEntry) {
+      throw new Error(`toc_v2 output metadata missing anchor ${anchorId}`);
+    }
+    const expectedTitle = normalizeTocLinkWrappedTitleV2(sourceEntry.title);
+    const actualTitle = normalizeTocLinkWrappedTitleV2(outputEntry.title);
+    if (sourceEntry.level !== outputEntry.level || expectedTitle !== actualTitle) {
+      throw new Error(`toc_v2 source/output metadata mismatch for anchor ${anchorId}`);
+    }
+    const pageNo = outputSnapshot.pageNumbersByAnchorId.get(anchorId);
+    if (!Number.isInteger(pageNo) || pageNo <= 0 || pageNo > outputSnapshot.pageCount) {
+      throw new Error(`toc_v2 invalid page_no for anchor ${anchorId}: ${pageNo}`);
+    }
+    entries.push({
+      ...sourceEntry,
+      page_no: pageNo,
+    });
+  }
+
   const payload = {
     version: TYPED_ARTIFACTS_VERSION_V0,
-    schema: 'toc_v1',
-    entries: extractTocEntriesFromSourceV0(fixtureBytes),
+    schema: 'toc_v2',
+    entries,
   };
   const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
-  const relpath = 'toc_v1.json';
+  const relpath = 'toc_v2.json';
   const fullPath = path.join(caseOutDir, relpath);
   await writeFile(fullPath, bytes);
   return {
@@ -3728,9 +4306,10 @@ async function emitTypedArtifactsV0(
   fixtureBytes,
   mountedFiles = [],
   inputEntries = [],
+  xdvBytes = new Uint8Array(),
 ) {
   if (caseSpec.id === 'typeset_demo_toc_probe_v0') {
-    typedArtifacts.toc = await emitTocTypedArtifactV0(caseOutDir, fixtureBytes);
+    typedArtifacts.toc = await emitTocTypedArtifactV2(caseOutDir, fixtureBytes, xdvBytes);
   }
   if (caseSpec.id === 'typeset_demo_labels_probe_v0') {
     typedArtifacts.labels = await emitLabelsTypedArtifactV0(caseOutDir, fixtureBytes);
@@ -4372,6 +4951,7 @@ async function runCaseV0(
     fixtureBytes,
     inputInclusionGraph.mounted_files,
     inputInclusionGraph.entries,
+    xdvBytes,
   );
   const typedArtifactRequests = await collectResolverRequestsFromResourceHintsV0(
     caseSpec,

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
@@ -189,9 +189,9 @@ if (tocSummary?.typed_artifacts?.toc?.present !== true) {
   console.error('FAIL: expected toc typed artifact present after first run');
   process.exit(1);
 }
-const tocPath = path.join(outDir, 'typeset_demo_toc_probe_v0', 'toc_v1.json');
+const tocPath = path.join(outDir, 'typeset_demo_toc_probe_v0', 'toc_v2.json');
 if (!fs.existsSync(tocPath)) {
-  console.error('FAIL: expected toc_v1.json artifact after first run');
+  console.error('FAIL: expected toc_v2.json artifact after first run');
   process.exit(1);
 }
 const tocShaFirst = tocSummary.typed_artifacts.toc.artifact_sha256;
@@ -201,33 +201,38 @@ if (typeof tocShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(tocShaFirst)) {
 }
 const tocArtifactFirst = JSON.parse(fs.readFileSync(tocPath, 'utf8'));
 if (!Array.isArray(tocArtifactFirst?.entries)) {
-  console.error('FAIL: expected toc_v1.entries array in first-run artifact');
+  console.error('FAIL: expected toc_v2.entries array in first-run artifact');
   process.exit(1);
 }
-if (tocArtifactFirst?.schema !== 'toc_v1') {
-  console.error('FAIL: expected toc_v1 schema in first-run artifact');
+if (tocArtifactFirst?.schema !== 'toc_v2') {
+  console.error('FAIL: expected toc_v2 schema in first-run artifact');
   process.exit(1);
 }
 if (tocArtifactFirst.entries.length <= 0) {
-  console.error('FAIL: expected non-empty toc_v1.entries for toc probe');
+  console.error('FAIL: expected non-empty toc_v2.entries for toc probe');
   process.exit(1);
 }
 for (const [index, entry] of tocArtifactFirst.entries.entries()) {
   if (!Number.isInteger(entry?.level) || entry.level < 1 || entry.level > 2) {
-    console.error(`FAIL: toc_v1.entries[${index}] must have level in [1,2]`);
+    console.error(`FAIL: toc_v2.entries[${index}] must have level in [1,2]`);
     process.exit(1);
   }
   if (typeof entry?.anchor_id !== 'string' || !/^h[1-9]\d*$/.test(entry.anchor_id)) {
-    console.error(`FAIL: toc_v1.entries[${index}] must have anchor_id like hN`);
+    console.error(`FAIL: toc_v2.entries[${index}] must have anchor_id like hN`);
     process.exit(1);
   }
-  if (entry?.page !== null) {
-    console.error(`FAIL: toc_v1.entries[${index}].page must be null in v1`);
+  if (!Number.isInteger(entry?.page_no) || entry.page_no <= 0) {
+    console.error(`FAIL: toc_v2.entries[${index}].page_no must be positive integer`);
     process.exit(1);
   }
 }
-assertEntrySourceSpans('typeset_demo_toc_probe_v0', 'toc_v1', tocArtifactFirst.entries);
-fs.writeFileSync(firstRunShaPath('toc_v1'), `${tocShaFirst}\n`);
+const tocDistinctPagesFirst = new Set(tocArtifactFirst.entries.map((entry) => entry.page_no));
+if (tocDistinctPagesFirst.size < 2 || ![...tocDistinctPagesFirst].some((pageNo) => pageNo >= 2)) {
+  console.error('FAIL: expected toc_v2 probe to include mixed page_no values including page 2');
+  process.exit(1);
+}
+assertEntrySourceSpans('typeset_demo_toc_probe_v0', 'toc_v2', tocArtifactFirst.entries);
+fs.writeFileSync(firstRunShaPath('toc_v2'), `${tocShaFirst}\n`);
 
 const bibSummary = JSON.parse(
   fs.readFileSync(path.join(outDir, 'typeset_demo_bib_probe_v0', 'summary.json'), 'utf8'),

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
@@ -67,7 +67,7 @@ const requiredTypedKeys = ['toc', 'labels', 'refs', 'pageref', 'bib', 'cite', 'h
 const labelsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'labels_v1_first.sha256'), 'utf8').trim();
 const refsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'refs_v1_first.sha256'), 'utf8').trim();
 const pagerefShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'pageref_v2_first.sha256'), 'utf8').trim();
-const tocShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'toc_v1_first.sha256'), 'utf8').trim();
+const tocShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'toc_v2_first.sha256'), 'utf8').trim();
 const bibShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'bib_v1_first.sha256'), 'utf8').trim();
 const citeShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'cite_v1_first.sha256'), 'utf8').trim();
 const hyperrefShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'hyperref_v0_first.sha256'), 'utf8').trim();
@@ -399,33 +399,38 @@ if (!tocArtifact || tocArtifact.present !== true) {
 }
 const tocShaSecond = tocArtifact.artifact_sha256;
 if (tocShaSecond !== tocShaFirst) {
-  console.error('FAIL: toc_v1 artifact sha256 must be stable across reruns');
+  console.error('FAIL: toc_v2 artifact sha256 must be stable across reruns');
   process.exit(1);
 }
 const tocArtifactSecond = JSON.parse(
-  fs.readFileSync(path.join(outDir, 'typeset_demo_toc_probe_v0', 'toc_v1.json'), 'utf8'),
+  fs.readFileSync(path.join(outDir, 'typeset_demo_toc_probe_v0', 'toc_v2.json'), 'utf8'),
 );
 if (!Array.isArray(tocArtifactSecond?.entries) || tocArtifactSecond.entries.length <= 0) {
-  console.error('FAIL: expected non-empty toc_v1.entries after rerun');
+  console.error('FAIL: expected non-empty toc_v2.entries after rerun');
   process.exit(1);
 }
-if (tocArtifactSecond?.schema !== 'toc_v1') {
-  console.error('FAIL: expected toc_v1 schema after rerun');
+if (tocArtifactSecond?.schema !== 'toc_v2') {
+  console.error('FAIL: expected toc_v2 schema after rerun');
   process.exit(1);
 }
 for (const [index, entry] of tocArtifactSecond.entries.entries()) {
   if (!Number.isInteger(entry?.level) || entry.level < 1 || entry.level > 2) {
-    console.error(`FAIL: rerun toc_v1.entries[${index}] must have level in [1,2]`);
+    console.error(`FAIL: rerun toc_v2.entries[${index}] must have level in [1,2]`);
     process.exit(1);
   }
   if (typeof entry?.anchor_id !== 'string' || !/^h[1-9]\d*$/.test(entry.anchor_id)) {
-    console.error(`FAIL: rerun toc_v1.entries[${index}] must have anchor_id like hN`);
+    console.error(`FAIL: rerun toc_v2.entries[${index}] must have anchor_id like hN`);
     process.exit(1);
   }
-  if (entry?.page !== null) {
-    console.error(`FAIL: rerun toc_v1.entries[${index}].page must be null in v1`);
+  if (!Number.isInteger(entry?.page_no) || entry.page_no <= 0) {
+    console.error(`FAIL: rerun toc_v2.entries[${index}].page_no must be positive integer`);
     process.exit(1);
   }
+}
+const tocDistinctPagesSecond = new Set(tocArtifactSecond.entries.map((entry) => entry.page_no));
+if (tocDistinctPagesSecond.size < 2 || ![...tocDistinctPagesSecond].some((pageNo) => pageNo >= 2)) {
+  console.error('FAIL: expected toc_v2 rerun artifact to retain mixed page_no values including page 2');
+  process.exit(1);
 }
 
 const bibSummary = JSON.parse(
@@ -684,7 +689,7 @@ console.log('PASS: resource_hints_v0 excludes ok_demo_v0');
 console.log(`PASS: labels_v1 sha stable ${labelsShaSecond}`);
 console.log(`PASS: refs_v1 sha stable ${refsShaSecond}`);
 console.log(`PASS: pageref_v2 sha stable ${pagerefShaSecond}`);
-console.log(`PASS: toc_v1 sha stable ${tocShaSecond}`);
+console.log(`PASS: toc_v2 sha stable ${tocShaSecond}`);
 console.log(`PASS: bib_v1 sha stable ${bibShaSecond}`);
 console.log(`PASS: cite_v1 sha stable ${citeShaSecond}`);
 console.log(`PASS: hyperref_v0 sha stable ${hyperrefShaSecond}`);

--- a/scripts/wasm_typeset_minimal_v0_emit_pdf.mjs
+++ b/scripts/wasm_typeset_minimal_v0_emit_pdf.mjs
@@ -52,7 +52,7 @@ function parsePdfAnnotationActionIdV0(body) {
 }
 
 function parsePdfAnnotationDestPageIdV0(body) {
-  const match = body.match(/\/Dest \[(\d+)\s+0\s+R\s+\/XYZ/);
+  const match = body.match(/\/Dest \[(\d+)\s+0\s+R\s+\/(?:XYZ|Fit)\b/);
   if (!match) return null;
   const id = Number.parseInt(match[1], 10);
   return Number.isFinite(id) ? id : null;


### PR DESCRIPTION
Closes #412

## Summary
- derive toc_v2 typed artifact page_no from parsed main.xdv anchor destinations (fail-closed on malformed/missing/out-of-range)
- render TOC page-number column and emit hyperref-aware page-number links to page destinations (/Fit)
- extend TOC fixture/proofs to enforce mixed page numbers with a heading on page 2
- update wasm typeset PDF proof annotation parser to accept /Fit internal destinations

## Proofs
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml
- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12
- ./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25