### PR TITLE
pdf fidelity bundle v4: title, centered, and right block polish

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -98,6 +98,12 @@ enum FigurePlacementHintV0 {
     Top,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum InlineBlockAlignmentV0 {
+    Center,
+    Right,
+}
+
 
 // Inline/text segmentation and marker parsing.
 include!("pdf_v0/style_and_segments_v0.rs");

--- a/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
@@ -44,6 +44,7 @@ fn build_page_content_stream_v0(
     let mut skip_indent_after_title_block = title_block_len > 0;
     let mut active_hang_indent_pt = 0.0f32;
     let mut active_quote_indent_pt = 0.0f32;
+    let mut active_inline_alignment = None::<InlineBlockAlignmentV0>;
     let mut annotations = Vec::<PdfLinkAnnotationV0>::new();
     let mut style_stack = Vec::<PdfTextStyleV0>::new();
     let mut current_style = PdfTextStyleV0::Regular;
@@ -88,6 +89,7 @@ fn build_page_content_stream_v0(
             skip_indent_after_title_block = false;
             active_hang_indent_pt = 0.0;
             active_quote_indent_pt = 0.0;
+            active_inline_alignment = None;
             line_index = table_end;
             continue;
         }
@@ -130,6 +132,7 @@ fn build_page_content_stream_v0(
             skip_indent_after_title_block = false;
             active_hang_indent_pt = 0.0;
             active_quote_indent_pt = 0.0;
+            active_inline_alignment = None;
             line_index = cursor + 1;
             continue;
         }
@@ -153,6 +156,7 @@ fn build_page_content_stream_v0(
             skip_indent_after_title_block = false;
             active_hang_indent_pt = 0.0;
             active_quote_indent_pt = 0.0;
+            active_inline_alignment = None;
             line_index += 1;
             continue;
         }
@@ -261,45 +265,74 @@ fn build_page_content_stream_v0(
             && previous_rendered_line_was_empty
             && next_raw_line_is_empty
             && is_heading_line_segments_v0(&segments);
+        let centered_continuation = !in_title_block
+            && !line_is_empty
+            && quote_prefix_advance_pt.is_none()
+            && !center_prefixed
+            && !right_prefixed
+            && !noindent_prefixed
+            && heading_kind.is_none()
+            && list_prefix.is_none()
+            && matches!(active_inline_alignment, Some(InlineBlockAlignmentV0::Center));
+        let right_continuation = !in_title_block
+            && !line_is_empty
+            && quote_prefix_advance_pt.is_none()
+            && !center_prefixed
+            && !right_prefixed
+            && !noindent_prefixed
+            && heading_kind.is_none()
+            && list_prefix.is_none()
+            && matches!(active_inline_alignment, Some(InlineBlockAlignmentV0::Right));
         if !line_is_empty {
             let line_width_pt: f32 = render_segments
                 .iter()
                 .map(|segment| segment.advance_pt)
                 .sum();
             let line_x = if in_title_block {
+                active_inline_alignment = None;
                 centered_line_x_v0(line_width_pt)
             } else if heading_kind.is_some() || heading_centered {
                 active_quote_indent_pt = 0.0;
                 active_hang_indent_pt = 0.0;
+                active_inline_alignment = None;
                 centered_line_x_v0(line_width_pt)
-            } else if center_prefixed {
+            } else if center_prefixed || centered_continuation {
                 active_quote_indent_pt = 0.0;
                 active_hang_indent_pt = 0.0;
+                active_inline_alignment = Some(InlineBlockAlignmentV0::Center);
                 centered_line_x_v0(line_width_pt)
-            } else if right_prefixed {
+            } else if right_prefixed || right_continuation {
                 active_quote_indent_pt = 0.0;
                 active_hang_indent_pt = 0.0;
+                active_inline_alignment = Some(InlineBlockAlignmentV0::Right);
                 (PAGE_WIDTH_PT_V0 - MARGIN_PT_V0 - line_width_pt).max(MARGIN_PT_V0)
             } else if let Some(prefix_advance_pt) = quote_prefix_advance_pt {
                 active_quote_indent_pt =
                     QUOTE_BODY_INDENT_PT_V0.max(prefix_advance_pt + QUOTE_PREFIX_GAP_PT_V0);
                 active_hang_indent_pt = 0.0;
+                active_inline_alignment = None;
                 MARGIN_PT_V0 + active_quote_indent_pt
             } else if let Some(prefix) = list_prefix {
                 active_hang_indent_pt = LIST_BODY_INDENT_PT_V0 + prefix.leading_advance_pt;
                 active_quote_indent_pt = 0.0;
+                active_inline_alignment = None;
                 MARGIN_PT_V0 + active_hang_indent_pt
             } else if noindent_prefixed {
                 active_hang_indent_pt = 0.0;
                 active_quote_indent_pt = 0.0;
+                active_inline_alignment = None;
                 MARGIN_PT_V0
             } else if active_quote_indent_pt > 0.0 {
+                active_inline_alignment = None;
                 MARGIN_PT_V0 + active_quote_indent_pt
             } else if active_hang_indent_pt > 0.0 {
+                active_inline_alignment = None;
                 MARGIN_PT_V0 + active_hang_indent_pt
             } else if previous_rendered_line_was_empty && !skip_indent_after_title_block {
+                active_inline_alignment = None;
                 MARGIN_PT_V0 + INDENT_PT_V0
             } else {
+                active_inline_alignment = None;
                 MARGIN_PT_V0
             };
             let mut equation_ordinal = None::<u32>;
@@ -395,6 +428,7 @@ fn build_page_content_stream_v0(
         } else {
             active_hang_indent_pt = 0.0;
             active_quote_indent_pt = 0.0;
+            active_inline_alignment = None;
         }
         previous_rendered_line_was_empty = line_is_empty;
         y -= LEADING_PT_V0;

--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
@@ -129,6 +129,17 @@ fn rendered_text_for_line_containing_segment_v0(pdf: &[u8], segment_text: &str) 
     None
 }
 
+fn rendered_text_for_line_containing_needle_v0(pdf: &[u8], needle: &str) -> Option<String> {
+    let text = String::from_utf8_lossy(pdf);
+    for line in text.lines() {
+        if !line.contains(needle) || !line.contains(" Tj ") {
+            continue;
+        }
+        return decode_pdf_text_segments_from_line_v0(line);
+    }
+    None
+}
+
 fn rendered_text_for_first_text_line_v0(pdf: &[u8]) -> Option<String> {
     let text = String::from_utf8_lossy(pdf);
     for line in text.lines() {
@@ -599,6 +610,28 @@ fn layout_line_width_for_exact_bytes_v0(
             if bytes == target {
                 return Some(line.width_sp);
             }
+        }
+    }
+    None
+}
+
+fn layout_render_width_for_substring_v0(
+    layout: &super::LayoutPlanV0,
+    needle: &[u8],
+) -> Option<u32> {
+    for page in &layout.pages {
+        for line in &page.lines {
+            let bytes: Vec<u8> = line.glyphs.iter().map(|glyph| glyph.byte).collect();
+            if !bytes.windows(needle.len()).any(|window| window == needle) {
+                continue;
+            }
+            if let Some(width_sp) = width_sp_for_prefixed_rendered_line_v0(line, [b'^', b' ']) {
+                return Some(width_sp);
+            }
+            if let Some(width_sp) = width_sp_for_prefixed_rendered_line_v0(line, [b'|', b' ']) {
+                return Some(width_sp);
+            }
+            return Some(line.width_sp);
         }
     }
     None
@@ -1795,5 +1828,87 @@ fn pdf_renderer_right_alignment_handles_styled_segments_without_drift_v0() {
     assert!(
         ((trail_x - core_x) - segment_width_pt_v0(b"core")).abs() <= epsilon_pt,
         "core->trail spacing drift: core_x={core_x}, trail_x={trail_x}"
+    );
+}
+
+#[test]
+fn pdf_renderer_center_alignment_keeps_wrapped_continuation_centered_v1() {
+    let xdv = write_dvi_v2_text_page_with_layout_and_wrap_v0(
+        b"\n^ CENTERSTART alpha [mid] gamma words words words words WRAPCENTER tail.",
+        65_536,
+        786_432,
+        30,
+    )
+    .expect("writer should accept wrapped centered text");
+    let layout = parse_dvi_v2_text_page_to_layout_v0(&xdv, 786_432).expect("layout parse");
+    let expected_start_x = expected_center_x_pt_v0(
+        layout_render_width_for_substring_v0(&layout, b"CENTERSTART")
+            .expect("center start width"),
+    );
+    let expected_wrap_x = expected_center_x_pt_v0(
+        layout_render_width_for_substring_v0(&layout, b"WRAPCENTER").expect("center wrap width"),
+    );
+
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let (start_x, start_y) = tm_position_for_line_containing_text_v0(&pdf, "CENTERSTART")
+        .expect("center start line position");
+    let (wrap_x, wrap_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "WRAPCENTER").expect("center wrap line position");
+    let epsilon_pt = 0.02f32;
+    assert!(
+        (start_x - expected_start_x).abs() <= epsilon_pt,
+        "center wrapped first line drift: actual={start_x}, expected={expected_start_x}"
+    );
+    assert!(
+        (wrap_x - expected_wrap_x).abs() <= epsilon_pt,
+        "center wrapped continuation drift: actual={wrap_x}, expected={expected_wrap_x}"
+    );
+    assert!(start_y > wrap_y, "wrapped continuation should render below first line");
+    let rendered = rendered_text_for_line_containing_needle_v0(&pdf, "CENTERSTART")
+        .expect("center wrapped styled line should decode");
+    assert!(
+        rendered == "CENTERSTART alpha mid",
+        "center wrapped style boundaries should retain stable spacing: {rendered}"
+    );
+}
+
+#[test]
+fn pdf_renderer_right_alignment_keeps_wrapped_continuation_right_v1() {
+    let xdv = write_dvi_v2_text_page_with_layout_and_wrap_v0(
+        b"\n| RIGHTSTART edge, [core] trail words words words words WRAPRIGHT tail.",
+        65_536,
+        786_432,
+        30,
+    )
+    .expect("writer should accept wrapped right-aligned text");
+    let layout = parse_dvi_v2_text_page_to_layout_v0(&xdv, 786_432).expect("layout parse");
+    let expected_start_x = expected_right_x_pt_v0(
+        layout_render_width_for_substring_v0(&layout, b"RIGHTSTART")
+            .expect("right start width"),
+    );
+    let expected_wrap_x = expected_right_x_pt_v0(
+        layout_render_width_for_substring_v0(&layout, b"WRAPRIGHT").expect("right wrap width"),
+    );
+
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let (start_x, start_y) = tm_position_for_line_containing_text_v0(&pdf, "RIGHTSTART")
+        .expect("right start line position");
+    let (wrap_x, wrap_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "WRAPRIGHT").expect("right wrap line position");
+    let epsilon_pt = 0.02f32;
+    assert!(
+        (start_x - expected_start_x).abs() <= epsilon_pt,
+        "right wrapped first line drift: actual={start_x}, expected={expected_start_x}"
+    );
+    assert!(
+        (wrap_x - expected_wrap_x).abs() <= epsilon_pt,
+        "right wrapped continuation drift: actual={wrap_x}, expected={expected_wrap_x}"
+    );
+    assert!(start_y > wrap_y, "wrapped continuation should render below first line");
+    let rendered = rendered_text_for_line_containing_needle_v0(&pdf, "RIGHTSTART")
+        .expect("right wrapped styled line should decode");
+    assert!(
+        rendered == "RIGHTSTART edge, core",
+        "right wrapped style boundaries should retain stable spacing: {rendered}"
     );
 }


### PR DESCRIPTION
Closes #439

## Summary
- preserve title block per-line centering while tightening centered/right block consistency for wrapped continuation lines
- carry center/right alignment across wrapped continuation lines until block termination, keeping deterministic placement
- add focused renderer tests for wrapped center/right alignment and style-boundary stability in centered/right blocks

## Proof
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml
- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12
- ./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25