### PR TITLE
package seam convergence v1 (amsmath + CJK probes)

### DIFF
--- a/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_minimal_v0_tests.rs
@@ -86,6 +86,14 @@ fn typeset_minimal_accepts_package_class_capture_preamble_commands_v1() {
 }
 
 #[test]
+fn typeset_minimal_accepts_setcjkmainfont_preamble_declaration_as_noop_v1() {
+    let main = b"\\documentclass{article}\\usepackage{xeCJK}\\setCJKmainfont{FoundSans}\\begin{document}CJK seam probe body.\\end{document}";
+    let result = compile_typeset(main);
+    assert_eq!(result.status, CompileStatus::Ok);
+    assert!(!result.main_xdv_bytes.is_empty());
+}
+
+#[test]
 fn typeset_minimal_rejects_unsafe_documentclass_path_v1() {
     let main = b"\\documentclass{../evil}\\begin{document}Body\\end{document}";
     let result = compile_typeset(main);

--- a/crates/carreltex-engine/src/compile_v0/typeset_v0/extract.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_v0/extract.rs
@@ -54,6 +54,9 @@ pub(crate) fn extract_typeset_minimal_text_body_with_external_bib_v0(
             {
                 index = consume_pass_options_declaration_noop_v0(tokens, index)?;
             }
+            Some(TokenV0::ControlSeq(name)) if name.as_slice() == SETCJKMAINFONT_CONTROL_V0 => {
+                index = consume_setcjkmainfont_declaration_noop_v0(tokens, index)?;
+            }
             Some(TokenV0::ControlSeq(name)) if name.as_slice() == INCLUDEONLY_CONTROL_V0 => {
                 index = consume_includeonly_declaration_noop_v0(tokens, index)?;
             }

--- a/crates/carreltex-engine/src/compile_v0/typeset_v0/mod.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_v0/mod.rs
@@ -30,6 +30,7 @@ const REQUIREPACKAGE_CONTROL_V0: &[u8] = b"RequirePackage";
 const REQUIREPACKAGEWITHOPTIONS_CONTROL_V0: &[u8] = b"RequirePackageWithOptions";
 const PASSOPTIONSTOPACKAGE_CONTROL_V0: &[u8] = b"PassOptionsToPackage";
 const PASSOPTIONSTOCLASS_CONTROL_V0: &[u8] = b"PassOptionsToClass";
+const SETCJKMAINFONT_CONTROL_V0: &[u8] = b"setCJKmainfont";
 const ADDBIBRESOURCE_CONTROL_V0: &[u8] = b"addbibresource";
 const PRINTBIBLIOGRAPHY_CONTROL_V0: &[u8] = b"printbibliography";
 const CAPTION_CONTROL_V0: &[u8] = b"caption";

--- a/crates/carreltex-engine/src/compile_v0/typeset_v0/preamble.rs
+++ b/crates/carreltex-engine/src/compile_v0/typeset_v0/preamble.rs
@@ -312,3 +312,19 @@ fn consume_includeonly_declaration_noop_v0(tokens: &[TokenV0], index: usize) -> 
     validate_non_empty_comma_values_v0(&raw_group)?;
     Some(next)
 }
+
+fn consume_setcjkmainfont_declaration_noop_v0(tokens: &[TokenV0], index: usize) -> Option<usize> {
+    if !matches!(
+        tokens.get(index),
+        Some(TokenV0::ControlSeq(name)) if name.as_slice() == SETCJKMAINFONT_CONTROL_V0
+    ) {
+        return None;
+    }
+    let cursor = consume_simple_bracket_non_empty(tokens, index + 1)?;
+    let (group_start, group_end, next) = consume_group_bounds(tokens, cursor)?;
+    let font_value = parse_char_space_group_trimmed_v0(tokens, group_start, group_end)?;
+    if font_value.is_empty() {
+        return None;
+    }
+    Some(next)
+}

--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -51,15 +51,15 @@
     },
     {
       "id": "typeset_demo_cjk_probe_v0",
-      "tags": ["typeset", "cjk", "font", "probe", "ni"],
-      "expected_status": "NI",
-      "purpose": "Probes CJK package/font seam for on-demand package request generation."
+      "tags": ["typeset", "cjk", "font", "probe", "ok"],
+      "expected_status": "OK",
+      "purpose": "Exercises deterministic CJK package/font seam capture with stable package/resource request mapping."
     },
     {
       "id": "typeset_demo_math_probe_v0",
-      "tags": ["typeset", "math", "amsmath", "probe", "ni"],
-      "expected_status": "NI",
-      "purpose": "Probes amsmath package seam for on-demand package request generation."
+      "tags": ["typeset", "math", "amsmath", "probe", "ok"],
+      "expected_status": "OK",
+      "purpose": "Exercises deterministic amsmath package seam capture with stable package/resource request mapping."
     },
     {
       "id": "typeset_demo_math_short_probe_v0",

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
@@ -467,6 +467,76 @@ if (typeof packagesShaFirst !== 'string' || !/^[0-9a-f]{64}$/.test(packagesShaFi
 }
 fs.writeFileSync(firstRunShaPath('packages_v1'), `${packagesShaFirst}\n`);
 
+const mathProbeSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_math_probe_v0', 'summary.json'), 'utf8'),
+);
+if (mathProbeSummary?.status !== 'OK' || mathProbeSummary?.compile_status !== 'OK') {
+  console.error('FAIL: expected typeset_demo_math_probe_v0 status/compile_status OK after first run');
+  process.exit(1);
+}
+if (mathProbeSummary?.typed_artifacts?.packages?.present !== true) {
+  console.error('FAIL: expected packages_v1 artifact present for typeset_demo_math_probe_v0 after first run');
+  process.exit(1);
+}
+const mathProbePackagesArtifact = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_math_probe_v0', 'packages_v1.json'), 'utf8'),
+);
+if (!Array.isArray(mathProbePackagesArtifact?.entries) || mathProbePackagesArtifact.entries.length <= 0) {
+  console.error('FAIL: expected non-empty packages_v1 entries for typeset_demo_math_probe_v0');
+  process.exit(1);
+}
+if (!mathProbePackagesArtifact.entries.some((entry) => entry.name === 'amsmath.sty')) {
+  console.error('FAIL: expected typeset_demo_math_probe_v0 packages_v1 entries to include amsmath.sty');
+  process.exit(1);
+}
+assertEntrySourceSpans('typeset_demo_math_probe_v0', 'packages_v1', mathProbePackagesArtifact.entries);
+const mathProbeResourceHintsArtifact = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_math_probe_v0', 'resource_hints_v0.json'), 'utf8'),
+);
+if (!Array.isArray(mathProbeResourceHintsArtifact?.entries)) {
+  console.error('FAIL: expected resource_hints_v0.entries for typeset_demo_math_probe_v0');
+  process.exit(1);
+}
+if (!mathProbeResourceHintsArtifact.entries.some((entry) => entry.hint_type === 'package_file' && entry.value === 'amsmath.sty')) {
+  console.error('FAIL: expected typeset_demo_math_probe_v0 resource_hints_v0 package_file=amsmath.sty');
+  process.exit(1);
+}
+
+const cjkProbeSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_cjk_probe_v0', 'summary.json'), 'utf8'),
+);
+if (cjkProbeSummary?.status !== 'OK' || cjkProbeSummary?.compile_status !== 'OK') {
+  console.error('FAIL: expected typeset_demo_cjk_probe_v0 status/compile_status OK after first run');
+  process.exit(1);
+}
+if (cjkProbeSummary?.typed_artifacts?.packages?.present !== true) {
+  console.error('FAIL: expected packages_v1 artifact present for typeset_demo_cjk_probe_v0 after first run');
+  process.exit(1);
+}
+const cjkProbePackagesArtifact = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_cjk_probe_v0', 'packages_v1.json'), 'utf8'),
+);
+if (!Array.isArray(cjkProbePackagesArtifact?.entries) || cjkProbePackagesArtifact.entries.length <= 0) {
+  console.error('FAIL: expected non-empty packages_v1 entries for typeset_demo_cjk_probe_v0');
+  process.exit(1);
+}
+if (!cjkProbePackagesArtifact.entries.some((entry) => entry.name === 'xeCJK.sty')) {
+  console.error('FAIL: expected typeset_demo_cjk_probe_v0 packages_v1 entries to include xeCJK.sty');
+  process.exit(1);
+}
+assertEntrySourceSpans('typeset_demo_cjk_probe_v0', 'packages_v1', cjkProbePackagesArtifact.entries);
+const cjkProbeResourceHintsArtifact = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_cjk_probe_v0', 'resource_hints_v0.json'), 'utf8'),
+);
+if (!Array.isArray(cjkProbeResourceHintsArtifact?.entries)) {
+  console.error('FAIL: expected resource_hints_v0.entries for typeset_demo_cjk_probe_v0');
+  process.exit(1);
+}
+if (!cjkProbeResourceHintsArtifact.entries.some((entry) => entry.hint_type === 'package_file' && entry.value === 'xeCJK.sty')) {
+  console.error('FAIL: expected typeset_demo_cjk_probe_v0 resource_hints_v0 package_file=xeCJK.sty');
+  process.exit(1);
+}
+
 const packageMultiCaptureArtifact = JSON.parse(
   fs.readFileSync(path.join(outDir, 'typeset_demo_usepackage_multi_capture_probe_v1', 'packages_v1.json'), 'utf8'),
 );

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
@@ -162,6 +162,24 @@ if (!mathInvalidStatus || mathInvalidStatus.status !== 'INVALID') {
   console.error('FAIL: expected typeset_demo_math_invalid_payload_probe_v0 status INVALID');
   process.exit(1);
 }
+const mathProbeStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_math_probe_v0');
+if (!mathProbeStatus || mathProbeStatus.status !== 'OK') {
+  console.error('FAIL: expected typeset_demo_math_probe_v0 status OK');
+  process.exit(1);
+}
+if (mathProbeStatus?.typed_artifacts_presence?.packages !== true) {
+  console.error('FAIL: expected typeset_demo_math_probe_v0 typed_artifacts_presence.packages=true');
+  process.exit(1);
+}
+const cjkProbeStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_cjk_probe_v0');
+if (!cjkProbeStatus || cjkProbeStatus.status !== 'OK') {
+  console.error('FAIL: expected typeset_demo_cjk_probe_v0 status OK');
+  process.exit(1);
+}
+if (cjkProbeStatus?.typed_artifacts_presence?.packages !== true) {
+  console.error('FAIL: expected typeset_demo_cjk_probe_v0 typed_artifacts_presence.packages=true');
+  process.exit(1);
+}
 const pagerefStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_pageref_probe_v2');
 if (!pagerefStatus || pagerefStatus.status !== 'OK') {
   console.error('FAIL: expected typeset_demo_pageref_probe_v2 status OK');
@@ -560,6 +578,20 @@ if (!rerunHyperrefPackage) {
 }
 if (JSON.stringify(rerunHyperrefPackage.options) !== JSON.stringify(['unicode'])) {
   console.error('FAIL: expected packages_v1 rerun options for hyperref.sty to remain [unicode]');
+  process.exit(1);
+}
+const mathProbePackagesRerun = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_math_probe_v0', 'packages_v1.json'), 'utf8'),
+);
+if (!Array.isArray(mathProbePackagesRerun?.entries) || !mathProbePackagesRerun.entries.some((entry) => entry.name === 'amsmath.sty')) {
+  console.error('FAIL: expected typeset_demo_math_probe_v0 packages_v1 rerun entries to include amsmath.sty');
+  process.exit(1);
+}
+const cjkProbePackagesRerun = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_cjk_probe_v0', 'packages_v1.json'), 'utf8'),
+);
+if (!Array.isArray(cjkProbePackagesRerun?.entries) || !cjkProbePackagesRerun.entries.some((entry) => entry.name === 'xeCJK.sty')) {
+  console.error('FAIL: expected typeset_demo_cjk_probe_v0 packages_v1 rerun entries to include xeCJK.sty');
   process.exit(1);
 }
 

--- a/scripts/wasm_fixture_gallery_v1/typed_artifacts_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v1/typed_artifacts_v0.mjs
@@ -111,6 +111,8 @@ const RESOURCE_HINT_TYPE_ALLOWLIST_V0 = new Set([
 const PACKAGE_ARTIFACT_CASE_IDS_V1 = new Set([
   'typeset_demo_hyperref_probe_v0',
   'typeset_demo_hyperref_links_probe_v0',
+  'typeset_demo_math_probe_v0',
+  'typeset_demo_cjk_probe_v0',
   'typeset_demo_package_require_probe_v0',
   'typeset_demo_usepackage_opts_multi_probe_v0',
   'typeset_demo_usepackage_multipackage_probe_v0',


### PR DESCRIPTION
Closes #427

## Summary
- reclassify `typeset_demo_math_probe_v0` from `NI` to delivered deterministic `OK`
- reclassify `typeset_demo_cjk_probe_v0` from `NI` to delivered deterministic `OK`
- add strict preamble seam support for `\setCJKmainfont{...}` as a no-op declaration path (no typography expansion)
- align gallery manifest + typed-artifact emission + proof steps so status/report behavior matches delivered runtime behavior
- preserve deterministic typed-artifact/source-span/resource-hint outputs and fail-closed gallery gates

## Focused Proofs
- PASS: `cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests`
- PASS: `cargo test --manifest-path crates/carreltex-xdv/Cargo.toml`
- PASS: `./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12`
- PASS: `./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25`
