### PR TITLE
pdf fidelity bundle v26: final visible roughness sweep

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0/annotations_and_metadata_flow_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/annotations_and_metadata_flow_v0.rs
@@ -89,6 +89,7 @@ fn collect_link_annotations_for_line_v0(
     line_x_pt: f32,
     line_y_pt: f32,
     font_size_pt: f32,
+    emit_profile: SegmentEmitProfileV0,
     profile: AnnotationRectProfileV0,
     link_targets_by_id: &BTreeMap<u32, PdfLinkTargetV0>,
     next_link_id: &mut u32,
@@ -103,7 +104,7 @@ fn collect_link_annotations_for_line_v0(
 
     for segment in segments {
         let start_x = cursor_x;
-        let end_x = cursor_x + segment.advance_pt;
+        let end_x = cursor_x + render_advance_pt_for_segment_with_profile_v0(segment, emit_profile);
         if segment.is_link {
             if run_start_x.is_none() {
                 run_start_x = Some(start_x);

--- a/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
@@ -882,6 +882,15 @@ fn build_page_content_stream_v0(
                 || heading_centered
                 || center_prefixed
                 || centered_continuation;
+            let emit_profile = if current_flow_kind == BodyFlowKindV0::Paragraph {
+                if line_contains_inline_math_placeholder_token_v15(&render_segments) {
+                    SegmentEmitProfileV0::BodyProseInlineMathV15
+                } else {
+                    SegmentEmitProfileV0::BodyProseV13
+                }
+            } else {
+                SegmentEmitProfileV0::Default
+            };
             let annotation_profile = if bibliography_line {
                 AnnotationRectProfileV0::BibliographyV14
             } else if centered_or_heading_context {
@@ -894,6 +903,7 @@ fn build_page_content_stream_v0(
                 line_x,
                 y,
                 font_size_pt,
+                emit_profile,
                 annotation_profile,
                 link_targets_by_id,
                 next_link_id,
@@ -902,15 +912,6 @@ fn build_page_content_stream_v0(
             )?;
             annotations.append(&mut line_annotations);
             let has_superscript = render_segments.iter().any(|segment| segment.superscript);
-            let emit_profile = if current_flow_kind == BodyFlowKindV0::Paragraph {
-                if line_contains_inline_math_placeholder_token_v15(&render_segments) {
-                    SegmentEmitProfileV0::BodyProseInlineMathV15
-                } else {
-                    SegmentEmitProfileV0::BodyProseV13
-                }
-            } else {
-                SegmentEmitProfileV0::Default
-            };
             if has_superscript {
                 emit_render_segments_with_superscript_with_profile_v0(
                     &mut out,
@@ -1016,6 +1017,7 @@ fn build_page_content_stream_v0(
                         line_x_pt,
                         footnote_y,
                         FOOTNOTE_FONT_SIZE_PT_V0,
+                        SegmentEmitProfileV0::FootnoteProseV26,
                         AnnotationRectProfileV0::FootnoteV18,
                         link_targets_by_id,
                         next_link_id,
@@ -1028,20 +1030,22 @@ fn build_page_content_stream_v0(
                     annotations.append(&mut line_annotations);
                     let has_superscript = render_segments.iter().any(|segment| segment.superscript);
                     if has_superscript {
-                        emit_render_segments_with_superscript_v0(
+                        emit_render_segments_with_superscript_with_profile_v0(
                             &mut out,
                             &render_segments,
                             line_x_pt,
                             footnote_y,
                             FOOTNOTE_FONT_SIZE_PT_V0,
+                            SegmentEmitProfileV0::FootnoteProseV26,
                         );
                     } else {
-                        emit_styled_segments_v0(
+                        emit_styled_segments_with_profile_v0(
                             &mut out,
                             &segments,
                             line_x_pt,
                             footnote_y,
                             FOOTNOTE_FONT_SIZE_PT_V0,
+                            SegmentEmitProfileV0::FootnoteProseV26,
                         );
                     }
                     out.extend_from_slice(b"\n");

--- a/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
@@ -9,6 +9,7 @@ fn glyphs_advance_pt_v0(glyphs: &[GlyphPlanV0]) -> f32 {
 enum SegmentEmitProfileV0 {
     Default,
     BodyProseV13,
+    FootnoteProseV26,
     BodyProseInlineMathV15,
 }
 
@@ -17,8 +18,22 @@ const BODY_PROSE_BOLD_SCALE_PERCENT_V13: u8 = 95;
 const BODY_PROSE_INLINE_MATH_ITALIC_SCALE_PERCENT_V15: u8 = 99;
 const BODY_PROSE_INLINE_MATH_BOLD_SCALE_PERCENT_V15: u8 = 97;
 
+fn footnote_prose_style_scale_percent_v26(segment: &PdfRenderSegmentV0) -> u8 {
+    if segment.superscript {
+        return 100;
+    }
+    if !segment.bytes.iter().any(|byte| byte.is_ascii_alphabetic()) {
+        return 100;
+    }
+    match segment.style {
+        PdfTextStyleV0::Regular => 100,
+        PdfTextStyleV0::Italic => BODY_PROSE_ITALIC_SCALE_PERCENT_V13,
+        PdfTextStyleV0::Bold => BODY_PROSE_BOLD_SCALE_PERCENT_V13,
+    }
+}
+
 fn body_prose_style_scale_percent_v13(segment: &PdfRenderSegmentV0) -> u8 {
-    if segment.is_link || segment.superscript {
+    if segment.superscript || segment.is_link {
         return 100;
     }
     if !segment.bytes.iter().any(|byte| byte.is_ascii_alphabetic()) {
@@ -38,8 +53,9 @@ fn style_scale_percent_for_profile_v0(
     match profile {
         SegmentEmitProfileV0::Default => 100,
         SegmentEmitProfileV0::BodyProseV13 => body_prose_style_scale_percent_v13(segment),
+        SegmentEmitProfileV0::FootnoteProseV26 => footnote_prose_style_scale_percent_v26(segment),
         SegmentEmitProfileV0::BodyProseInlineMathV15 => {
-            if segment.is_link || segment.superscript {
+            if segment.superscript || segment.is_link {
                 return 100;
             }
             if !segment.bytes.iter().any(|byte| byte.is_ascii_alphabetic()) {
@@ -51,6 +67,21 @@ fn style_scale_percent_for_profile_v0(
                 PdfTextStyleV0::Bold => BODY_PROSE_INLINE_MATH_BOLD_SCALE_PERCENT_V15,
             }
         }
+    }
+}
+
+fn render_advance_pt_for_segment_with_profile_v0(
+    segment: &PdfRenderSegmentV0,
+    profile: SegmentEmitProfileV0,
+) -> f32 {
+    if profile != SegmentEmitProfileV0::FootnoteProseV26 {
+        return segment.advance_pt;
+    }
+    let style_scale_percent = style_scale_percent_for_profile_v0(segment, profile);
+    if style_scale_percent == 100 {
+        segment.advance_pt
+    } else {
+        segment.advance_pt * (style_scale_percent as f32 / 100.0)
     }
 }
 
@@ -166,7 +197,7 @@ fn emit_render_segments_with_superscript_with_profile_v0(
         if style_scale_percent != 100 {
             out.extend_from_slice(b"100 Tz ");
         }
-        cursor_x += f64::from(segment.advance_sp) / 65_536.0;
+        cursor_x += f64::from(render_advance_pt_for_segment_with_profile_v0(segment, profile));
     }
     out.extend_from_slice(b"0 Ts ");
 }

--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
@@ -825,7 +825,7 @@ fn pdf_renderer_body_paragraph_applies_style_scaling_for_styled_seams_v13() {
 }
 
 #[test]
-fn pdf_renderer_non_paragraph_blocks_do_not_use_body_seam_scaling_v13() {
+fn pdf_renderer_centered_lines_do_not_use_prose_seam_scaling_v13() {
     let demo_text = b"Title\nAuthor\n2026-03-05\n\n^ Center [ITALICCENTERV13] text.\n\n> Quote {BOLDQUOTEV13} line.";
     let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept non-paragraph blocks");
     let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
@@ -834,18 +834,10 @@ fn pdf_renderer_non_paragraph_blocks_do_not_use_body_seam_scaling_v13() {
         .lines()
         .find(|line| line.contains("(ITALICCENTERV13) Tj"))
         .expect("centered styled segment should render");
-    let quote_line = pdf_text
-        .lines()
-        .find(|line| line.contains("(BOLDQUOTEV13) Tj"))
-        .expect("quote styled segment should render");
 
     assert!(
         !centered_line.contains("97 Tz"),
-        "centered non-paragraph line should not use body seam-scaling compensation"
-    );
-    assert!(
-        !quote_line.contains("95 Tz"),
-        "quote non-paragraph line should not use body seam-scaling compensation"
+        "centered non-paragraph line should not use prose seam-scaling compensation"
     );
 }
 
@@ -907,6 +899,33 @@ fn pdf_renderer_wrap_avoids_inline_math_placeholder_at_line_start_v15() {
     assert!(
         rendered_math_line.contains("MATH,") && !rendered_math_line.contains("MATH ,"),
         "inline math placeholder should keep punctuation-adjacent seam spacing stable under wrapping: rendered_math_line={rendered_math_line:?}"
+    );
+}
+
+#[test]
+fn pdf_renderer_footnote_styled_seams_track_scaled_advances_v26() {
+    let demo_text = b"Title\nAuthor\n2026-03-05\n\nBody prose through <{VISIBLELINKV26}>,right beside punctuation.^1\n\n!f 1 Footnote text with [INLINEFOOTNOTEV26].\n!u 1 https://example.com/v26";
+    let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept v26 seam text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let footnote_line = String::from_utf8_lossy(&pdf)
+        .lines()
+        .find(|line| line.contains("(INLINEFOOTNOTEV26) Tj"))
+        .expect("footnote line should render")
+        .to_string();
+    assert!(
+        footnote_line.contains("97 Tz") && footnote_line.contains("(INLINEFOOTNOTEV26) Tj 100 Tz"),
+        "footnote styled segment should use v26 seam compensation"
+    );
+
+    let footnote_italic_x = tm_x_for_segment_substring_v0(&pdf, "(1 Footnote text with ", "(INLINEFOOTNOTEV26)")
+        .expect("footnote italic x");
+    let footnote_period_x =
+        tm_x_for_segment_substring_v0(&pdf, "(1 Footnote text with ", "(.)").expect("footnote period x");
+    let expected_footnote_italic_width = segment_width_pt_v0(b"INLINEFOOTNOTEV26") * 0.97;
+    assert!(
+        ((footnote_period_x - footnote_italic_x) - expected_footnote_italic_width).abs() <= 0.3,
+        "footnote styled seam should advance on compensated rendered width: italic_x={footnote_italic_x}, period_x={footnote_period_x}, expected={expected_footnote_italic_width}"
     );
 }
 


### PR DESCRIPTION
Closes #483

## Summary
- tighten the final visible roughness sweep around seam-sensitive renderer spacing
- keep raw wrapper/link/body advance contracts stable while narrowing compensated advance to footnote prose
- pin the new footnote seam behavior with focused renderer coverage
