### PR TITLE
pdf fidelity bundle v8: multipage flow polish

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
@@ -85,6 +85,22 @@ fn transition_blank_advance_pt_v7(previous: BodyFlowKindV0) -> f32 {
     (BLOCK_TRANSITION_GAP_PT_V7 - previous_leading_pt).max(0.0)
 }
 
+#[derive(Clone)]
+struct PageContinuationStateV0 {
+    previous_rendered_line_was_empty: bool,
+    skip_indent_after_title_block: bool,
+    active_hang_indent_pt: f32,
+    active_hang_prefix_kind: Option<ListPrefixKindV0>,
+    active_quote_indent_pt: f32,
+    active_inline_alignment: Option<InlineBlockAlignmentV0>,
+    previous_line_was_bibliography_heading: bool,
+    last_non_empty_flow_kind: Option<BodyFlowKindV0>,
+    style_stack: Vec<PdfTextStyleV0>,
+    current_style: PdfTextStyleV0,
+    link_active: bool,
+    active_link_target: Option<PdfLinkTargetV0>,
+}
+
 fn build_page_content_stream_v0(
     lines: &[LinePlanV0],
     footnote_defs_by_id: &BTreeMap<u32, Vec<Vec<GlyphPlanV0>>>,
@@ -98,7 +114,9 @@ fn build_page_content_stream_v0(
     next_anchor_id: &mut u32,
     anchor_destinations: &mut BTreeMap<u32, AnchorDestinationV0>,
     allow_title_block: bool,
-) -> Option<PageRenderV0> {
+    initial_state: Option<&PageContinuationStateV0>,
+    is_last_page: bool,
+) -> Option<(PageRenderV0, PageContinuationStateV0)> {
     let mut out = Vec::new();
     out.extend_from_slice(b"BT\n");
     out.extend_from_slice(b"0 g\n");
@@ -127,19 +145,44 @@ fn build_page_content_stream_v0(
         0
     };
     let mut y = PAGE_HEIGHT_PT_V0 - MARGIN_PT_V0 - TITLE_FONT_SIZE_PT_V0;
-    let mut previous_rendered_line_was_empty = false;
-    let mut skip_indent_after_title_block = title_block_len > 0;
-    let mut active_hang_indent_pt = 0.0f32;
-    let mut active_hang_prefix_kind = None::<ListPrefixKindV0>;
-    let mut active_quote_indent_pt = 0.0f32;
-    let mut active_inline_alignment = None::<InlineBlockAlignmentV0>;
-    let mut previous_line_was_bibliography_heading = false;
-    let mut last_non_empty_flow_kind = None::<BodyFlowKindV0>;
+    let mut previous_rendered_line_was_empty = initial_state
+        .map(|state| state.previous_rendered_line_was_empty)
+        .unwrap_or(false);
+    let mut skip_indent_after_title_block = if title_block_len > 0 {
+        true
+    } else {
+        initial_state
+            .map(|state| state.skip_indent_after_title_block)
+            .unwrap_or(false)
+    };
+    let mut active_hang_indent_pt = initial_state
+        .map(|state| state.active_hang_indent_pt)
+        .unwrap_or(0.0);
+    let mut active_hang_prefix_kind = initial_state
+        .map(|state| state.active_hang_prefix_kind)
+        .unwrap_or(None);
+    let mut active_quote_indent_pt = initial_state
+        .map(|state| state.active_quote_indent_pt)
+        .unwrap_or(0.0);
+    let mut active_inline_alignment = initial_state
+        .map(|state| state.active_inline_alignment)
+        .unwrap_or(None);
+    let mut previous_line_was_bibliography_heading = initial_state
+        .map(|state| state.previous_line_was_bibliography_heading)
+        .unwrap_or(false);
+    let mut last_non_empty_flow_kind = initial_state
+        .map(|state| state.last_non_empty_flow_kind)
+        .unwrap_or(None);
     let mut annotations = Vec::<PdfLinkAnnotationV0>::new();
-    let mut style_stack = Vec::<PdfTextStyleV0>::new();
-    let mut current_style = PdfTextStyleV0::Regular;
-    let mut link_active = false;
-    let mut active_link_target = None::<PdfLinkTargetV0>;
+    let mut style_stack = initial_state
+        .map(|state| state.style_stack.clone())
+        .unwrap_or_default();
+    let mut current_style = initial_state
+        .map(|state| state.current_style)
+        .unwrap_or(PdfTextStyleV0::Regular);
+    let mut link_active = initial_state.map(|state| state.link_active).unwrap_or(false);
+    let mut active_link_target = initial_state
+        .and_then(|state| state.active_link_target.clone());
     let mut line_index = 0usize;
     while line_index < lines.len() {
         let line = &lines[line_index];
@@ -642,11 +685,13 @@ fn build_page_content_stream_v0(
         }
         line_index += 1;
     }
-    if !style_stack.is_empty() || link_active {
-        return None;
-    }
-    if active_link_target.is_some() {
-        return None;
+    if is_last_page {
+        if !style_stack.is_empty() || link_active {
+            return None;
+        }
+        if active_link_target.is_some() {
+            return None;
+        }
     }
 
     if footnote_line_count > 0 {
@@ -687,10 +732,27 @@ fn build_page_content_stream_v0(
     }
 
     out.extend_from_slice(b"ET\n");
-    Some(PageRenderV0 {
-        stream: out,
-        annotations,
-    })
+    let continuation_state = PageContinuationStateV0 {
+        previous_rendered_line_was_empty,
+        skip_indent_after_title_block,
+        active_hang_indent_pt,
+        active_hang_prefix_kind,
+        active_quote_indent_pt,
+        active_inline_alignment,
+        previous_line_was_bibliography_heading,
+        last_non_empty_flow_kind,
+        style_stack,
+        current_style,
+        link_active,
+        active_link_target,
+    };
+    Some((
+        PageRenderV0 {
+            stream: out,
+            annotations,
+        },
+        continuation_state,
+    ))
 }
 
 fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
@@ -716,10 +778,11 @@ fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
 
     let mut next_link_id = 1u32;
     let mut next_anchor_id = 1u32;
+    let mut continuation_state = None::<PageContinuationStateV0>;
     let mut anchor_destinations = BTreeMap::<u32, AnchorDestinationV0>::new();
     let mut page_renders = Vec::<PageRenderV0>::with_capacity(body_pages.len());
     for (page_index, body_lines) in body_pages.iter().enumerate() {
-        let Some(rendered) = build_page_content_stream_v0(
+        let Some((rendered, next_state)) = build_page_content_stream_v0(
             body_lines,
             &footnote_defs_by_id,
             &link_targets_by_id,
@@ -732,9 +795,12 @@ fn build_pdf_for_pages_v0(pages: &[PagePlanV0]) -> Vec<u8> {
             &mut next_anchor_id,
             &mut anchor_destinations,
             page_index == 0,
+            continuation_state.as_ref(),
+            page_index + 1 == body_pages.len(),
         ) else {
             return Vec::new();
         };
+        continuation_state = Some(next_state);
         page_renders.push(rendered);
     }
     for (anchor_id, destination) in nominal_anchor_destinations {

--- a/crates/carreltex-xdv/src/tests/roundtrip_and_core_renderer_v0.rs
+++ b/crates/carreltex-xdv/src/tests/roundtrip_and_core_renderer_v0.rs
@@ -813,3 +813,115 @@ fn pdf_renderer_multipage_footnotes_and_annots_associate_per_page_v0() {
         "page 2 footnote should render near bottom: y={page_two_footnote_y}"
     );
 }
+
+#[test]
+fn pdf_renderer_preserves_wrapped_list_and_quote_continuation_indent_across_pages_v8() {
+    let text = b"- LISTSTART alpha alpha alpha alpha alpha alpha alpha alpha alpha alpha alpha alpha LISTWRAPTOKEN\n\n> QUOTESTART beta beta beta beta beta beta beta beta beta beta beta beta QUOTEWRAPTOKEN";
+    let xdv = write_dvi_v2_text_page_with_layout_wrap_and_paging_v0(text, 65_536, 786_432, 32, 1)
+        .expect("writer should accept multipage wrapped list/quote text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let page_count = count_pdf_page_objects_v0(&pdf);
+    assert!(page_count >= 4, "expected multipage output for wrapped blocks");
+
+    let first_stream_id = 3u32 + page_count as u32;
+    let mut list_start = None::<(usize, f32)>;
+    let mut list_wrap = None::<(usize, f32)>;
+    let mut quote_start = None::<(usize, f32)>;
+    let mut quote_wrap = None::<(usize, f32)>;
+    for page_index in 0..page_count {
+        let stream_body = parse_pdf_object_body_v0(&pdf, first_stream_id + page_index as u32)
+            .expect("stream body");
+        if list_start.is_none() {
+            if let Some((x, _)) =
+                tm_position_for_line_containing_text_in_body_v0(&stream_body, "LISTSTART")
+            {
+                list_start = Some((page_index, x));
+            }
+        }
+        if list_wrap.is_none() {
+            if let Some((x, _)) =
+                tm_position_for_line_containing_text_in_body_v0(&stream_body, "LISTWRAPTOKEN")
+            {
+                list_wrap = Some((page_index, x));
+            }
+        }
+        if quote_start.is_none() {
+            if let Some((x, _)) =
+                tm_position_for_line_containing_text_in_body_v0(&stream_body, "QUOTESTART")
+            {
+                quote_start = Some((page_index, x));
+            }
+        }
+        if quote_wrap.is_none() {
+            if let Some((x, _)) =
+                tm_position_for_line_containing_text_in_body_v0(&stream_body, "QUOTEWRAPTOKEN")
+            {
+                quote_wrap = Some((page_index, x));
+            }
+        }
+    }
+
+    let (list_start_page, list_start_x) = list_start.expect("LISTSTART position");
+    let (list_wrap_page, list_wrap_x) = list_wrap.expect("LISTWRAPTOKEN position");
+    let (quote_start_page, quote_start_x) = quote_start.expect("QUOTESTART position");
+    let (quote_wrap_page, quote_wrap_x) = quote_wrap.expect("QUOTEWRAPTOKEN position");
+    let epsilon_pt = 0.2f32;
+    assert!(
+        list_wrap_page > list_start_page,
+        "wrapped list continuation should cross a page boundary: start_page={list_start_page}, wrap_page={list_wrap_page}"
+    );
+    assert!(
+        quote_wrap_page > quote_start_page,
+        "wrapped quote continuation should cross a page boundary: start_page={quote_start_page}, wrap_page={quote_wrap_page}"
+    );
+    assert!(
+        (list_start_x - list_wrap_x).abs() <= epsilon_pt,
+        "list continuation x must remain stable across page boundary: start_x={list_start_x}, wrap_x={list_wrap_x}"
+    );
+    assert!(
+        (quote_start_x - quote_wrap_x).abs() <= epsilon_pt,
+        "quote continuation x must remain stable across page boundary: start_x={quote_start_x}, wrap_x={quote_wrap_x}"
+    );
+    assert!(
+        quote_start_x >= list_start_x + 4.0,
+        "quote indentation should remain deeper than list indentation across pages: list_x={list_start_x}, quote_x={quote_start_x}"
+    );
+}
+
+#[test]
+fn pdf_renderer_keeps_link_annotations_and_footnotes_stable_when_link_wraps_across_pages_v8() {
+    let text = b"- marker^1 <{LINKSTART gamma gamma gamma gamma gamma gamma gamma gamma gamma gamma gamma gamma LINKMID gamma gamma gamma gamma gamma gamma gamma gamma gamma gamma gamma LINKEND}>tail tail marker^2\n\n!f 1 First split footnote.\n!f 2 Second split footnote.\n!u 1 https://example.com/split";
+    let xdv = write_dvi_v2_text_page_with_layout_wrap_and_paging_v0(text, 65_536, 786_432, 64, 1)
+        .expect("writer should accept wrapped multipage link and footnote text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let page_count = count_pdf_page_objects_v0(&pdf);
+    assert!(page_count >= 2, "expected at least two pages for wrapped link");
+
+    let mut uri_annotation_count = 0usize;
+    for page_index in 0..page_count {
+        let page_obj = parse_pdf_object_body_v0(&pdf, 3 + page_index as u32).expect("page object");
+        let annots = parse_pdf_ref_ids_v0(&page_obj, "/Annots");
+        for annot_id in annots {
+            let annotation = parse_pdf_object_body_v0(&pdf, annot_id).expect("annotation body");
+            let action_id =
+                parse_pdf_annotation_action_id_v0(&annotation).expect("annotation action id");
+            let action_body = parse_pdf_object_body_v0(&pdf, action_id).expect("action body");
+            if parse_pdf_action_uri_v0(&action_body).as_deref() == Some("https://example.com/split")
+            {
+                uri_annotation_count += 1;
+                let rect = parse_pdf_annotation_rect_v0(&annotation).expect("annotation rect");
+                assert!(rect[2] > rect[0], "annotation width must be positive: {rect:?}");
+                assert!(rect[3] > rect[1], "annotation height must be positive: {rect:?}");
+                assert!(
+                    rect[0] >= 0.0 && rect[1] >= 0.0 && rect[2] <= 612.0 && rect[3] <= 792.0,
+                    "annotation rect must stay within page bounds: {rect:?}"
+                );
+            }
+        }
+    }
+    assert!(
+        uri_annotation_count >= 2,
+        "wrapped link should keep annotation association across page boundaries"
+    );
+
+}


### PR DESCRIPTION
Closes #447

## Scope
- preserve paragraph/list/quote flow continuity when wrapped blocks cross page boundaries
- carry styled/link state across pages so wrapped links keep deterministic annotation association
- keep deterministic multipage rhythm and indentation for wrapped list/quote continuations
- add focused multipage renderer tests for cross-page continuation and wrapped-link stability

## Proof gates
- PASS: cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- PASS: cargo test --manifest-path crates/carreltex-xdv/Cargo.toml
- PASS: ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12
- PASS: ./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25