### PR TITLE
pdf fidelity bundle v11: front-matter rhythm polish

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
@@ -1,10 +1,15 @@
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum BodyFlowKindV0 {
+    FrontMatter,
     Paragraph,
     List,
     Quote,
     Table,
     Other,
+}
+
+fn has_front_matter_title_block_v11(title_block_len: usize) -> bool {
+    title_block_len >= 3
 }
 
 fn classify_next_flow_kind_v0(
@@ -17,6 +22,9 @@ fn classify_next_flow_kind_v0(
             continue;
         }
         if line_index < title_block_len {
+            if has_front_matter_title_block_v11(title_block_len) {
+                return Some(BodyFlowKindV0::FrontMatter);
+            }
             return Some(BodyFlowKindV0::Other);
         }
         if has_table_spec_prefix_v0(&line.glyphs)
@@ -79,11 +87,14 @@ fn should_tighten_transition_gap_v7(previous: BodyFlowKindV0, next: BodyFlowKind
             | (BodyFlowKindV0::Quote, BodyFlowKindV0::List)
             | (BodyFlowKindV0::Paragraph, BodyFlowKindV0::Table)
             | (BodyFlowKindV0::Table, BodyFlowKindV0::Paragraph)
+            | (BodyFlowKindV0::FrontMatter, BodyFlowKindV0::Paragraph)
+            | (BodyFlowKindV0::FrontMatter, BodyFlowKindV0::Other)
     )
 }
 
 fn transition_blank_advance_pt_v7(previous: BodyFlowKindV0) -> f32 {
     let previous_leading_pt = match previous {
+        BodyFlowKindV0::FrontMatter => LEADING_PT_V0,
         BodyFlowKindV0::List => LIST_ENTRY_LEADING_PT_V7,
         BodyFlowKindV0::Quote => QUOTE_ENTRY_LEADING_PT_V7,
         BodyFlowKindV0::Table => TABLE_ROW_LEADING_PT_V10,
@@ -289,6 +300,11 @@ fn build_page_content_stream_v0(
             return None;
         }
         if line_index >= title_block_len && has_toc_placeholder_line_v0(&resolved_line_glyphs) {
+            let toc_front_matter = matches!(
+                last_non_empty_flow_kind,
+                Some(BodyFlowKindV0::FrontMatter)
+            ) || (has_front_matter_title_block_v11(title_block_len)
+                && line_index <= title_block_len + 1);
             emit_toc_block_v0(
                 &mut out,
                 toc_entries,
@@ -305,7 +321,11 @@ fn build_page_content_stream_v0(
             active_quote_indent_pt = 0.0;
             active_inline_alignment = None;
             previous_line_was_bibliography_heading = false;
-            last_non_empty_flow_kind = Some(BodyFlowKindV0::Other);
+            last_non_empty_flow_kind = Some(if toc_front_matter {
+                BodyFlowKindV0::FrontMatter
+            } else {
+                BodyFlowKindV0::Other
+            });
             line_index += 1;
             continue;
         }
@@ -494,7 +514,10 @@ fn build_page_content_stream_v0(
                     .iter()
                     .flat_map(|segment| segment.bytes.iter().copied())
                     .eq(BIBLIOGRAPHY_HEADING_TEXT_V0.iter().copied());
-            current_flow_kind = if bibliography_line {
+            current_flow_kind = if in_title_block && has_front_matter_title_block_v11(title_block_len)
+            {
+                BodyFlowKindV0::FrontMatter
+            } else if bibliography_line {
                 BodyFlowKindV0::Other
             } else if quote_line {
                 BodyFlowKindV0::Quote

--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
@@ -1125,6 +1125,28 @@ fn pdf_renderer_paragraph_indent_and_line_gap_invariants_v0() {
 }
 
 #[test]
+fn pdf_renderer_front_matter_title_to_first_body_rhythm_is_tightened_v11() {
+    let demo_text = b"Front Matter Title\nAuthor Name\n2026-03-05\n\nFirst body paragraph line.";
+    let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept demo text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let (_, date_y) = tm_position_for_line_containing_text_v0(&pdf, "(2026-03-05)")
+        .expect("date line position");
+    let (body_x, body_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(First body paragraph line.)")
+            .expect("first body line position");
+    let epsilon_pt = 0.05f32;
+    assert!(
+        (date_y - body_y - 38.0).abs() <= epsilon_pt,
+        "front-matter date->first-body rhythm should stay tightened and deterministic: date_y={date_y}, body_y={body_y}"
+    );
+    assert!(
+        (body_x - 72.0).abs() <= 0.02,
+        "first body line after front matter should remain unindented: body_x={body_x}"
+    );
+}
+
+#[test]
 fn pdf_renderer_section_heading_spacing_invariants_v0() {
     let demo_text =
         b"Title\nAuthor\n2026-03-05\n\nIntro paragraph.\n\n{Section Heading}\n\n~ Body after heading.";

--- a/crates/carreltex-xdv/src/tests/toc_outline_v0.rs
+++ b/crates/carreltex-xdv/src/tests/toc_outline_v0.rs
@@ -464,6 +464,48 @@ fn pdf_renderer_toc_without_entries_renders_title_only_v0() {
 }
 
 #[test]
+fn pdf_renderer_front_matter_toc_heading_rhythm_is_stable_v11() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"Front Matter Title\nAuthor Name\n2026-03-05\n\n!toc\n\n@S {Intro heading}\n\n~ Intro body paragraph.\n\n!toc 1 1 Intro toc entry",
+    )
+    .expect("writer should accept front-matter toc bytes");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let (_, date_y) = tm_position_for_line_containing_text_v0(&pdf, "(2026-03-05)")
+        .expect("date position");
+    let (_, toc_title_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Contents)").expect("toc title");
+    let (_, toc_entry_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Intro toc entry)").expect("toc entry");
+    let (_, heading_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Intro heading)").expect("heading");
+    let (body_x, body_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Intro body paragraph.)").expect("body");
+    let epsilon_pt = 0.05f32;
+
+    assert!(
+        (date_y - toc_title_y - 38.0).abs() <= epsilon_pt,
+        "front-matter date->toc-title rhythm should stay tightened and deterministic: date_y={date_y}, toc_title_y={toc_title_y}"
+    );
+    assert!(
+        (toc_title_y - toc_entry_y - 12.0).abs() <= epsilon_pt,
+        "toc title->entry rhythm should remain stable: toc_title_y={toc_title_y}, toc_entry_y={toc_entry_y}"
+    );
+    assert!(
+        (toc_entry_y - heading_y - 23.0).abs() <= epsilon_pt,
+        "front-matter toc->first-heading transition should stay tightened and deterministic: toc_entry_y={toc_entry_y}, heading_y={heading_y}"
+    );
+    assert!(
+        (heading_y - body_y - 28.0).abs() <= epsilon_pt,
+        "heading->first-body rhythm should remain stable: heading_y={heading_y}, body_y={body_y}"
+    );
+    assert!(
+        (body_x - 72.0).abs() <= 0.02,
+        "first body line after heading should remain unindented: body_x={body_x}"
+    );
+}
+
+#[test]
 fn pdf_renderer_rejects_toc_entry_with_non_numeric_anchor_id_v0() {
     let xdv =
         write_dvi_v2_text_page_v0(b"!toc\n\n!toc 1 abc Intro").expect("writer should accept bytes");


### PR DESCRIPTION
Closes #453\n\n## Summary\n- treat only full title/author/date blocks as front matter for deterministic transition tightening\n- tighten front-matter blank-line rhythm into first body/toc blocks without changing non-front paragraphs\n- add focused front-matter rhythm tests for title->body and title+toc+heading coexistence, while preserving existing toc block rhythm invariants\n\n## Proofs\n- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests\n- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml\n- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12\n- ./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25