### PR TITLE
pdf fidelity bundle v22: heading transition polish

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
@@ -1,6 +1,7 @@
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum BodyFlowKindV0 {
     FrontMatter,
+    Heading,
     Paragraph,
     DisplayMath,
     BibliographyHeading,
@@ -74,7 +75,7 @@ fn classify_next_flow_kind_v0(
             return Some(BodyFlowKindV0::Table);
         }
         if is_centered_heading_candidate_line_v12(lines, line_index, title_block_len) {
-            return Some(BodyFlowKindV0::Other);
+            return Some(BodyFlowKindV0::Heading);
         }
         if has_figure_box_marker_prefix_v0(&line.glyphs)
             || has_figure_image_prefix_v0(&line.glyphs)
@@ -107,7 +108,7 @@ fn classify_next_flow_kind_v0(
             if line_is_bibliography_heading_v17(&line.glyphs) {
                 return Some(BodyFlowKindV0::BibliographyHeading);
             }
-            return Some(BodyFlowKindV0::Other);
+            return Some(BodyFlowKindV0::Heading);
         }
         let render_glyphs = if noindent_prefixed {
             &line.glyphs[2..]
@@ -149,7 +150,17 @@ fn should_tighten_transition_gap_v7(previous: BodyFlowKindV0, next: BodyFlowKind
             | (BodyFlowKindV0::Paragraph, BodyFlowKindV0::Table)
             | (BodyFlowKindV0::Table, BodyFlowKindV0::Paragraph)
             | (BodyFlowKindV0::Table, BodyFlowKindV0::Table)
+            | (BodyFlowKindV0::Paragraph, BodyFlowKindV0::Heading)
+            | (BodyFlowKindV0::Heading, BodyFlowKindV0::Paragraph)
+            | (BodyFlowKindV0::List, BodyFlowKindV0::Heading)
+            | (BodyFlowKindV0::Heading, BodyFlowKindV0::List)
+            | (BodyFlowKindV0::Quote, BodyFlowKindV0::Heading)
+            | (BodyFlowKindV0::Heading, BodyFlowKindV0::Quote)
+            | (BodyFlowKindV0::Table, BodyFlowKindV0::Heading)
+            | (BodyFlowKindV0::Heading, BodyFlowKindV0::Table)
+            | (BodyFlowKindV0::Heading, BodyFlowKindV0::Heading)
             | (BodyFlowKindV0::FrontMatter, BodyFlowKindV0::Paragraph)
+            | (BodyFlowKindV0::FrontMatter, BodyFlowKindV0::Heading)
             | (BodyFlowKindV0::FrontMatter, BodyFlowKindV0::Other)
     )
 }
@@ -161,6 +172,7 @@ fn is_quote_transition_v19(previous: BodyFlowKindV0, next: BodyFlowKindV0) -> bo
 fn transition_blank_advance_pt_v7(previous: BodyFlowKindV0, next: BodyFlowKindV0) -> f32 {
     let previous_leading_pt = match previous {
         BodyFlowKindV0::FrontMatter => LEADING_PT_V0,
+        BodyFlowKindV0::Heading => LEADING_PT_V0,
         BodyFlowKindV0::DisplayMath => LEADING_PT_V0,
         BodyFlowKindV0::BibliographyHeading => LEADING_PT_V0,
         BodyFlowKindV0::List => LIST_ENTRY_LEADING_PT_V7,
@@ -704,7 +716,7 @@ fn build_page_content_stream_v0(
                 || right_continuation
                 || centered_continuation
             {
-                BodyFlowKindV0::Other
+                BodyFlowKindV0::Heading
             } else {
                 BodyFlowKindV0::Paragraph
             };

--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
@@ -1139,11 +1139,11 @@ fn pdf_renderer_paragraph_rhythm_and_noindent_invariants_v0() {
         "paragraph break gap mismatch: same_para_y={same_para_y}, second_para_y={second_para_y}"
     );
     assert!(
-        (second_para_y - heading_y - 28.0).abs() <= epsilon_pt,
+        (second_para_y - heading_y - 24.0).abs() <= epsilon_pt,
         "paragraph->heading gap mismatch: second_para_y={second_para_y}, heading_y={heading_y}"
     );
     assert!(
-        (heading_y - after_heading_y - 28.0).abs() <= epsilon_pt,
+        (heading_y - after_heading_y - 24.0).abs() <= epsilon_pt,
         "heading->noindent gap mismatch: heading_y={heading_y}, after_heading_y={after_heading_y}"
     );
     assert!(
@@ -1339,11 +1339,11 @@ fn pdf_renderer_section_heading_spacing_invariants_v0() {
         .expect("body position");
 
     assert!(
-        (intro_y - heading_y - 28.0).abs() <= 0.02,
+        (intro_y - heading_y - 24.0).abs() <= 0.02,
         "intro->heading y-gap mismatch: intro_y={intro_y}, heading_y={heading_y}"
     );
     assert!(
-        (heading_y - body_y - 28.0).abs() <= 0.02,
+        (heading_y - body_y - 24.0).abs() <= 0.02,
         "heading->body y-gap mismatch: heading_y={heading_y}, body_y={body_y}"
     );
     assert!(
@@ -1353,6 +1353,88 @@ fn pdf_renderer_section_heading_spacing_invariants_v0() {
     assert!(
         (body_x - 72.0).abs() <= 0.02,
         "first paragraph after heading should not indent: {body_x}"
+    );
+}
+
+#[test]
+fn pdf_renderer_front_matter_heading_opening_rhythm_polish_v22() {
+    let demo_text = b"Title\nAuthor\n2026-03-05\n\n@S {Front Heading}\n\n~ Body after front heading.";
+    let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept front-matter heading text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let (_, date_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(2026-03-05)").expect("date position");
+    let (_, heading_y) = tm_position_for_line_containing_text_v0(&pdf, "(Front Heading)")
+        .expect("heading position");
+    let (_, body_y) = tm_position_for_line_containing_text_v0(&pdf, "(Body after front heading.)")
+        .expect("body position");
+
+    let epsilon_pt = 0.02f32;
+    assert!(
+        (date_y - heading_y - 38.0).abs() <= epsilon_pt,
+        "front-matter->heading opening gap mismatch: date_y={date_y}, heading_y={heading_y}"
+    );
+    assert!(
+        (heading_y - body_y - 24.0).abs() <= epsilon_pt,
+        "heading->first-body gap mismatch: heading_y={heading_y}, body_y={body_y}"
+    );
+}
+
+#[test]
+fn pdf_renderer_heading_transitions_across_list_quote_table_polish_v22() {
+    let demo_text = b"\nPrelude paragraph.\n\n- List line one.\n- List line two.\n\n@S {After List Heading}\n\n~ Body after list heading.\n\n> Quote line one.\n> Quote line two.\n\n@S {After Quote Heading}\n\n~ Body after quote heading.\n\n!ts ll\n!t TROWONEA||TROWONEB\n!t TROWTWOA||TROWTWOB\n\n@S {After Table Heading}\n\n~ Body after table heading.";
+    let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept mixed heading transition text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let (_, list_two_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(List line two.)").expect("list line two");
+    let (_, after_list_heading_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(After List Heading)")
+            .expect("after-list heading");
+    let (_, after_list_body_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Body after list heading.)")
+            .expect("after-list body");
+    let (_, quote_two_y) = tm_position_for_line_containing_text_v0(&pdf, "(Quote line two.)")
+        .expect("quote line two");
+    let (_, after_quote_heading_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(After Quote Heading)")
+            .expect("after-quote heading");
+    let (_, after_quote_body_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Body after quote heading.)")
+            .expect("after-quote body");
+    let (_, table_row_two_y) =
+        tm_position_for_segment_substring_v0(&pdf, "TROWTWOA").expect("table row two");
+    let (_, after_table_heading_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(After Table Heading)")
+            .expect("after-table heading");
+    let (_, after_table_body_y) =
+        tm_position_for_line_containing_text_v0(&pdf, "(Body after table heading.)")
+            .expect("after-table body");
+
+    let epsilon_pt = 0.2f32;
+    assert!(
+        (list_two_y - after_list_heading_y - 24.0).abs() <= epsilon_pt,
+        "list->heading gap mismatch: list_two_y={list_two_y}, after_list_heading_y={after_list_heading_y}"
+    );
+    assert!(
+        (after_list_heading_y - after_list_body_y - 24.0).abs() <= epsilon_pt,
+        "heading->paragraph gap mismatch after list: after_list_heading_y={after_list_heading_y}, after_list_body_y={after_list_body_y}"
+    );
+    assert!(
+        (quote_two_y - after_quote_heading_y - 23.0).abs() <= epsilon_pt,
+        "quote->heading gap mismatch: quote_two_y={quote_two_y}, after_quote_heading_y={after_quote_heading_y}"
+    );
+    assert!(
+        (after_quote_heading_y - after_quote_body_y - 24.0).abs() <= epsilon_pt,
+        "heading->paragraph gap mismatch after quote: after_quote_heading_y={after_quote_heading_y}, after_quote_body_y={after_quote_body_y}"
+    );
+    assert!(
+        (table_row_two_y - after_table_heading_y - 24.0).abs() <= epsilon_pt,
+        "table->heading gap mismatch: table_row_two_y={table_row_two_y}, after_table_heading_y={after_table_heading_y}"
+    );
+    assert!(
+        (after_table_heading_y - after_table_body_y - 24.0).abs() <= epsilon_pt,
+        "heading->paragraph gap mismatch after table: after_table_heading_y={after_table_heading_y}, after_table_body_y={after_table_body_y}"
     );
 }
 
@@ -1382,9 +1464,9 @@ fn pdf_renderer_heading_list_quote_rhythm_invariants_v0() {
             .expect("after quote");
 
     let epsilon_pt = 0.02f32;
-    assert!((prelude_y - heading_y - 28.0).abs() <= epsilon_pt);
+    assert!((prelude_y - heading_y - 24.0).abs() <= epsilon_pt);
     assert!(
-        (heading_y - after_heading_y - 28.0).abs() <= epsilon_pt,
+        (heading_y - after_heading_y - 24.0).abs() <= epsilon_pt,
         "heading->first paragraph gap mismatch: heading_y={heading_y}, after_heading_y={after_heading_y}"
     );
     assert!(

--- a/crates/carreltex-xdv/src/tests/toc_outline_v0.rs
+++ b/crates/carreltex-xdv/src/tests/toc_outline_v0.rs
@@ -496,7 +496,7 @@ fn pdf_renderer_front_matter_toc_heading_rhythm_is_stable_v11() {
         "front-matter toc->first-heading transition should stay tightened and deterministic: toc_entry_y={toc_entry_y}, heading_y={heading_y}"
     );
     assert!(
-        (heading_y - body_y - 28.0).abs() <= epsilon_pt,
+        (heading_y - body_y - 24.0).abs() <= epsilon_pt,
         "heading->first-body rhythm should remain stable: heading_y={heading_y}, body_y={body_y}"
     );
     assert!(
@@ -542,7 +542,7 @@ fn pdf_renderer_front_matter_toc_body_bibliography_flow_rhythm_is_stable_v17() {
         "toc->first heading transition should stay tightened: toc_entry_y={toc_entry_y}, heading_y={heading_y}"
     );
     assert!(
-        (heading_y - body_y - 28.0).abs() <= epsilon_pt,
+        (heading_y - body_y - 24.0).abs() <= epsilon_pt,
         "heading->body transition should remain stable: heading_y={heading_y}, body_y={body_y}"
     );
     assert!(


### PR DESCRIPTION
Closes #475

## Summary
- classify section-style heading lines as heading flow so transition tightening applies consistently across mixed-content seams
- tighten heading transition handling for paragraph/list/table/front-matter adjacency while preserving quote-specific rhythm
- add focused heading-transition invariants across front matter, list/quote/table blocks, and update affected TOC heading rhythm assertions

## Proof
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml
- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12
- ./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25