### PR TITLE
pdf fidelity bundle v10: dense table polish

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0.rs
@@ -52,11 +52,11 @@ const FIGURE_IMAGE_PREFIX_MARKER_V0: &[u8] = b"!gimg ";
 const FIGURE_CAPTION_PREFIX_MARKER_V0: &[u8] = b"!gcap ";
 const TOC_PLACEHOLDER_MARKER_V0: &[u8] = b"!toc";
 const TOC_ENTRY_LINE_PREFIX_MARKER_V0: &[u8] = b"!toc ";
-const TABLE_CELL_PADDING_PT_V0: f32 = 7.0;
-const TABLE_ROW_LEADING_PT_V0: f32 = 14.0;
+const TABLE_CELL_PADDING_PT_V10: f32 = 6.0;
+const TABLE_ROW_LEADING_PT_V10: f32 = 13.0;
 const TABLE_BORDER_LINE_WIDTH_PT_V0: f32 = 0.5;
-const TABLE_BORDER_TOP_OFFSET_PT_V0: f32 = 5.0;
-const TABLE_BORDER_BOTTOM_OFFSET_PT_V0: f32 = 5.0;
+const TABLE_BORDER_TOP_OFFSET_PT_V10: f32 = 4.0;
+const TABLE_BORDER_BOTTOM_OFFSET_PT_V10: f32 = 4.0;
 const ANNOTATION_RECT_DESCENT_RATIO_V9: f32 = 0.22;
 const ANNOTATION_RECT_ASCENT_RATIO_V9: f32 = 0.78;
 const ANNOTATION_RECT_MIN_HEIGHT_PT_V9: f32 = 8.0;
@@ -117,7 +117,6 @@ enum InlineBlockAlignmentV0 {
     Center,
     Right,
 }
-
 
 // Inline/text segmentation and marker parsing.
 include!("pdf_v0/style_and_segments_v0.rs");

--- a/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
@@ -3,6 +3,7 @@ enum BodyFlowKindV0 {
     Paragraph,
     List,
     Quote,
+    Table,
     Other,
 }
 
@@ -20,7 +21,10 @@ fn classify_next_flow_kind_v0(
         }
         if has_table_spec_prefix_v0(&line.glyphs)
             || has_table_row_prefix_v0(&line.glyphs)
-            || has_figure_box_marker_prefix_v0(&line.glyphs)
+        {
+            return Some(BodyFlowKindV0::Table);
+        }
+        if has_figure_box_marker_prefix_v0(&line.glyphs)
             || has_figure_image_prefix_v0(&line.glyphs)
             || has_figure_caption_prefix_v0(&line.glyphs)
             || has_toc_placeholder_line_v0(&line.glyphs)
@@ -73,6 +77,8 @@ fn should_tighten_transition_gap_v7(previous: BodyFlowKindV0, next: BodyFlowKind
             | (BodyFlowKindV0::Quote, BodyFlowKindV0::Paragraph)
             | (BodyFlowKindV0::List, BodyFlowKindV0::Quote)
             | (BodyFlowKindV0::Quote, BodyFlowKindV0::List)
+            | (BodyFlowKindV0::Paragraph, BodyFlowKindV0::Table)
+            | (BodyFlowKindV0::Table, BodyFlowKindV0::Paragraph)
     )
 }
 
@@ -80,6 +86,7 @@ fn transition_blank_advance_pt_v7(previous: BodyFlowKindV0) -> f32 {
     let previous_leading_pt = match previous {
         BodyFlowKindV0::List => LIST_ENTRY_LEADING_PT_V7,
         BodyFlowKindV0::Quote => QUOTE_ENTRY_LEADING_PT_V7,
+        BodyFlowKindV0::Table => TABLE_ROW_LEADING_PT_V10,
         BodyFlowKindV0::Paragraph | BodyFlowKindV0::Other => LEADING_PT_V0,
     };
     (BLOCK_TRANSITION_GAP_PT_V7 - previous_leading_pt).max(0.0)
@@ -225,7 +232,7 @@ fn build_page_content_stream_v0(
             active_quote_indent_pt = 0.0;
             active_inline_alignment = None;
             previous_line_was_bibliography_heading = false;
-            last_non_empty_flow_kind = Some(BodyFlowKindV0::Other);
+            last_non_empty_flow_kind = Some(BodyFlowKindV0::Table);
             line_index = table_end;
             continue;
         }

--- a/crates/carreltex-xdv/src/pdf_v0/table_float_toc_emit_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/table_float_toc_emit_v0.rs
@@ -44,7 +44,7 @@ fn emit_table_block_v0(
         .iter()
         .copied()
         .fold(0.0f32, |acc, width_pt| {
-            acc + width_pt + (TABLE_CELL_PADDING_PT_V0 * 2.0)
+            acc + width_pt + (TABLE_CELL_PADDING_PT_V10 * 2.0)
         });
     let max_content_width_pt = PAGE_WIDTH_PT_V0 - (2.0 * MARGIN_PT_V0);
     if table_width_pt > max_content_width_pt {
@@ -55,11 +55,11 @@ fn emit_table_block_v0(
     let mut col_cursor_x_pt = MARGIN_PT_V0;
     for col_index in 0..col_count {
         col_left_edges_pt[col_index] = col_cursor_x_pt;
-        col_cursor_x_pt += col_max_width_pt[col_index] + (TABLE_CELL_PADDING_PT_V0 * 2.0);
+        col_cursor_x_pt += col_max_width_pt[col_index] + (TABLE_CELL_PADDING_PT_V10 * 2.0);
     }
     let table_left_x_pt = MARGIN_PT_V0;
     let table_right_x_pt = table_left_x_pt + table_width_pt;
-    let table_top_y_pt = *y + TABLE_BORDER_TOP_OFFSET_PT_V0;
+    let table_top_y_pt = *y + TABLE_BORDER_TOP_OFFSET_PT_V10;
 
     for row in &parsed_rows {
         if *y < min_body_y_pt {
@@ -78,7 +78,7 @@ fn emit_table_block_v0(
                 b'r' => col_content_width_pt - cell_width_pt,
                 _ => return None,
             };
-            let x_pt = col_left_x + TABLE_CELL_PADDING_PT_V0 + align_offset_pt.max(0.0);
+            let x_pt = col_left_x + TABLE_CELL_PADDING_PT_V10 + align_offset_pt.max(0.0);
             emit_render_segments_with_superscript_v0(
                 out,
                 &row[col_index],
@@ -86,13 +86,13 @@ fn emit_table_block_v0(
                 *y,
                 FONT_SIZE_PT_V0,
             );
-            col_left_x += col_content_width_pt + (TABLE_CELL_PADDING_PT_V0 * 2.0);
+            col_left_x += col_content_width_pt + (TABLE_CELL_PADDING_PT_V10 * 2.0);
         }
         out.extend_from_slice(b"\n");
-        *y -= TABLE_ROW_LEADING_PT_V0;
+        *y -= TABLE_ROW_LEADING_PT_V10;
     }
 
-    let table_bottom_y_pt = *y + TABLE_BORDER_BOTTOM_OFFSET_PT_V0;
+    let table_bottom_y_pt = *y + TABLE_BORDER_BOTTOM_OFFSET_PT_V10;
     if table_bottom_y_pt < min_body_y_pt {
         return None;
     }
@@ -114,7 +114,7 @@ fn emit_table_block_v0(
         .as_bytes(),
     );
     for separator_index in 1..parsed_rows.len() {
-        let y_pt = table_top_y_pt - (separator_index as f32 * TABLE_ROW_LEADING_PT_V0);
+        let y_pt = table_top_y_pt - (separator_index as f32 * TABLE_ROW_LEADING_PT_V10);
         out.extend_from_slice(
             format!(
                 "{:.2} {:.2} m {:.2} {:.2} l S\n",

--- a/crates/carreltex-xdv/src/tests/table_and_float_v0.rs
+++ b/crates/carreltex-xdv/src/tests/table_and_float_v0.rs
@@ -99,7 +99,7 @@ fn pdf_renderer_table_cells_stay_within_column_bounds_v1() {
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
 
     let left_margin_pt = 72.0f32;
-    let cell_padding_pt = 7.0f32;
+    let cell_padding_pt = 6.0f32;
     let epsilon_pt = 0.05f32;
     let col1_width_pt = segment_width_pt_v0(b"LongLeft");
     let col2_width_pt = segment_width_pt_v0(b"WideMiddle");
@@ -263,7 +263,7 @@ fn pdf_renderer_table_grid_lines_render_deterministically_v1() {
 }
 
 #[test]
-fn pdf_renderer_table_row_height_is_stable_v2() {
+fn pdf_renderer_table_row_height_is_stable_v10() {
     let xdv = write_dvi_v2_text_page_v0(b"Before.\n\n!ts lcr\n!t A||B||C\n!t D||E||F\n\nAfter.")
         .expect("writer should accept table marker lines");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
@@ -271,36 +271,78 @@ fn pdf_renderer_table_row_height_is_stable_v2() {
     let (_, row2_y) = tm_position_for_line_containing_text_v0(&pdf, "(D)").expect("row 2 y");
     let delta = row1_y - row2_y;
     assert!(
-        (delta - 14.0).abs() <= 0.2,
-        "table row height should remain stable at TABLE_ROW_LEADING_PT_V0: {delta}"
+        (delta - 13.0).abs() <= 0.2,
+        "table row height should remain stable at TABLE_ROW_LEADING_PT_V10: {delta}"
     );
 }
 
 #[test]
-fn pdf_renderer_table_block_spacing_transitions_are_stable_v1() {
+fn pdf_renderer_dense_table_caption_and_transition_spacing_are_stable_v10() {
     let xdv = write_dvi_v2_text_page_v0(
-        b"~ Before paragraph.\n\n!ts lcr\n!t Alpha||Beta||Gamma\n!t Delta||Epsilon||Zeta\n\nAfter paragraph.",
+        b"~ Table 1: Dense sample caption.\n\n!ts lcr\n!t Alpha||Beta||Gamma\n!t Delta||Epsilon||Zeta\n\nAfter paragraph.",
     )
     .expect("writer should accept table marker lines");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
-    let (_, before_y) =
-        tm_position_for_line_containing_text_v0(&pdf, "(Before paragraph.)").expect("before");
+    let (_, caption_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Table 1: Dense sample caption.)")
+            .expect("caption");
     let (_, row1_y) = tm_position_for_line_containing_text_v0(&pdf, "(Alpha)").expect("row 1");
     let (_, row2_y) = tm_position_for_line_containing_text_v0(&pdf, "(Delta)").expect("row 2");
     let (_, after_y) =
         tm_position_for_line_containing_text_v0(&pdf, "(After paragraph.)").expect("after");
     let epsilon_pt = 0.2f32;
     assert!(
-        (before_y - row1_y - 28.0).abs() <= epsilon_pt,
-        "paragraph->table transition should keep stable rhythm: before_y={before_y}, row1_y={row1_y}"
+        (caption_y - row1_y - 24.0).abs() <= epsilon_pt,
+        "caption->table transition should keep tightened dense-table rhythm: caption_y={caption_y}, row1_y={row1_y}"
     );
     assert!(
-        (row1_y - row2_y - 14.0).abs() <= epsilon_pt,
-        "table row density should stay consistent after v5 polish: row1_y={row1_y}, row2_y={row2_y}"
+        (row1_y - row2_y - 13.0).abs() <= epsilon_pt,
+        "dense table row spacing should stay stable after v10 polish: row1_y={row1_y}, row2_y={row2_y}"
     );
     assert!(
-        (row2_y - after_y - 28.0).abs() <= epsilon_pt,
-        "table->paragraph transition should keep stable rhythm: row2_y={row2_y}, after_y={after_y}"
+        (row2_y - after_y - 24.0).abs() <= epsilon_pt,
+        "table->paragraph transition should keep tightened dense-table rhythm: row2_y={row2_y}, after_y={after_y}"
+    );
+}
+
+#[test]
+fn pdf_renderer_dense_table_mixed_width_alignment_invariants_v10() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"Before.\n\n!ts lcr\n!t Label||Average||9.9\n!t Longer label||M||12345.67\n!t X||Midpoint||456.0\n\nAfter.",
+    )
+    .expect("writer should accept table marker lines");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let avg_x = *tm_xs_for_segment_text_v0(&pdf, "Average")
+        .first()
+        .expect("Average x");
+    let m_x = *tm_xs_for_segment_text_v0(&pdf, "M").first().expect("M x");
+    let midpoint_x = *tm_xs_for_segment_text_v0(&pdf, "Midpoint")
+        .first()
+        .expect("Midpoint x");
+    let avg_center = avg_x + (segment_width_pt_v0(b"Average") * 0.5);
+    let m_center = m_x + (segment_width_pt_v0(b"M") * 0.5);
+    let midpoint_center = midpoint_x + (segment_width_pt_v0(b"Midpoint") * 0.5);
+    assert!(
+        (avg_center - m_center).abs() <= 0.2 && (avg_center - midpoint_center).abs() <= 0.2,
+        "center column should retain stable center across mixed-width rows: avg={avg_center}, m={m_center}, midpoint={midpoint_center}"
+    );
+
+    let nine_x = *tm_xs_for_segment_text_v0(&pdf, "9.9")
+        .first()
+        .expect("9.9 x");
+    let long_num_x = *tm_xs_for_segment_text_v0(&pdf, "12345.67")
+        .first()
+        .expect("12345.67 x");
+    let mid_num_x = *tm_xs_for_segment_text_v0(&pdf, "456.0")
+        .first()
+        .expect("456.0 x");
+    let nine_right = nine_x + segment_width_pt_v0(b"9.9");
+    let long_num_right = long_num_x + segment_width_pt_v0(b"12345.67");
+    let mid_num_right = mid_num_x + segment_width_pt_v0(b"456.0");
+    assert!(
+        (nine_right - long_num_right).abs() <= 0.1 && (nine_right - mid_num_right).abs() <= 0.1,
+        "right-aligned numeric column should retain stable right edge: nine={nine_right}, long={long_num_right}, mid={mid_num_right}"
     );
 }
 


### PR DESCRIPTION
Closes #451\n\n## Summary\n- tighten dense-table geometry by reducing horizontal cell padding and row-leading for more consistent row density\n- add table-aware paragraph↔table transition tightening so caption-to-table and table-to-paragraph gaps stay stable\n- add focused renderer tests for dense table transition rhythm and mixed-width center/right alignment invariants\n\n## Proofs\n- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests\n- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml\n- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12\n- ./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25