### PR TITLE
pdf fidelity bundle v13: body seam spacing polish

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
@@ -723,16 +723,29 @@ fn build_page_content_stream_v0(
             )?;
             annotations.append(&mut line_annotations);
             let has_superscript = render_segments.iter().any(|segment| segment.superscript);
+            let emit_profile = if current_flow_kind == BodyFlowKindV0::Paragraph {
+                SegmentEmitProfileV0::BodyProseV13
+            } else {
+                SegmentEmitProfileV0::Default
+            };
             if has_superscript {
-                emit_render_segments_with_superscript_v0(
+                emit_render_segments_with_superscript_with_profile_v0(
                     &mut out,
                     &render_segments,
                     line_x,
                     y,
                     font_size_pt,
+                    emit_profile,
                 );
             } else {
-                emit_styled_segments_v0(&mut out, &segments, line_x, y, font_size_pt);
+                emit_styled_segments_with_profile_v0(
+                    &mut out,
+                    &segments,
+                    line_x,
+                    y,
+                    font_size_pt,
+                    emit_profile,
+                );
             }
             if let Some(ordinal) = equation_ordinal {
                 let equation_number = format!("({ordinal})").into_bytes();
@@ -743,6 +756,7 @@ fn build_page_content_stream_v0(
                 let equation_segments = [PdfRenderSegmentV0 {
                     style: PdfTextStyleV0::Regular,
                     bytes: equation_number,
+                    advance_sp: (equation_number_width_pt * 65_536.0).round() as i32,
                     advance_pt: equation_number_width_pt,
                     is_link: false,
                     superscript: false,

--- a/crates/carreltex-xdv/src/pdf_v0/line_markers_and_blocks_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/line_markers_and_blocks_v0.rs
@@ -416,6 +416,7 @@ fn placeholder_segments_v0(image_path: Option<&[u8]>) -> Vec<PdfStyledSegmentV0>
     vec![PdfStyledSegmentV0 {
         style: PdfTextStyleV0::Regular,
         glyphs: glyphs.clone(),
+        advance_sp: glyphs.iter().map(|glyph| glyph.advance_sp).sum(),
         advance_pt: glyphs
             .iter()
             .map(|glyph| (glyph.advance_sp as f32) / 65_536.0)

--- a/crates/carreltex-xdv/src/pdf_v0/style_and_segments_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/style_and_segments_v0.rs
@@ -67,6 +67,7 @@ fn write_pdf_stream_obj(out: &mut Vec<u8>, id: u32, stream: &[u8]) -> u32 {
 struct PdfStyledSegmentV0 {
     style: PdfTextStyleV0,
     glyphs: Vec<GlyphPlanV0>,
+    advance_sp: i32,
     advance_pt: f32,
     is_link: bool,
 }
@@ -75,6 +76,7 @@ struct PdfStyledSegmentV0 {
 struct PdfRenderSegmentV0 {
     style: PdfTextStyleV0,
     bytes: Vec<u8>,
+    advance_sp: i32,
     advance_pt: f32,
     is_link: bool,
     superscript: bool,
@@ -202,10 +204,12 @@ fn parse_styled_segments_with_state_v0(
                 *link_active = false;
             }
             _ => {
+                let advance_sp = glyph.advance_sp;
                 let advance_pt = (glyph.advance_sp as f32) / 65_536.0;
                 if let Some(segment) = segments.last_mut() {
                     if segment.style == *current_style && segment.is_link == *link_active {
                         segment.glyphs.push(glyph.clone());
+                        segment.advance_sp += advance_sp;
                         segment.advance_pt += advance_pt;
                         continue;
                     }
@@ -213,6 +217,7 @@ fn parse_styled_segments_with_state_v0(
                 segments.push(PdfStyledSegmentV0 {
                     style: *current_style,
                     glyphs: vec![glyph.clone()],
+                    advance_sp,
                     advance_pt,
                     is_link: *link_active,
                 });
@@ -254,6 +259,7 @@ fn split_superscript_segments_v0(segments: &[PdfStyledSegmentV0]) -> Vec<PdfRend
                 out.push(PdfRenderSegmentV0 {
                     style: segment.style,
                     bytes: bytes_from_glyphs_v0(glyph_slice),
+                    advance_sp: glyph_slice.iter().map(|glyph| glyph.advance_sp).sum(),
                     advance_pt: glyph_slice
                         .iter()
                         .map(|glyph| (glyph.advance_sp as f32) / 65_536.0)
@@ -266,6 +272,7 @@ fn split_superscript_segments_v0(segments: &[PdfStyledSegmentV0]) -> Vec<PdfRend
             out.push(PdfRenderSegmentV0 {
                 style: segment.style,
                 bytes: bytes_from_glyphs_v0(marker_slice),
+                advance_sp: marker_slice.iter().map(|glyph| glyph.advance_sp).sum(),
                 advance_pt: marker_slice
                     .iter()
                     .map(|glyph| (glyph.advance_sp as f32) / 65_536.0)
@@ -281,6 +288,7 @@ fn split_superscript_segments_v0(segments: &[PdfStyledSegmentV0]) -> Vec<PdfRend
             out.push(PdfRenderSegmentV0 {
                 style: segment.style,
                 bytes: bytes_from_glyphs_v0(glyph_slice),
+                advance_sp: glyph_slice.iter().map(|glyph| glyph.advance_sp).sum(),
                 advance_pt: glyph_slice
                     .iter()
                     .map(|glyph| (glyph.advance_sp as f32) / 65_536.0)

--- a/crates/carreltex-xdv/src/pdf_v0/table_float_toc_emit_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/table_float_toc_emit_v0.rs
@@ -251,6 +251,7 @@ fn emit_toc_block_v0(
         .collect();
     let title_segments = vec![PdfStyledSegmentV0 {
         style: PdfTextStyleV0::Bold,
+        advance_sp: title_glyphs.iter().map(|glyph| glyph.advance_sp).sum(),
         advance_pt: title_glyphs
             .iter()
             .map(|glyph| (glyph.advance_sp as f32) / 65_536.0)
@@ -324,6 +325,7 @@ fn emit_toc_block_v0(
         let page_no_segments = vec![PdfRenderSegmentV0 {
             style: PdfTextStyleV0::Regular,
             bytes: bytes_from_glyphs_v0(&page_no_glyphs),
+            advance_sp: page_no_glyphs.iter().map(|glyph| glyph.advance_sp).sum(),
             advance_pt: page_no_width_pt,
             is_link: title_links_enabled,
             superscript: false,

--- a/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
@@ -5,12 +5,63 @@ fn glyphs_advance_pt_v0(glyphs: &[GlyphPlanV0]) -> f32 {
         .sum()
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SegmentEmitProfileV0 {
+    Default,
+    BodyProseV13,
+}
+
+const BODY_PROSE_ITALIC_SCALE_PERCENT_V13: u8 = 97;
+const BODY_PROSE_BOLD_SCALE_PERCENT_V13: u8 = 95;
+
+fn body_prose_style_scale_percent_v13(segment: &PdfRenderSegmentV0) -> u8 {
+    if segment.is_link || segment.superscript {
+        return 100;
+    }
+    if !segment.bytes.iter().any(|byte| byte.is_ascii_alphabetic()) {
+        return 100;
+    }
+    match segment.style {
+        PdfTextStyleV0::Regular => 100,
+        PdfTextStyleV0::Italic => BODY_PROSE_ITALIC_SCALE_PERCENT_V13,
+        PdfTextStyleV0::Bold => BODY_PROSE_BOLD_SCALE_PERCENT_V13,
+    }
+}
+
+fn style_scale_percent_for_profile_v0(
+    segment: &PdfRenderSegmentV0,
+    profile: SegmentEmitProfileV0,
+) -> u8 {
+    match profile {
+        SegmentEmitProfileV0::Default => 100,
+        SegmentEmitProfileV0::BodyProseV13 => body_prose_style_scale_percent_v13(segment),
+    }
+}
+
 fn emit_styled_segments_v0(
     out: &mut Vec<u8>,
     segments: &[PdfStyledSegmentV0],
     x_pt: f32,
     y_pt: f32,
     font_size_pt: f32,
+) {
+    emit_styled_segments_with_profile_v0(
+        out,
+        segments,
+        x_pt,
+        y_pt,
+        font_size_pt,
+        SegmentEmitProfileV0::Default,
+    );
+}
+
+fn emit_styled_segments_with_profile_v0(
+    out: &mut Vec<u8>,
+    segments: &[PdfStyledSegmentV0],
+    x_pt: f32,
+    y_pt: f32,
+    font_size_pt: f32,
+    profile: SegmentEmitProfileV0,
 ) {
     if segments.is_empty() {
         return;
@@ -20,12 +71,20 @@ fn emit_styled_segments_v0(
         render_segments.push(PdfRenderSegmentV0 {
             style: segment.style,
             bytes: bytes_from_glyphs_v0(&segment.glyphs),
+            advance_sp: segment.advance_sp,
             advance_pt: segment.advance_pt,
             is_link: segment.is_link,
             superscript: false,
         });
     }
-    emit_render_segments_with_superscript_v0(out, &render_segments, x_pt, y_pt, font_size_pt);
+    emit_render_segments_with_superscript_with_profile_v0(
+        out,
+        &render_segments,
+        x_pt,
+        y_pt,
+        font_size_pt,
+        profile,
+    );
 }
 
 fn emit_render_segments_with_superscript_v0(
@@ -35,6 +94,24 @@ fn emit_render_segments_with_superscript_v0(
     y_pt: f32,
     font_size_pt: f32,
 ) {
+    emit_render_segments_with_superscript_with_profile_v0(
+        out,
+        segments,
+        x_pt,
+        y_pt,
+        font_size_pt,
+        SegmentEmitProfileV0::Default,
+    );
+}
+
+fn emit_render_segments_with_superscript_with_profile_v0(
+    out: &mut Vec<u8>,
+    segments: &[PdfRenderSegmentV0],
+    x_pt: f32,
+    y_pt: f32,
+    font_size_pt: f32,
+    profile: SegmentEmitProfileV0,
+) {
     if segments.is_empty() {
         return;
     }
@@ -42,8 +119,12 @@ fn emit_render_segments_with_superscript_v0(
     let y_pt_f64 = f64::from(y_pt);
     for segment in segments {
         if segment.bytes.is_empty() {
-            cursor_x += f64::from(segment.advance_pt);
+            cursor_x += f64::from(segment.advance_sp) / 65_536.0;
             continue;
+        }
+        let style_scale_percent = style_scale_percent_for_profile_v0(segment, profile);
+        if style_scale_percent != 100 {
+            out.extend_from_slice(format!("{style_scale_percent} Tz ").as_bytes());
         }
         out.extend_from_slice(b"1 0 0 1 ");
         out.extend_from_slice(format!("{cursor_x:.3} {y_pt_f64:.3} Tm ").as_bytes());
@@ -66,7 +147,10 @@ fn emit_render_segments_with_superscript_v0(
         out.extend_from_slice(b" Tf (");
         out.extend_from_slice(&escaped);
         out.extend_from_slice(b") Tj ");
-        cursor_x += f64::from(segment.advance_pt);
+        if style_scale_percent != 100 {
+            out.extend_from_slice(b"100 Tz ");
+        }
+        cursor_x += f64::from(segment.advance_sp) / 65_536.0;
     }
     out.extend_from_slice(b"0 Ts ");
 }

--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
@@ -800,6 +800,56 @@ fn pdf_renderer_body_wrap_balances_lines_and_preserves_styled_punctuation_seams_
 }
 
 #[test]
+fn pdf_renderer_body_paragraph_applies_style_scaling_for_styled_seams_v13() {
+    let demo_text = b"Title\nAuthor\n2026-03-05\n\nBody prose with [ITALICV13] seam and {BOLDV13} seam.";
+    let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept body prose");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    let italic_line = pdf_text
+        .lines()
+        .find(|line| line.contains("(ITALICV13) Tj"))
+        .expect("italic body segment should render");
+    let bold_line = pdf_text
+        .lines()
+        .find(|line| line.contains("(BOLDV13) Tj"))
+        .expect("bold body segment should render");
+
+    assert!(
+        italic_line.contains("97 Tz") && italic_line.contains("(ITALICV13) Tj 100 Tz"),
+        "body prose italic segment should use v13 seam-scaling compensation"
+    );
+    assert!(
+        bold_line.contains("95 Tz") && bold_line.contains("(BOLDV13) Tj 100 Tz"),
+        "body prose bold segment should use v13 seam-scaling compensation"
+    );
+}
+
+#[test]
+fn pdf_renderer_non_paragraph_blocks_do_not_use_body_seam_scaling_v13() {
+    let demo_text = b"Title\nAuthor\n2026-03-05\n\n^ Center [ITALICCENTERV13] text.\n\n> Quote {BOLDQUOTEV13} line.";
+    let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept non-paragraph blocks");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    let centered_line = pdf_text
+        .lines()
+        .find(|line| line.contains("(ITALICCENTERV13) Tj"))
+        .expect("centered styled segment should render");
+    let quote_line = pdf_text
+        .lines()
+        .find(|line| line.contains("(BOLDQUOTEV13) Tj"))
+        .expect("quote styled segment should render");
+
+    assert!(
+        !centered_line.contains("97 Tz"),
+        "centered non-paragraph line should not use body seam-scaling compensation"
+    );
+    assert!(
+        !quote_line.contains("95 Tz"),
+        "quote non-paragraph line should not use body seam-scaling compensation"
+    );
+}
+
+#[test]
 fn pdf_renderer_centers_title_block_lines_within_epsilon_v0() {
     let demo_text = b"Centering Accuracy Title\nAlice Bob\n2026-03-05\n\nBody line.";
     let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept demo text");


### PR DESCRIPTION
Closes #457

## Summary
- polish body-text punctuation and wrapper seam spacing in ordinary prose beyond v12 wrap balancing
- refine mixed styled-span transitions in body paragraphs with deterministic seam compensation
- stabilize long-prose density behavior for wrapped body lines with mixed style boundaries

## Validation
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml
- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12
- ./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25