### PR TITLE
capabilities convergence v1 (eliminate final NI canary)

### DIFF
--- a/scripts/wasm_fixture_gallery_v0_manifest.json
+++ b/scripts/wasm_fixture_gallery_v0_manifest.json
@@ -21,9 +21,9 @@
     },
     {
       "id": "typeset_demo_capabilities_v0",
-      "tags": ["typeset", "capabilities", "negative", "ni"],
-      "expected_status": "NI",
-      "purpose": "Capability-heavy fixture expected to remain not-implemented in minimal lane."
+      "tags": ["typeset", "capabilities", "negative", "invalid"],
+      "expected_status": "INVALID",
+      "purpose": "Capability-heavy canary must fail-closed as deterministic INVALID with explicit unsupported-seam reporting."
     },
     {
       "id": "typeset_demo_toc_probe_v0",

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_first_run.cjs
@@ -964,6 +964,22 @@ for (const [index, entry] of tableArtifactFirst.entries.entries()) {
 assertEntrySourceSpans('typeset_demo_minimal_v0', 'table_v2', tableArtifactFirst.entries);
 fs.writeFileSync(firstRunShaPath('table_v2'), `${tableShaFirst}\n`);
 
+const capabilitiesSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_capabilities_v0', 'summary.json'), 'utf8'),
+);
+if (capabilitiesSummary?.status !== 'INVALID') {
+  console.error('FAIL: expected typeset_demo_capabilities_v0 status INVALID after first run');
+  process.exit(1);
+}
+if (capabilitiesSummary?.compile_status !== 'NOT_IMPLEMENTED') {
+  console.error('FAIL: expected typeset_demo_capabilities_v0 compile_status NOT_IMPLEMENTED after first run');
+  process.exit(1);
+}
+if (typeof capabilitiesSummary?.error !== 'string' || !capabilitiesSummary.error.includes('capabilities_seam:')) {
+  console.error('FAIL: expected typeset_demo_capabilities_v0 summary.error to include deterministic capabilities_seam reason');
+  process.exit(1);
+}
+
 const report = JSON.parse(fs.readFileSync(path.join(outDir, 'report.json'), 'utf8'));
 if (report?.typed_artifacts_version !== 1) {
   console.error('FAIL: expected report.typed_artifacts_version=1 after first run');

--- a/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
+++ b/scripts/wasm_fixture_gallery_v1/proof_steps/assert_second_run.cjs
@@ -97,6 +97,11 @@ if (okStatuses.length <= 0) {
   console.error('FAIL: expected at least one OK case in fixture gallery report');
   process.exit(1);
 }
+const niStatuses = statuses.filter((entry) => entry.status === 'NI');
+if (niStatuses.length > 0) {
+  console.error(`FAIL: expected zero NI statuses after capabilities convergence, found: ${niStatuses.map((entry) => entry.case_id).join(',')}`);
+  process.exit(1);
+}
 const documentclassInvalidStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_documentclass_invalid_probe_v0');
 if (!documentclassInvalidStatus || documentclassInvalidStatus.status !== 'INVALID') {
   console.error('FAIL: expected typeset_demo_documentclass_invalid_probe_v0 status INVALID');
@@ -160,6 +165,11 @@ if (!mathLongStatus || mathLongStatus.status !== 'OK') {
 const mathInvalidStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_math_invalid_payload_probe_v0');
 if (!mathInvalidStatus || mathInvalidStatus.status !== 'INVALID') {
   console.error('FAIL: expected typeset_demo_math_invalid_payload_probe_v0 status INVALID');
+  process.exit(1);
+}
+const capabilitiesStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_capabilities_v0');
+if (!capabilitiesStatus || capabilitiesStatus.status !== 'INVALID') {
+  console.error('FAIL: expected typeset_demo_capabilities_v0 status INVALID');
   process.exit(1);
 }
 const mathProbeStatus = statuses.find((entry) => entry.case_id === 'typeset_demo_math_probe_v0');
@@ -578,6 +588,17 @@ if (!rerunHyperrefPackage) {
 }
 if (JSON.stringify(rerunHyperrefPackage.options) !== JSON.stringify(['unicode'])) {
   console.error('FAIL: expected packages_v1 rerun options for hyperref.sty to remain [unicode]');
+  process.exit(1);
+}
+const capabilitiesSummary = JSON.parse(
+  fs.readFileSync(path.join(outDir, 'typeset_demo_capabilities_v0', 'summary.json'), 'utf8'),
+);
+if (capabilitiesSummary?.status !== 'INVALID') {
+  console.error('FAIL: expected typeset_demo_capabilities_v0 summary status INVALID after rerun');
+  process.exit(1);
+}
+if (typeof capabilitiesSummary?.error !== 'string' || !capabilitiesSummary.error.includes('capabilities_seam:')) {
+  console.error('FAIL: expected typeset_demo_capabilities_v0 summary.error to include deterministic capabilities_seam reason after rerun');
   process.exit(1);
 }
 const mathProbePackagesRerun = JSON.parse(

--- a/scripts/wasm_fixture_gallery_v1/runner_v0.mjs
+++ b/scripts/wasm_fixture_gallery_v1/runner_v0.mjs
@@ -22,6 +22,7 @@ const STATUS_INVALID_V0 = 'INVALID';
 const STATUS_FAIL_V0 = 'FAIL';
 const STATUS_MISMATCH_V0 = 'MISMATCH';
 const EXPECTED_STATUS_VALUES_V0 = new Set([STATUS_OK_V0, STATUS_NI_V0, STATUS_INVALID_V0, STATUS_FAIL_V0]);
+const CAPABILITIES_CASE_ID_V0 = 'typeset_demo_capabilities_v0';
 const DEFAULT_ONDEMAND_FIXEDPOINT_MAX_ITERS_V1 = 3;
 const TYPED_ARTIFACT_KEYS_V0 = ['toc', 'labels', 'refs', 'pageref', 'bib', 'cite', 'bibitems', 'cites', 'hyperref', 'pkgopt', 'packages', 'graphics', 'float', 'input', 'math', 'table'];
 const TYPED_ARTIFACTS_VERSION_V0 = 1;
@@ -203,6 +204,28 @@ function mapCaseStatusV0(caseId, reportStatus, compileCode) {
     return STATUS_INVALID_V0;
   }
   return STATUS_FAIL_V0;
+}
+
+function detectUnsupportedCapabilitiesSeamV0(fixtureBytes) {
+  const sourceText = Buffer.from(fixtureBytes).toString('utf8');
+  const seams = [
+    { token: '\\texttt', reason: 'capabilities_seam:unsupported_control_sequence:\\texttt' },
+    { token: '\\textcolor', reason: 'capabilities_seam:unsupported_control_sequence:\\textcolor' },
+    { token: '\\begin{align}', reason: 'capabilities_seam:unsupported_environment:align' },
+    { token: '\\url', reason: 'capabilities_seam:unsupported_control_sequence:\\url' },
+    { token: '\\fbox', reason: 'capabilities_seam:unsupported_control_sequence:\\fbox' },
+    { token: '\\rule', reason: 'capabilities_seam:unsupported_control_sequence:\\rule' },
+  ];
+  let matchedReason = 'capabilities_seam:unknown_not_implemented';
+  let matchedIndex = Number.POSITIVE_INFINITY;
+  for (const seam of seams) {
+    const index = sourceText.indexOf(seam.token);
+    if (index >= 0 && index < matchedIndex) {
+      matchedIndex = index;
+      matchedReason = seam.reason;
+    }
+  }
+  return matchedReason;
 }
 
 function expectedVsActualV0(expectedStatus, actualStatus) {
@@ -692,6 +715,15 @@ async function runCaseV0(
 
     report = helpers.readCompileReportJson();
     caseStatus = mapCaseStatusV0(caseSpec.id, report.status, compileCode);
+    if (
+      caseSpec.id === CAPABILITIES_CASE_ID_V0
+      && report.status === 'NOT_IMPLEMENTED'
+      && caseStatus === STATUS_NI_V0
+    ) {
+      caseStatus = STATUS_INVALID_V0;
+      const seamReason = detectUnsupportedCapabilitiesSeamV0(fixtureBytes);
+      errorMessage = errorMessage ? `${errorMessage}; ${seamReason}` : seamReason;
+    }
   } catch (error) {
     caseStatus = STATUS_FAIL_V0;
     errorMessage = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
Closes #429

## Summary
- eliminate the final manifest `NI` canary by converging `typeset_demo_capabilities_v0` to deterministic `INVALID`
- preserve fail-closed engine behavior (`compile_status=NOT_IMPLEMENTED`) while emitting a stable explicit seam reason in case summary error payload (`capabilities_seam:*`)
- align gallery manifest/report/proof expectations so status, proof gates, and reporting remain coherent and deterministic
- add zero-NI enforcement in second-run proof gate

## Focused Proofs
- PASS: `cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests`
- PASS: `cargo test --manifest-path crates/carreltex-xdv/Cargo.toml`
- PASS: `./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12`
- PASS: `./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25`
