### PR TITLE
pdf fidelity bundle v15: inline math seam polish

### DIFF
--- a/crates/carreltex-xdv/src/layout_v0.rs
+++ b/crates/carreltex-xdv/src/layout_v0.rs
@@ -167,12 +167,32 @@ fn wrap_logical_line_v0(line: &[u8], max_line_glyphs: usize) -> Option<Vec<Vec<u
 const WRAP_BALANCE_REMAINDER_CHARS_MAX_V12: usize = 12;
 const WRAP_BALANCE_MIN_FILL_NUM_V12: u32 = 11;
 const WRAP_BALANCE_MIN_FILL_DEN_V12: u32 = 20;
+const INLINE_MATH_PLACEHOLDER_TOKEN_V15: &[u8] = b"MATH";
 
 fn is_wrap_unfriendly_leading_byte_v12(byte: u8) -> bool {
     matches!(
         byte,
         b'.' | b',' | b';' | b':' | b'!' | b'?' | b')' | b']' | b'}'
     )
+}
+
+fn is_token_delimiter_byte_v15(byte: u8) -> bool {
+    byte == b' '
+        || matches!(
+            byte,
+            b'.'
+                | b','
+                | b';'
+                | b':'
+                | b'!'
+                | b'?'
+                | b'('
+                | b')'
+                | b'['
+                | b']'
+                | b'{'
+                | b'}'
+        )
 }
 
 fn next_visible_byte_after_v12(line: &[u8], start: usize) -> Option<u8> {
@@ -194,6 +214,73 @@ fn remaining_visible_count_v12(line: &[u8], start: usize) -> usize {
         .copied()
         .filter(|byte| *byte != b' ' && !is_style_marker_byte_v0(*byte))
         .count()
+}
+
+fn next_visible_token_is_inline_math_v15(line: &[u8], start: usize) -> bool {
+    let mut cursor = start;
+    while cursor < line.len() {
+        let byte = line[cursor];
+        if is_style_marker_byte_v0(byte) || is_token_delimiter_byte_v15(byte) {
+            cursor += 1;
+            continue;
+        }
+        break;
+    }
+    if cursor >= line.len() {
+        return false;
+    }
+    let mut token = Vec::<u8>::new();
+    while cursor < line.len() {
+        let byte = line[cursor];
+        if is_token_delimiter_byte_v15(byte) {
+            break;
+        }
+        if !is_style_marker_byte_v0(byte) {
+            token.push(byte);
+            if token.len() > INLINE_MATH_PLACEHOLDER_TOKEN_V15.len() {
+                return false;
+            }
+        }
+        cursor += 1;
+    }
+    token == INLINE_MATH_PLACEHOLDER_TOKEN_V15
+}
+
+fn previous_visible_token_is_inline_math_v15(line: &[u8], end_exclusive: usize) -> bool {
+    if end_exclusive == 0 {
+        return false;
+    }
+    let mut cursor = end_exclusive;
+    while cursor > 0 {
+        let byte = line[cursor - 1];
+        if is_style_marker_byte_v0(byte) || is_token_delimiter_byte_v15(byte) {
+            cursor -= 1;
+            continue;
+        }
+        break;
+    }
+    if cursor == 0 {
+        return false;
+    }
+    let token_end = cursor;
+    while cursor > 0 {
+        let byte = line[cursor - 1];
+        if is_token_delimiter_byte_v15(byte) {
+            break;
+        }
+        cursor -= 1;
+    }
+    let mut token = Vec::<u8>::new();
+    for byte in line[cursor..token_end].iter().copied() {
+        if is_style_marker_byte_v0(byte) {
+            continue;
+        }
+        token.push(byte);
+        if token.len() > INLINE_MATH_PLACEHOLDER_TOKEN_V15.len() {
+            return false;
+        }
+    }
+    token == INLINE_MATH_PLACEHOLDER_TOKEN_V15
 }
 
 fn wrap_logical_line_by_width_v0(
@@ -250,12 +337,18 @@ fn wrap_logical_line_by_width_v0(
                     next_visible_byte_after_v12(line, next_line_start)
                         .map(is_wrap_unfriendly_leading_byte_v12)
                         .unwrap_or(false);
+                let inline_math_leading_remainder =
+                    next_visible_token_is_inline_math_v15(line, next_line_start);
+                let inline_math_trailing_token =
+                    previous_visible_token_is_inline_math_v15(line, candidate_space_index);
                 let min_fill_sp = max_line_width_sp
                     .checked_mul(WRAP_BALANCE_MIN_FILL_NUM_V12)?
                     .checked_div(WRAP_BALANCE_MIN_FILL_DEN_V12)?;
-                if candidate_width_sp >= min_fill_sp
-                    && (short_remainder || punctuation_leading_remainder)
-                {
+                let should_backtrack_for_inline_math =
+                    inline_math_leading_remainder || inline_math_trailing_token;
+                let should_backtrack_for_short_or_punctuation = candidate_width_sp >= min_fill_sp
+                    && (short_remainder || punctuation_leading_remainder);
+                if should_backtrack_for_short_or_punctuation || should_backtrack_for_inline_math {
                     chosen_space_candidate -= 1;
                     continue;
                 }

--- a/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
@@ -171,6 +171,21 @@ fn line_starts_bibliography_entry_v14(
     )
 }
 
+fn line_contains_inline_math_placeholder_token_v15(segments: &[PdfRenderSegmentV0]) -> bool {
+    let mut text = Vec::<u8>::new();
+    for segment in segments {
+        text.extend_from_slice(&segment.bytes);
+    }
+    text.split(|byte| {
+        byte.is_ascii_whitespace()
+            || matches!(
+                *byte,
+                b'.' | b',' | b';' | b':' | b'!' | b'?' | b'(' | b')' | b'[' | b']' | b'{' | b'}'
+            )
+    })
+    .any(|token| token == b"MATH")
+}
+
 #[derive(Clone)]
 struct PageContinuationStateV0 {
     previous_rendered_line_was_empty: bool,
@@ -767,7 +782,11 @@ fn build_page_content_stream_v0(
             annotations.append(&mut line_annotations);
             let has_superscript = render_segments.iter().any(|segment| segment.superscript);
             let emit_profile = if current_flow_kind == BodyFlowKindV0::Paragraph {
-                SegmentEmitProfileV0::BodyProseV13
+                if line_contains_inline_math_placeholder_token_v15(&render_segments) {
+                    SegmentEmitProfileV0::BodyProseInlineMathV15
+                } else {
+                    SegmentEmitProfileV0::BodyProseV13
+                }
             } else {
                 SegmentEmitProfileV0::Default
             };

--- a/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
@@ -9,10 +9,13 @@ fn glyphs_advance_pt_v0(glyphs: &[GlyphPlanV0]) -> f32 {
 enum SegmentEmitProfileV0 {
     Default,
     BodyProseV13,
+    BodyProseInlineMathV15,
 }
 
 const BODY_PROSE_ITALIC_SCALE_PERCENT_V13: u8 = 97;
 const BODY_PROSE_BOLD_SCALE_PERCENT_V13: u8 = 95;
+const BODY_PROSE_INLINE_MATH_ITALIC_SCALE_PERCENT_V15: u8 = 99;
+const BODY_PROSE_INLINE_MATH_BOLD_SCALE_PERCENT_V15: u8 = 97;
 
 fn body_prose_style_scale_percent_v13(segment: &PdfRenderSegmentV0) -> u8 {
     if segment.is_link || segment.superscript {
@@ -35,6 +38,19 @@ fn style_scale_percent_for_profile_v0(
     match profile {
         SegmentEmitProfileV0::Default => 100,
         SegmentEmitProfileV0::BodyProseV13 => body_prose_style_scale_percent_v13(segment),
+        SegmentEmitProfileV0::BodyProseInlineMathV15 => {
+            if segment.is_link || segment.superscript {
+                return 100;
+            }
+            if !segment.bytes.iter().any(|byte| byte.is_ascii_alphabetic()) {
+                return 100;
+            }
+            match segment.style {
+                PdfTextStyleV0::Regular => 100,
+                PdfTextStyleV0::Italic => BODY_PROSE_INLINE_MATH_ITALIC_SCALE_PERCENT_V15,
+                PdfTextStyleV0::Bold => BODY_PROSE_INLINE_MATH_BOLD_SCALE_PERCENT_V15,
+            }
+        }
     }
 }
 

--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
@@ -850,6 +850,67 @@ fn pdf_renderer_non_paragraph_blocks_do_not_use_body_seam_scaling_v13() {
 }
 
 #[test]
+fn pdf_renderer_body_paragraph_uses_inline_math_seam_scaling_profile_v15() {
+    let demo_text =
+        b"Title\nAuthor\n2026-03-05\n\nBody [ITALICMATHV15] MATH seam and {BOLDMATHV15} MATH seam.";
+    let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept inline math seam text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    let italic_line = pdf_text
+        .lines()
+        .find(|line| line.contains("(ITALICMATHV15) Tj"))
+        .expect("italic inline-math-adjacent segment should render");
+    let bold_line = pdf_text
+        .lines()
+        .find(|line| line.contains("(BOLDMATHV15) Tj"))
+        .expect("bold inline-math-adjacent segment should render");
+    assert!(
+        italic_line.contains("99 Tz"),
+        "inline-math-adjacent italic segment should use v15 seam scaling"
+    );
+    assert!(
+        bold_line.contains("97 Tz"),
+        "inline-math-adjacent bold segment should use v15 seam scaling"
+    );
+}
+
+#[test]
+fn pdf_renderer_wrap_avoids_inline_math_placeholder_at_line_start_v15() {
+    let xdv = write_dvi_v2_text_page_with_layout_and_wrap_v0(
+        b"PSTART alpha beta gamma MATH, delta epsilon zeta eta WRAPTOKEN",
+        65_536,
+        786_432,
+        30,
+    )
+    .expect("writer should accept wrapped inline-math paragraph");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let rendered_math_line =
+        rendered_text_for_line_containing_needle_v0(&pdf, "MATH").expect("inline math placeholder should render");
+    let (start_x, start_y) =
+        tm_position_for_segment_substring_v0(&pdf, "PSTART").expect("paragraph start");
+    let (wrap_x, wrap_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "WRAPTOKEN").expect("wrap line");
+    let epsilon_pt = 0.05f32;
+    assert!(
+        (start_x - 72.0).abs() <= epsilon_pt && (wrap_x - 72.0).abs() <= epsilon_pt,
+        "wrapped body paragraph columns should stay stable: start_x={start_x}, wrap_x={wrap_x}"
+    );
+    assert!(
+        start_y > wrap_y,
+        "wrapped inline-math paragraph line should render below paragraph start: start_y={start_y}, wrap_y={wrap_y}"
+    );
+    let line_steps = ((start_y - wrap_y) / 13.0).round();
+    assert!(
+        line_steps >= 1.0 && (start_y - wrap_y - (line_steps * 13.0)).abs() <= epsilon_pt,
+        "wrapped inline-math paragraph rhythm should stay on stable 13pt steps: start_y={start_y}, wrap_y={wrap_y}, line_steps={line_steps}"
+    );
+    assert!(
+        rendered_math_line.contains("MATH,") && !rendered_math_line.contains("MATH ,"),
+        "inline math placeholder should keep punctuation-adjacent seam spacing stable under wrapping: rendered_math_line={rendered_math_line:?}"
+    );
+}
+
+#[test]
 fn pdf_renderer_centers_title_block_lines_within_epsilon_v0() {
     let demo_text = b"Centering Accuracy Title\nAlice Bob\n2026-03-05\n\nBody line.";
     let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept demo text");


### PR DESCRIPTION
Closes #461

## Summary
- add inline-math-aware body seam scaling profile for paragraph text emission
- add wrap heuristics to avoid awkward inline math placeholder seam starts/ends when alternative breaks exist
- add focused renderer tests pinning inline math seam scaling and wrap behavior

## Proof gates
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml
- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12
- ./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25