### PR TITLE
float layout v0: figure placement policy

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0.rs
@@ -194,6 +194,12 @@ struct IncludeGraphicsCommandV0 {
     sizing: FigureSizingMptV0,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum FigurePlacementHintV0 {
+    Inline,
+    Top,
+}
+
 #[derive(Default)]
 struct TitleMetaV0 {
     title: Option<Vec<u8>>,
@@ -496,6 +502,38 @@ fn consume_env_name_command_v0(
         return None;
     }
     Some((env_bytes, next))
+}
+
+fn consume_figure_placement_hint_v0(
+    tokens: &[TokenV0],
+    index: usize,
+) -> Option<(FigurePlacementHintV0, usize)> {
+    let mut cursor = skip_spaces(tokens, index);
+    if !matches!(tokens.get(cursor), Some(TokenV0::Char(b'['))) {
+        return Some((FigurePlacementHintV0::Inline, cursor));
+    }
+    cursor += 1;
+    let mut saw_non_space = false;
+    let mut saw_top = false;
+    loop {
+        match tokens.get(cursor) {
+            Some(TokenV0::Char(b']')) => {
+                if !saw_non_space || !saw_top {
+                    return None;
+                }
+                return Some((FigurePlacementHintV0::Top, cursor + 1));
+            }
+            Some(TokenV0::Space) => {}
+            Some(TokenV0::Char(byte)) if is_horizontal_space_v0(*byte) => {}
+            Some(TokenV0::Char(b't')) if !saw_top => {
+                saw_non_space = true;
+                saw_top = true;
+            }
+            Some(TokenV0::Char(_)) => return None,
+            _ => return None,
+        }
+        cursor += 1;
+    }
 }
 
 fn consume_document_env_command_v0(tokens: &[TokenV0], index: usize, name: &[u8]) -> Option<usize> {
@@ -1540,6 +1578,8 @@ fn consume_figure_environment_v0(
     if env_name.as_slice() != FIGURE_ENV_V0 {
         return None;
     }
+    let (placement_hint, after_placement) = consume_figure_placement_hint_v0(tokens, cursor)?;
+    cursor = after_placement;
 
     let mut caption: Option<Vec<u8>> = None;
     let mut image: Option<IncludeGraphicsCommandV0> = None;
@@ -1556,8 +1596,17 @@ fn consume_figure_environment_v0(
                 if figure_caption.is_empty() {
                     return None;
                 }
-                push_paragraph_break(out);
+                if matches!(placement_hint, FigurePlacementHintV0::Top) {
+                    if !out.is_empty() && !matches!(out.last().copied(), Some(PAGE_BREAK_MARKER_V0)) {
+                        push_page_break(out);
+                    }
+                } else {
+                    push_paragraph_break(out);
+                }
                 out.extend_from_slice(FIGURE_BOX_PREFIX_MARKER_V0);
+                if matches!(placement_hint, FigurePlacementHintV0::Top) {
+                    out.extend_from_slice(b" t");
+                }
                 push_newline(out);
                 if let Some(image_meta) = &image {
                     out.extend_from_slice(FIGURE_IMAGE_PREFIX_MARKER_V0);

--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -944,6 +944,33 @@ fn typeset_minimal_figure_stub_accepts_includegraphics_scale_option() {
 }
 
 #[test]
+fn typeset_minimal_figure_top_placement_emits_top_marker_and_page_break_v0() {
+    let main = b"\\documentclass{article}\\begin{document}Before.\\begin{figure}[t]\\caption{Top figure}\\end{figure}After.\\end{document}";
+    let body = extract_typeset_body(main);
+    let text = String::from_utf8(body).expect("body should be valid utf8");
+    assert!(
+        text.contains("Before.\x0c!gbox t\n!gcap Figure 1: Top figure\n\nAfter."),
+        "body={text:?}"
+    );
+}
+
+#[test]
+fn typeset_minimal_rejects_figure_unsupported_placement_hint_v0() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{figure}[h]\\caption{Nope}\\end{figure}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
+fn typeset_minimal_rejects_figure_duplicated_top_placement_hint_v0() {
+    let main = b"\\documentclass{article}\\begin{document}\\begin{figure}[tt]\\caption{Nope}\\end{figure}\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::NotImplemented);
+    assert!(result.main_xdv_bytes.is_empty());
+}
+
+#[test]
 fn typeset_minimal_rejects_figure_includegraphics_unknown_option_key() {
     let main = b"\\documentclass{article}\\begin{document}\\begin{figure}\\includegraphics[keepaspectratio=true]{demo.png}\\caption{Nope}\\end{figure}\\end{document}";
     let result = compile_typeset(main);

--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -89,6 +89,12 @@ enum HeadingKindV0 {
     Subsection,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum FigurePlacementHintV0 {
+    Inline,
+    Top,
+}
+
 fn style_font_alias_v0(style: PdfTextStyleV0) -> &'static [u8] {
     match style {
         PdfTextStyleV0::Regular => b"F1",
@@ -572,12 +578,32 @@ fn has_table_spec_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
             .eq(TABLE_SPEC_PREFIX_MARKER_V0.iter().copied())
 }
 
-fn has_figure_box_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
-    glyphs.len() == FIGURE_BOX_PREFIX_MARKER_V0.len()
-        && glyphs
+fn has_figure_box_marker_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    glyphs.len() >= FIGURE_BOX_PREFIX_MARKER_V0.len()
+        && glyphs[..FIGURE_BOX_PREFIX_MARKER_V0.len()]
             .iter()
             .map(|glyph| glyph.byte)
             .eq(FIGURE_BOX_PREFIX_MARKER_V0.iter().copied())
+}
+
+fn parse_figure_box_line_v0(glyphs: &[GlyphPlanV0]) -> Option<FigurePlacementHintV0> {
+    if !has_figure_box_marker_prefix_v0(glyphs) {
+        return None;
+    }
+    if glyphs.len() == FIGURE_BOX_PREFIX_MARKER_V0.len() {
+        return Some(FigurePlacementHintV0::Inline);
+    }
+    if glyphs.len() == FIGURE_BOX_PREFIX_MARKER_V0.len() + 2
+        && glyphs[FIGURE_BOX_PREFIX_MARKER_V0.len()].byte == b' '
+        && glyphs[FIGURE_BOX_PREFIX_MARKER_V0.len() + 1].byte == b't'
+    {
+        return Some(FigurePlacementHintV0::Top);
+    }
+    None
+}
+
+fn has_figure_box_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
+    parse_figure_box_line_v0(glyphs).is_some()
 }
 
 fn has_figure_caption_prefix_v0(glyphs: &[GlyphPlanV0]) -> bool {
@@ -2011,7 +2037,8 @@ fn collect_nominal_anchor_destinations_v0(
         };
         let mut y = PAGE_HEIGHT_PT_V0 - MARGIN_PT_V0 - TITLE_FONT_SIZE_PT_V0;
         for (line_index, line) in lines.iter().enumerate() {
-            if line_index >= title_block_len && has_figure_box_prefix_v0(&line.glyphs) {
+            if line_index >= title_block_len && has_figure_box_marker_prefix_v0(&line.glyphs) {
+                parse_figure_box_line_v0(&line.glyphs)?;
                 if anchor_destinations
                     .insert(
                         next_anchor_id,
@@ -2280,7 +2307,9 @@ fn build_page_content_stream_v0(
             line_index = table_end;
             continue;
         }
-        if line_index >= title_block_len && has_figure_box_prefix_v0(&resolved_line_glyphs) {
+        if line_index >= title_block_len && has_figure_box_marker_prefix_v0(&resolved_line_glyphs)
+        {
+            let _figure_placement = parse_figure_box_line_v0(&resolved_line_glyphs)?;
             let figure_anchor_id = *next_anchor_id;
             *next_anchor_id = next_anchor_id.checked_add(1)?;
             if anchor_destinations

--- a/crates/carreltex-xdv/src/tests.rs
+++ b/crates/carreltex-xdv/src/tests.rs
@@ -3131,6 +3131,22 @@ fn pdf_renderer_figure_metadata_width_affects_placeholder_alignment_v2() {
 }
 
 #[test]
+fn pdf_renderer_accepts_figure_top_placement_marker_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"!gbox t\n!gcap Figure 1: Top caption.")
+        .expect("writer should accept figure marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    assert!(
+        pdf_text.contains("(Figure 1: Top caption.) Tj"),
+        "caption text should render for top-placement marker: {pdf_text}"
+    );
+    assert!(
+        pdf_text.contains("([ Figure placeholder ]) Tj"),
+        "placeholder text should render for top-placement marker: {pdf_text}"
+    );
+}
+
+#[test]
 fn pdf_renderer_rejects_figure_image_metadata_width_overflow_v2() {
     let xdv = write_dvi_v2_text_page_v0(
         b"!gbox\n!gimg 1 figures/demo.png 500000 120000\n!gcap Figure 1: Caption.",
@@ -3151,6 +3167,17 @@ fn pdf_renderer_rejects_malformed_figure_image_metadata_line_v0() {
     assert!(
         pdf.is_none(),
         "renderer should fail-closed on malformed !gimg metadata"
+    );
+}
+
+#[test]
+fn pdf_renderer_rejects_malformed_figure_box_placement_marker_v0() {
+    let xdv = write_dvi_v2_text_page_v0(b"!gbox h\n!gcap Figure 1: Caption.")
+        .expect("writer should accept figure marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv);
+    assert!(
+        pdf.is_none(),
+        "renderer should fail-closed on malformed !gbox placement hint"
     );
 }
 

--- a/scripts/texlive_smoke/fixtures/typeset_demo_float_probe_v0.tex
+++ b/scripts/texlive_smoke/fixtures/typeset_demo_float_probe_v0.tex
@@ -1,0 +1,14 @@
+\documentclass{article}
+\begin{document}
+Intro references before figure definitions: top=\ref{fig:top}, inline=\ref{fig:inline}.
+\begin{figure}
+\caption{Inline float caption that should stay inline.}
+\end{figure}
+\label{fig:inline}
+Reference after inline figure: \ref{fig:inline}.
+\begin{figure}[t]
+\caption{Top placed float caption for deterministic page placement.}
+\end{figure}
+\label{fig:top}
+Reference after top figure: \ref{fig:top}.
+\end{document}

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -128,6 +128,12 @@
       "purpose": "Exercises safe includegraphics scale option parsing and deterministic placeholder sizing."
     },
     {
+      "id": "typeset_demo_float_probe_v0",
+      "tags": ["typeset", "float", "figure", "placement", "probe", "ok"],
+      "expected_status": "OK",
+      "purpose": "Exercises deterministic figure placement policy with one top-of-page float and one inline float plus stable float_v0 typed artifacts."
+    },
+    {
       "id": "typeset_demo_graphicspath_probe_v0",
       "tags": ["typeset", "graphics", "graphicspath", "probe", "ni"],
       "expected_status": "NI",

--- a/scripts/wasm_fixture_gallery_v1/main.mjs
+++ b/scripts/wasm_fixture_gallery_v1/main.mjs
@@ -23,7 +23,7 @@ const STATUS_FAIL_V0 = 'FAIL';
 const STATUS_MISMATCH_V0 = 'MISMATCH';
 const EXPECTED_STATUS_VALUES_V0 = new Set([STATUS_OK_V0, STATUS_NI_V0, STATUS_INVALID_V0, STATUS_FAIL_V0]);
 const DEFAULT_ONDEMAND_FIXEDPOINT_MAX_ITERS_V1 = 3;
-const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'refs', 'pageref', 'bib', 'cite', 'bibitems', 'cites', 'hyperref', 'pkgopt', 'packages', 'graphics', 'input', 'math', 'table'];
+const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'refs', 'pageref', 'bib', 'cite', 'bibitems', 'cites', 'hyperref', 'pkgopt', 'packages', 'graphics', 'float', 'input', 'math', 'table'];
 const TYPED_ARTIFACTS_VERSION_V0 = 1;
 const MAX_TOC_ENTRIES_V0 = 256;
 const MAX_TOC_TITLE_BYTES_V0 = 256;
@@ -48,6 +48,8 @@ const DEFAULT_GRAPHICS_PLACEHOLDER_WIDTH_PT_V2 = 180.0;
 const DEFAULT_GRAPHICS_PLACEHOLDER_HEIGHT_PT_V2 = 120.0;
 const MAX_GRAPHICS_PLACEHOLDER_WIDTH_PT_V2 = 468.0;
 const MAX_GRAPHICS_PLACEHOLDER_HEIGHT_PT_V2 = 288.0;
+const MAX_FLOAT_ENTRIES_V0 = 256;
+const MAX_FLOAT_CAPTION_SUMMARY_BYTES_V0 = 128;
 const MAX_INPUT_ENTRIES_V1 = 512;
 const MAX_INPUT_INCLUDE_DEPTH_V1 = 32;
 const MAX_MATH_ENTRIES_V0 = 256;
@@ -93,6 +95,7 @@ const TABLE_SPEC_LINE_PREFIX_V2 = '!ts ';
 const TABLE_ROW_LINE_PREFIX_V2 = '!t ';
 const FIGURE_CAPTION_LINE_PREFIX_V2 = '!gcap ';
 const FIGURE_IMAGE_LINE_PREFIX_V2 = '!gimg ';
+const FIGURE_TOP_PLACEMENT_HINT_V2 = 't';
 const DISPLAY_MATH_PLACEHOLDER_SHORT_V2 = 'MATH DISPLAY';
 const DISPLAY_MATH_PLACEHOLDER_MEDIUM_V2 = 'MATH DISPLAY MEDIUM';
 const DISPLAY_MATH_PLACEHOLDER_LONG_V2 = 'MATH DISPLAY LONG FORM';
@@ -715,6 +718,11 @@ async function loadFixtureCasesV0() {
       id: 'typeset_demo_graphics_scale_probe_v0',
       mode: 'typeset',
       fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_graphics_scale_probe_v0.tex',
+    },
+    {
+      id: 'typeset_demo_float_probe_v0',
+      mode: 'typeset',
+      fixtureRelPath: 'scripts/texlive_smoke/fixtures/typeset_demo_float_probe_v0.tex',
     },
     {
       id: 'typeset_demo_graphicspath_probe_v0',
@@ -1464,6 +1472,21 @@ function lineEqualsAsciiV2(lineBytes, value) {
   return true;
 }
 
+function hasFigureBoxMarkerPrefixV2(lineBytes) {
+  return lineStartsWithAsciiV2(lineBytes, FIGURE_BOX_LINE_V2);
+}
+
+function parseFigurePlacementHintFromFigureBoxLineV0(lineBytes) {
+  if (lineEqualsAsciiV2(lineBytes, FIGURE_BOX_LINE_V2)) {
+    return 'inline';
+  }
+  const topMarker = `${FIGURE_BOX_LINE_V2} ${FIGURE_TOP_PLACEMENT_HINT_V2}`;
+  if (lineEqualsAsciiV2(lineBytes, topMarker)) {
+    return FIGURE_TOP_PLACEMENT_HINT_V2;
+  }
+  return null;
+}
+
 function detectListPrefixLineV2(lineBytes) {
   let leading = 0;
   while (leading < lineBytes.length && lineBytes[leading] === 0x20) {
@@ -1494,7 +1517,7 @@ function isStructuredNonTitleLineV2(lineBytes) {
     || lineStartsWithAsciiV2(lineBytes, '~ ')
     || lineStartsWithAsciiV2(lineBytes, TABLE_SPEC_LINE_PREFIX_V2)
     || lineStartsWithAsciiV2(lineBytes, TABLE_ROW_LINE_PREFIX_V2)
-    || lineEqualsAsciiV2(lineBytes, FIGURE_BOX_LINE_V2)
+    || hasFigureBoxMarkerPrefixV2(lineBytes)
     || lineStartsWithAsciiV2(lineBytes, FIGURE_CAPTION_LINE_PREFIX_V2)
     || lineStartsWithAsciiV2(lineBytes, FIGURE_IMAGE_LINE_PREFIX_V2)
     || lineEqualsAsciiV2(lineBytes, TOC_PLACEHOLDER_MARKER_V2)
@@ -1611,7 +1634,11 @@ function collectNominalAnchorPageNumbersFromBodyPagesV2(bodyPages) {
         continue;
       }
       const lineBytes = lines[lineIndex];
-      const hasAnchor = lineEqualsAsciiV2(lineBytes, FIGURE_BOX_LINE_V2)
+      const figurePlacementHint = parseFigurePlacementHintFromFigureBoxLineV0(lineBytes);
+      if (hasFigureBoxMarkerPrefixV2(lineBytes) && figurePlacementHint === null) {
+        throw new Error(`toc_v2 malformed figure marker line: ${Buffer.from(lineBytes).toString('utf8')}`);
+      }
+      const hasAnchor = figurePlacementHint !== null
         || isDisplayMathPlaceholderLineV2(lineBytes)
         || lineStartsWithAsciiV2(lineBytes, SECTION_HEADING_PREFIX_V2)
         || lineStartsWithAsciiV2(lineBytes, SUBSECTION_HEADING_PREFIX_V2);
@@ -1913,6 +1940,181 @@ function extractTableEntriesFromSourceV1(sourceBytes) {
     index = endIndex + endMarker.length;
   }
   return entries;
+}
+
+function normalizeFloatCaptionSummaryV0(rawCaption) {
+  const normalized = rawCaption.replace(/\s+/g, ' ').trim();
+  const normalizedBytes = Buffer.from(normalized, 'utf8');
+  if (normalizedBytes.length <= MAX_FLOAT_CAPTION_SUMMARY_BYTES_V0) {
+    return normalized;
+  }
+  return `${normalizedBytes.subarray(0, MAX_FLOAT_CAPTION_SUMMARY_BYTES_V0).toString('utf8')}...`;
+}
+
+function parseFigurePlacementHintOptionV0(rawOption) {
+  const normalized = rawOption.replace(/\s+/g, '');
+  if (normalized.length === 0) {
+    throw new Error('float_v0 figure placement option must be non-empty');
+  }
+  if (normalized === FIGURE_TOP_PLACEMENT_HINT_V2) {
+    return FIGURE_TOP_PLACEMENT_HINT_V2;
+  }
+  throw new Error(`float_v0 unsupported figure placement option '${rawOption.trim()}'`);
+}
+
+function extractFloatEntriesFromSourceV0(sourceBytes) {
+  const entries = [];
+  let index = 0;
+
+  while (index < sourceBytes.length) {
+    if (sourceBytes[index] !== 0x5c) {
+      index += 1;
+      continue;
+    }
+    let commandIndex = index + 1;
+    while (commandIndex < sourceBytes.length && isAsciiLetterByteV0(sourceBytes[commandIndex])) {
+      commandIndex += 1;
+    }
+    if (commandIndex === index + 1) {
+      index += 1;
+      continue;
+    }
+    const command = Buffer.from(sourceBytes.slice(index + 1, commandIndex)).toString('ascii');
+    if (command !== 'begin') {
+      index = commandIndex;
+      continue;
+    }
+
+    const envGroup = readBracedGroupV0(sourceBytes, commandIndex);
+    if (!envGroup.ok) {
+      throw new Error('float_v0 malformed \\begin group');
+    }
+    if (envGroup.value.trim() !== 'figure') {
+      index = envGroup.next;
+      continue;
+    }
+
+    const beginIndex = index;
+    let cursor = skipSpacesV0(sourceBytes, envGroup.next);
+    let placementHint = 'inline';
+    const placementGroup = readBracketGroupV0(sourceBytes, cursor);
+    if (placementGroup.ok) {
+      placementHint = parseFigurePlacementHintOptionV0(placementGroup.value);
+      cursor = placementGroup.next;
+    } else if (cursor < sourceBytes.length && sourceBytes[cursor] === 0x5b) {
+      throw new Error('float_v0 malformed figure placement option');
+    }
+
+    let captionSummary = null;
+    let endIndex = -1;
+    while (cursor < sourceBytes.length) {
+      if (sourceBytes[cursor] !== 0x5c) {
+        cursor += 1;
+        continue;
+      }
+      let innerCommandIndex = cursor + 1;
+      while (innerCommandIndex < sourceBytes.length && isAsciiLetterByteV0(sourceBytes[innerCommandIndex])) {
+        innerCommandIndex += 1;
+      }
+      if (innerCommandIndex === cursor + 1) {
+        cursor += 1;
+        continue;
+      }
+      const innerCommand = Buffer.from(sourceBytes.slice(cursor + 1, innerCommandIndex)).toString('ascii');
+      if (innerCommand === 'begin') {
+        throw new Error('float_v0 nested \\begin inside figure is unsupported');
+      }
+      if (innerCommand === 'end') {
+        const endGroup = readBracedGroupV0(sourceBytes, innerCommandIndex);
+        if (!endGroup.ok || endGroup.value.trim() !== 'figure') {
+          throw new Error('float_v0 malformed \\end{figure}');
+        }
+        endIndex = endGroup.next;
+        break;
+      }
+      if (innerCommand === 'caption') {
+        if (captionSummary !== null) {
+          throw new Error('float_v0 duplicate \\caption inside figure');
+        }
+        const captionGroup = readBracedGroupV0(sourceBytes, innerCommandIndex);
+        if (!captionGroup.ok) {
+          throw new Error('float_v0 malformed \\caption group');
+        }
+        const normalizedCaption = normalizeFloatCaptionSummaryV0(captionGroup.value);
+        if (normalizedCaption.length === 0) {
+          throw new Error('float_v0 caption summary must be non-empty');
+        }
+        captionSummary = normalizedCaption;
+        cursor = captionGroup.next;
+        continue;
+      }
+      cursor = innerCommandIndex;
+    }
+
+    if (endIndex < 0) {
+      throw new Error('float_v0 missing \\end{figure}');
+    }
+    if (captionSummary === null) {
+      throw new Error('float_v0 figure requires caption summary');
+    }
+    entries.push({
+      float_id: `flt${entries.length + 1}`,
+      figure_ordinal: entries.length + 1,
+      placement_hint: placementHint,
+      caption_summary: captionSummary,
+      source_span: buildSourceSpanV0(sourceBytes, beginIndex, endIndex, 'float_v0'),
+    });
+    if (entries.length > MAX_FLOAT_ENTRIES_V0) {
+      throw new Error(`float_v0 entries exceed cap ${MAX_FLOAT_ENTRIES_V0}`);
+    }
+    index = endIndex;
+  }
+
+  return entries;
+}
+
+function collectFloatOutputSnapshotV0(xdvBytes) {
+  const pages = parseDviTextPagesForTocV2(xdvBytes);
+  const { bodyPages } = splitBodyAndMetadataLinesV2(pages);
+  if (bodyPages.length <= 0) {
+    throw new Error('float_v0 requires at least one body page');
+  }
+  const figureEntries = [];
+  let nextAnchorId = 1;
+  for (let pageIndex = 0; pageIndex < bodyPages.length; pageIndex += 1) {
+    const lines = bodyPages[pageIndex];
+    const titleBlockLen = pageIndex === 0 ? detectTitleBlockLenV2(lines) : 0;
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+      if (lineIndex < titleBlockLen) {
+        continue;
+      }
+      const lineBytes = lines[lineIndex];
+      const figurePlacementHint = parseFigurePlacementHintFromFigureBoxLineV0(lineBytes);
+      if (hasFigureBoxMarkerPrefixV2(lineBytes) && figurePlacementHint === null) {
+        throw new Error(`float_v0 malformed figure marker line: ${Buffer.from(lineBytes).toString('utf8')}`);
+      }
+      const hasAnchor = figurePlacementHint !== null
+        || isDisplayMathPlaceholderLineV2(lineBytes)
+        || lineStartsWithAsciiV2(lineBytes, SECTION_HEADING_PREFIX_V2)
+        || lineStartsWithAsciiV2(lineBytes, SUBSECTION_HEADING_PREFIX_V2);
+      if (!hasAnchor) {
+        continue;
+      }
+      const anchorId = nextAnchorId;
+      nextAnchorId += 1;
+      if (figurePlacementHint !== null) {
+        figureEntries.push({
+          anchor_id: anchorId,
+          placement_hint: figurePlacementHint,
+          page_no: pageIndex + 1,
+        });
+      }
+    }
+  }
+  return {
+    entries: figureEntries,
+    page_count: bodyPages.length,
+  };
 }
 
 function splitCommaValuesV0(rawValue) {
@@ -4012,8 +4214,15 @@ async function emitPagerefTypedArtifactV2(caseOutDir, fixtureBytes, mountedFiles
 }
 
 async function emitTocTypedArtifactV2(caseOutDir, fixtureBytes, xdvBytes) {
+  const caseId = path.basename(caseOutDir);
   const sourceEntries = extractTocEntriesFromSourceV0(fixtureBytes);
-  const outputSnapshot = collectTocOutputSnapshotV2(xdvBytes);
+  let outputSnapshot;
+  try {
+    outputSnapshot = collectTocOutputSnapshotV2(xdvBytes);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`toc_v2 case=${caseId} xdv_bytes=${xdvBytes.length}: ${message}`);
+  }
   const outputByAnchorId = new Map();
   for (const entry of outputSnapshot.tocEntries) {
     outputByAnchorId.set(entry.anchor_id, entry);
@@ -4222,6 +4431,50 @@ async function emitGraphicsTypedArtifactV0(caseOutDir, fixtureBytes) {
   };
 }
 
+async function emitFloatTypedArtifactV0(caseOutDir, fixtureBytes, xdvBytes) {
+  const sourceEntries = extractFloatEntriesFromSourceV0(fixtureBytes);
+  const outputSnapshot = collectFloatOutputSnapshotV0(xdvBytes);
+  if (sourceEntries.length !== outputSnapshot.entries.length) {
+    throw new Error(
+      `float_v0 source/output figure count mismatch (${sourceEntries.length} vs ${outputSnapshot.entries.length})`,
+    );
+  }
+  const entries = sourceEntries.map((sourceEntry, index) => {
+    const outputEntry = outputSnapshot.entries[index];
+    if (!outputEntry || !Number.isInteger(outputEntry.anchor_id) || outputEntry.anchor_id <= 0) {
+      throw new Error(`float_v0 invalid output anchor for entry ${index + 1}`);
+    }
+    if (sourceEntry.placement_hint !== outputEntry.placement_hint) {
+      throw new Error(
+        `float_v0 placement mismatch for entry ${index + 1}: ${sourceEntry.placement_hint} vs ${outputEntry.placement_hint}`,
+      );
+    }
+    if (!Number.isInteger(outputEntry.page_no) || outputEntry.page_no <= 0 || outputEntry.page_no > outputSnapshot.page_count) {
+      throw new Error(`float_v0 invalid page_no for entry ${index + 1}: ${outputEntry.page_no}`);
+    }
+    return {
+      ...sourceEntry,
+      anchor_id: outputEntry.anchor_id,
+      page_no: outputEntry.page_no,
+    };
+  });
+  const payload = {
+    version: TYPED_ARTIFACTS_VERSION_V0,
+    schema: 'float_v0',
+    entries,
+  };
+  const bytes = Buffer.from(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  const relpath = 'float_v0.json';
+  const fullPath = path.join(caseOutDir, relpath);
+  await writeFile(fullPath, bytes);
+  return {
+    present: true,
+    items: payload.entries.length,
+    artifact_relpath: relpath,
+    artifact_sha256: sha256HexV0(bytes),
+  };
+}
+
 async function emitMathTypedArtifactV0(caseOutDir, fixtureBytes) {
   const payload = {
     version: TYPED_ARTIFACTS_VERSION_V0,
@@ -4361,6 +4614,9 @@ async function emitTypedArtifactsV0(
     || caseSpec.id === 'typeset_demo_graphics_scale_probe_v0'
   ) {
     typedArtifacts.graphics = await emitGraphicsTypedArtifactV0(caseOutDir, fixtureBytes);
+  }
+  if (caseSpec.id === 'typeset_demo_float_probe_v0') {
+    typedArtifacts.float = await emitFloatTypedArtifactV0(caseOutDir, fixtureBytes, xdvBytes);
   }
   if (caseSpec.mode === 'typeset' && Array.isArray(inputEntries) && inputEntries.length > 0) {
     typedArtifacts.input = await emitInputTypedArtifactV1(caseOutDir, inputEntries);
@@ -4944,15 +5200,24 @@ async function runCaseV0(
     errorMessage = errorMessage ? `${errorMessage}; ${message}` : message;
     summary.status = caseStatus;
   }
-  await emitTypedArtifactsV0(
-    caseSpec,
-    caseOutDir,
-    summary.typed_artifacts,
-    fixtureBytes,
-    inputInclusionGraph.mounted_files,
-    inputInclusionGraph.entries,
-    xdvBytes,
-  );
+  try {
+    await emitTypedArtifactsV0(
+      caseSpec,
+      caseOutDir,
+      summary.typed_artifacts,
+      fixtureBytes,
+      inputInclusionGraph.mounted_files,
+      inputInclusionGraph.entries,
+      xdvBytes,
+    );
+  } catch (error) {
+    caseStatus = STATUS_INVALID_V0;
+    summary.status = caseStatus;
+    summary.typed_artifacts = buildTypedArtifactsPlaceholderV0();
+    const message = error instanceof Error ? error.message : String(error);
+    const typedArtifactsMessage = `typed_artifacts: ${message}`;
+    errorMessage = errorMessage ? `${errorMessage}; ${typedArtifactsMessage}` : typedArtifactsMessage;
+  }
   const typedArtifactRequests = await collectResolverRequestsFromResourceHintsV0(
     caseSpec,
     caseOutDir,

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
@@ -685,6 +685,83 @@ for (const entry of graphicsArtifactFirst.entries) {
 assertEntrySourceSpans('typeset_demo_graphics_probe_v0', 'graphics_v2', graphicsArtifactFirst.entries);
 fs.writeFileSync(firstRunShaPath('graphics_v2'), `${graphicsShaFirst}\n`);
 
+const floatSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_float_probe_v0', 'summary.json'), 'utf8'),
+);
+if (floatSummary?.typed_artifacts?.float?.present !== true) {
+  console.error('FAIL: expected float typed artifact present after first run');
+  process.exit(1);
+}
+const floatPath = path.join(outDir, 'typeset_demo_float_probe_v0', 'float_v0.json');
+if (!fs.existsSync(floatPath)) {
+  console.error('FAIL: expected float_v0.json artifact after first run');
+  process.exit(1);
+}
+const floatShaFirst = floatSummary.typed_artifacts.float.artifact_sha256;
+if (typeof floatShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(floatShaFirst)) {
+  console.error('FAIL: expected float artifact sha256 in first summary');
+  process.exit(1);
+}
+const floatArtifactFirst = JSON.parse(fs.readFileSync(floatPath, 'utf8'));
+if (!Array.isArray(floatArtifactFirst?.entries)) {
+  console.error('FAIL: expected float_v0.entries array in first-run artifact');
+  process.exit(1);
+}
+if (floatArtifactFirst?.schema !== 'float_v0') {
+  console.error('FAIL: expected float_v0 schema in first-run artifact');
+  process.exit(1);
+}
+if (floatArtifactFirst.entries.length <= 0) {
+  console.error('FAIL: expected non-empty float_v0.entries for float probe');
+  process.exit(1);
+}
+let sawTopPlacement = false;
+let sawInlinePlacement = false;
+const floatPageNos = new Set();
+for (const [index, entry] of floatArtifactFirst.entries.entries()) {
+  if (typeof entry?.float_id !== 'string' || !/^flt[1-9]\d*$/.test(entry.float_id)) {
+    console.error(`FAIL: float_v0.entries[${index}] invalid float_id`);
+    process.exit(1);
+  }
+  if (!Number.isInteger(entry?.figure_ordinal) || entry.figure_ordinal !== index + 1) {
+    console.error(`FAIL: float_v0.entries[${index}] invalid figure_ordinal`);
+    process.exit(1);
+  }
+  if (!(entry?.placement_hint === 'inline' || entry?.placement_hint === 't')) {
+    console.error(`FAIL: float_v0.entries[${index}] invalid placement_hint`);
+    process.exit(1);
+  }
+  if (entry.placement_hint === 't') {
+    sawTopPlacement = true;
+  }
+  if (entry.placement_hint === 'inline') {
+    sawInlinePlacement = true;
+  }
+  if (typeof entry?.caption_summary !== 'string' || entry.caption_summary.trim().length === 0) {
+    console.error(`FAIL: float_v0.entries[${index}] invalid caption_summary`);
+    process.exit(1);
+  }
+  if (!Number.isInteger(entry?.anchor_id) || entry.anchor_id <= 0) {
+    console.error(`FAIL: float_v0.entries[${index}] invalid anchor_id`);
+    process.exit(1);
+  }
+  if (!Number.isInteger(entry?.page_no) || entry.page_no <= 0) {
+    console.error(`FAIL: float_v0.entries[${index}] invalid page_no`);
+    process.exit(1);
+  }
+  floatPageNos.add(entry.page_no);
+}
+if (!sawTopPlacement || !sawInlinePlacement) {
+  console.error('FAIL: expected float_v0 entries to include both top and inline placements');
+  process.exit(1);
+}
+if (floatPageNos.size < 2) {
+  console.error('FAIL: expected float_v0 entries to span at least two pages');
+  process.exit(1);
+}
+assertEntrySourceSpans('typeset_demo_float_probe_v0', 'float_v0', floatArtifactFirst.entries);
+fs.writeFileSync(firstRunShaPath('float_v0'), `${floatShaFirst}\n`);
+
 const mathSummary = JSON.parse(
   fs.readFileSync(path.join(outDir, 'typeset_demo_minimal_v0', 'summary.json'), 'utf8'),
 );
@@ -897,7 +974,7 @@ if (!typedArtifactShaMap || typeof typedArtifactShaMap !== 'object') {
   console.error('FAIL: expected report.typed_artifact_sha256 map after first run');
   process.exit(1);
 }
-const typedKeys = ['toc', 'labels', 'bib', 'cite', 'pageref', 'hyperref', 'pkgopt', 'packages', 'graphics', 'input', 'math', 'table'];
+const typedKeys = ['toc', 'labels', 'bib', 'cite', 'pageref', 'hyperref', 'pkgopt', 'packages', 'graphics', 'float', 'input', 'math', 'table'];
 for (const key of typedKeys) {
   const value = typedArtifactShaMap[key];
   if (typeof value !== 'string' || !/^[0-9a-f]{64}$/.test(value)) {

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
@@ -63,7 +63,7 @@ if (resourceHintsShaSecond !== resourceHintsShaFirst) {
   console.error('FAIL: report.resource_hints_v0 must be stable across reruns');
   process.exit(1);
 }
-const requiredTypedKeys = ['toc', 'labels', 'refs', 'pageref', 'bib', 'cite', 'hyperref', 'pkgopt', 'packages', 'graphics', 'input', 'math', 'table'];
+const requiredTypedKeys = ['toc', 'labels', 'refs', 'pageref', 'bib', 'cite', 'hyperref', 'pkgopt', 'packages', 'graphics', 'float', 'input', 'math', 'table'];
 const labelsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'labels_v1_first.sha256'), 'utf8').trim();
 const refsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'refs_v1_first.sha256'), 'utf8').trim();
 const pagerefShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'pageref_v2_first.sha256'), 'utf8').trim();
@@ -74,6 +74,7 @@ const hyperrefShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'hyperr
 const pkgoptShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'pkgopt_v0_first.sha256'), 'utf8').trim();
 const packagesShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'packages_v1_first.sha256'), 'utf8').trim();
 const graphicsShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'graphics_v2_first.sha256'), 'utf8').trim();
+const floatShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'float_v0_first.sha256'), 'utf8').trim();
 const mathShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'math_v2_first.sha256'), 'utf8').trim();
 const tableShaFirst = fs.readFileSync(path.join(`${outDir}_baseline`, 'table_v2_first.sha256'), 'utf8').trim();
 
@@ -583,6 +584,31 @@ if (!Array.isArray(graphicsArtifactSecond?.entries) || graphicsArtifactSecond.en
   process.exit(1);
 }
 
+const floatSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_float_probe_v0', 'summary.json'), 'utf8'),
+);
+const floatArtifact = floatSummary?.typed_artifacts?.float;
+if (!floatArtifact || floatArtifact.present !== true) {
+  console.error('FAIL: expected float typed artifact present after second run');
+  process.exit(1);
+}
+const floatShaSecond = floatArtifact.artifact_sha256;
+if (floatShaSecond !== floatShaFirst) {
+  console.error('FAIL: float_v0 artifact sha256 must be stable across reruns');
+  process.exit(1);
+}
+const floatArtifactSecond = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_float_probe_v0', 'float_v0.json'), 'utf8'),
+);
+if (!Array.isArray(floatArtifactSecond?.entries) || floatArtifactSecond.entries.length <= 0) {
+  console.error('FAIL: expected non-empty float_v0.entries after rerun');
+  process.exit(1);
+}
+if (floatArtifactSecond?.schema !== 'float_v0') {
+  console.error('FAIL: expected float_v0 schema after rerun');
+  process.exit(1);
+}
+
 const mathSummary = JSON.parse(
   fs.readFileSync(path.join(outDir, 'typeset_demo_minimal_v0', 'summary.json'), 'utf8'),
 );
@@ -696,6 +722,7 @@ console.log(`PASS: hyperref_v0 sha stable ${hyperrefShaSecond}`);
 console.log(`PASS: pkgopt_v0 sha stable ${pkgoptShaSecond}`);
 console.log(`PASS: packages_v1 sha stable ${packagesShaSecond}`);
 console.log(`PASS: graphics_v2 sha stable ${graphicsShaSecond}`);
+console.log(`PASS: float_v0 sha stable ${floatShaSecond}`);
 console.log(`PASS: math_v2 sha stable ${mathShaSecond}`);
 console.log(`PASS: table_v2 sha stable ${tableShaSecond}`);
 console.log('PASS: report typed_artifact_sha256 map present and stable');


### PR DESCRIPTION
## Summary
- implement float layout v0 placement policy for `figure` with deterministic `[t]` handling and `!gbox t` marker emission
- extend xdv/pdf parsing to accept and validate top-placement figure markers fail-closed
- add float probe fixture + `float_v0` typed artifact extraction and proof-gate checks
- harden fixture-gallery `runCaseV0` typed-artifact emission path with fail-closed per-case error handling instead of hard-abort

## Proofs
- `cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests`
- `cargo test --manifest-path crates/carreltex-xdv/Cargo.toml`
- `./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12`
- `./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25`

Closes #415
