### PR TITLE
pdf fidelity bundle v1: title centering + inline spacing + vertical rhythm

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
@@ -232,6 +232,11 @@ fn build_page_content_stream_v0(
         };
         let render_segments = split_superscript_segments_v0(&segments);
         let line_is_empty = render_segments.is_empty();
+        // Collapse consecutive blank lines to a single rhythm gap so vertical spacing stays stable.
+        if line_is_empty && previous_rendered_line_was_empty {
+            line_index += 1;
+            continue;
+        }
         let in_title_block = title_block_len > 0 && line_index < title_block_len;
         let font_size_pt = if in_title_block && line_index == 0 {
             TITLE_FONT_SIZE_PT_V0

--- a/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
@@ -38,14 +38,15 @@ fn emit_render_segments_with_superscript_v0(
     if segments.is_empty() {
         return;
     }
-    let mut cursor_x = x_pt;
+    let mut cursor_x = f64::from(x_pt);
+    let y_pt_f64 = f64::from(y_pt);
     for segment in segments {
         if segment.bytes.is_empty() {
-            cursor_x += segment.advance_pt;
+            cursor_x += f64::from(segment.advance_pt);
             continue;
         }
         out.extend_from_slice(b"1 0 0 1 ");
-        out.extend_from_slice(format!("{:.2} {:.2} Tm ", cursor_x, y_pt).as_bytes());
+        out.extend_from_slice(format!("{cursor_x:.3} {y_pt_f64:.3} Tm ").as_bytes());
         let escaped = escape_pdf_string_bytes(&segment.bytes);
         let segment_font_size_pt = if segment.superscript {
             FOOTNOTE_MARKER_FONT_SIZE_PT_V0
@@ -65,8 +66,7 @@ fn emit_render_segments_with_superscript_v0(
         out.extend_from_slice(b" Tf (");
         out.extend_from_slice(&escaped);
         out.extend_from_slice(b") Tj ");
-        cursor_x += segment.advance_pt;
+        cursor_x += f64::from(segment.advance_pt);
     }
     out.extend_from_slice(b"0 Ts ");
 }
-

--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
@@ -612,7 +612,7 @@ fn pdf_renderer_caps_segment_tm_gap_for_styled_line_v0() {
     let max_tm_gap = max_tm_gap_pt_for_line_containing_v0(&pdf, "Styled")
         .expect("pdf should include styled line");
     assert!(
-        max_tm_gap <= 24.0,
+        max_tm_gap <= 12.0,
         "styled line tm gap should be capped, got {max_tm_gap}"
     );
 }
@@ -635,7 +635,7 @@ fn pdf_renderer_inline_wrapper_spacing_invariants_v0() {
         tm_x_for_segment_substring_v0(&pdf, "(word)", "( trail,)").expect("trail segment x");
     let bold_x = tm_xs_for_segment_text_v0(&pdf, "bold")[0];
 
-    let epsilon_pt = 0.02f32;
+    let epsilon_pt = 0.01f32;
     assert!(
         ((mid_x - word_x) - segment_width_pt_v0(b"word")).abs() <= epsilon_pt,
         "word->mid advance mismatch: word_x={word_x}, mid_x={mid_x}"
@@ -795,7 +795,7 @@ fn pdf_renderer_centers_section_headings_within_epsilon_v0() {
     let heading_x = tm_x_for_line_containing_text_v0(&pdf, "(Centered Section Heading)")
         .expect("centered heading position");
     assert!(
-        (heading_x - expected_heading_x).abs() <= 0.02,
+        (heading_x - expected_heading_x).abs() <= 0.01,
         "centered heading x mismatch: actual={heading_x}, expected={expected_heading_x}"
     );
     assert!(
@@ -828,7 +828,7 @@ fn pdf_renderer_title_and_heading_centering_per_line_width_v0() {
     let heading_beta_x =
         tm_x_for_line_containing_text_v0(&pdf, "(Heading Beta)").expect("heading beta x");
 
-    let epsilon_pt = 0.02f32;
+    let epsilon_pt = 0.01f32;
     assert!(
         (title_x - expected_title_x).abs() <= epsilon_pt,
         "title centering mismatch: actual={title_x}, expected={expected_title_x}"
@@ -844,6 +844,25 @@ fn pdf_renderer_title_and_heading_centering_per_line_width_v0() {
     assert!(
         (heading_alpha_x - 72.0).abs() > 0.5 && (heading_beta_x - 72.0).abs() > 0.5,
         "heading lines should not be left-margin aligned: alpha={heading_alpha_x}, beta={heading_beta_x}"
+    );
+}
+
+#[test]
+fn pdf_renderer_title_centering_stays_stable_with_inline_style_segments_v1() {
+    let demo_text =
+        b"Center [Accurate] {Title}\nAlice Bob\n2026-03-05\n\nBody line after styled title.";
+    let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept styled title demo");
+    let layout = parse_dvi_v2_text_page_to_layout_v0(&xdv, 786_432).expect("layout parse");
+    let title_width = layout_line_width_for_exact_bytes_v0(&layout, b"Center [Accurate] {Title}")
+        .expect("styled title width");
+    let expected_title_x = expected_center_x_pt_v0(title_width);
+
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let title_x = tm_x_for_line_containing_text_v0(&pdf, "Center")
+        .expect("styled title first segment x");
+    assert!(
+        (title_x - expected_title_x).abs() <= 0.01,
+        "styled title centering mismatch: actual={title_x}, expected={expected_title_x}"
     );
 }
 
@@ -959,6 +978,34 @@ fn pdf_renderer_paragraph_rhythm_and_noindent_invariants_v0() {
     assert!(
         (heading_x - 72.0).abs() > 0.5,
         "heading should be centered: {heading_x}"
+    );
+}
+
+#[test]
+fn pdf_renderer_consecutive_blank_lines_collapse_to_single_rhythm_gap_v1() {
+    let demo_text = b"Title\nAuthor\n2026-03-05\n\nFirst paragraph line.\n\n\nSecond paragraph line.";
+    let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept blank-line rhythm demo");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let (first_x, first_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(First paragraph line.)")
+            .expect("first paragraph line");
+    let (second_x, second_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Second paragraph line.)")
+            .expect("second paragraph line");
+
+    let epsilon_pt = 0.02f32;
+    assert!(
+        (first_x - 72.0).abs() <= epsilon_pt,
+        "first paragraph should start at body margin: {first_x}"
+    );
+    assert!(
+        (second_x - 96.0).abs() <= epsilon_pt,
+        "second paragraph should keep paragraph indent: {second_x}"
+    );
+    assert!(
+        (first_y - second_y - 28.0).abs() <= epsilon_pt,
+        "consecutive blank lines should collapse to a single paragraph gap: first_y={first_y}, second_y={second_y}"
     );
 }
 
@@ -1709,4 +1756,3 @@ fn pdf_renderer_right_alignment_handles_styled_segments_without_drift_v0() {
         "core->trail spacing drift: core_x={core_x}, trail_x={trail_x}"
     );
 }
-


### PR DESCRIPTION
Closes #433

## Summary
- tighten title/heading centering checks and add mixed-inline title centering coverage
- reduce styled-inline positioning drift by increasing text matrix precision and accumulation precision
- collapse consecutive blank lines to a single vertical rhythm gap in page content stream
- add focused rhythm test to pin blank-line collapse behavior

## Proof
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml
- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12
- ./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25