### PR TITLE
pdf fidelity bundle v27: final acceptance sweep v1

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
@@ -737,6 +737,16 @@ fn build_page_content_stream_v0(
                     classify_next_flow_kind_v0(lines, line_index + 1, title_block_len),
                     Some(BodyFlowKindV0::Paragraph)
                 );
+            let flowing_line_continues_next_v27 = current_flow_kind == BodyFlowKindV0::Paragraph
+                && !next_raw_line_is_empty
+                && matches!(
+                    classify_next_flow_kind_v0(lines, line_index + 1, title_block_len),
+                    Some(BodyFlowKindV0::Paragraph)
+                );
+            let flowing_line_continues_from_previous_v27 =
+                current_flow_kind == BodyFlowKindV0::Paragraph
+                    && !previous_rendered_line_was_empty
+                    && matches!(last_non_empty_flow_kind, Some(BodyFlowKindV0::Paragraph));
             let line_width_pt: f32 = render_segments
                 .iter()
                 .map(|segment| segment.advance_pt)
@@ -885,6 +895,8 @@ fn build_page_content_stream_v0(
             let emit_profile = if current_flow_kind == BodyFlowKindV0::Paragraph {
                 if line_contains_inline_math_placeholder_token_v15(&render_segments) {
                     SegmentEmitProfileV0::BodyProseInlineMathV15
+                } else if flowing_line_continues_next_v27 || flowing_line_continues_from_previous_v27 {
+                    SegmentEmitProfileV0::BodyWrappedProseV27
                 } else {
                     SegmentEmitProfileV0::BodyProseV13
                 }

--- a/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
@@ -9,6 +9,7 @@ fn glyphs_advance_pt_v0(glyphs: &[GlyphPlanV0]) -> f32 {
 enum SegmentEmitProfileV0 {
     Default,
     BodyProseV13,
+    BodyWrappedProseV27,
     FootnoteProseV26,
     BodyProseInlineMathV15,
 }
@@ -19,6 +20,20 @@ const BODY_PROSE_INLINE_MATH_ITALIC_SCALE_PERCENT_V15: u8 = 99;
 const BODY_PROSE_INLINE_MATH_BOLD_SCALE_PERCENT_V15: u8 = 97;
 
 fn footnote_prose_style_scale_percent_v26(segment: &PdfRenderSegmentV0) -> u8 {
+    if segment.superscript {
+        return 100;
+    }
+    if !segment.bytes.iter().any(|byte| byte.is_ascii_alphabetic()) {
+        return 100;
+    }
+    match segment.style {
+        PdfTextStyleV0::Regular => 100,
+        PdfTextStyleV0::Italic => BODY_PROSE_ITALIC_SCALE_PERCENT_V13,
+        PdfTextStyleV0::Bold => BODY_PROSE_BOLD_SCALE_PERCENT_V13,
+    }
+}
+
+fn wrapped_body_prose_style_scale_percent_v27(segment: &PdfRenderSegmentV0) -> u8 {
     if segment.superscript {
         return 100;
     }
@@ -53,6 +68,9 @@ fn style_scale_percent_for_profile_v0(
     match profile {
         SegmentEmitProfileV0::Default => 100,
         SegmentEmitProfileV0::BodyProseV13 => body_prose_style_scale_percent_v13(segment),
+        SegmentEmitProfileV0::BodyWrappedProseV27 => {
+            wrapped_body_prose_style_scale_percent_v27(segment)
+        }
         SegmentEmitProfileV0::FootnoteProseV26 => footnote_prose_style_scale_percent_v26(segment),
         SegmentEmitProfileV0::BodyProseInlineMathV15 => {
             if segment.superscript || segment.is_link {
@@ -74,7 +92,10 @@ fn render_advance_pt_for_segment_with_profile_v0(
     segment: &PdfRenderSegmentV0,
     profile: SegmentEmitProfileV0,
 ) -> f32 {
-    if profile != SegmentEmitProfileV0::FootnoteProseV26 {
+    if !matches!(
+        profile,
+        SegmentEmitProfileV0::FootnoteProseV26 | SegmentEmitProfileV0::BodyWrappedProseV27
+    ) {
         return segment.advance_pt;
     }
     let style_scale_percent = style_scale_percent_for_profile_v0(segment, profile);

--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
@@ -930,6 +930,46 @@ fn pdf_renderer_footnote_styled_seams_track_scaled_advances_v26() {
 }
 
 #[test]
+fn pdf_renderer_wrapped_body_paragraph_styled_seams_track_scaled_advances_v27() {
+    let demo_text = b"Title\nAuthor\n2026-03-05\n\nWRAPSTART alpha alpha alpha alpha alpha alpha alpha alpha <{BODYLINKWRAPV27}> and [ITALICWRAPV27],right beside punctuation with {BOLDWRAPV27} seam before WRAPTOKENV27.\n\n!u 1 https://example.com/v27";
+    let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept wrapped v27 seam text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    let link_line = pdf_text
+        .lines()
+        .find(|line| line.contains("(BODYLINKWRAPV27) Tj"))
+        .expect("wrapped body link line should render");
+    let italic_line = pdf_text
+        .lines()
+        .find(|line| line.contains("(ITALICWRAPV27) Tj"))
+        .expect("wrapped body italic line should render");
+    let bold_line = pdf_text
+        .lines()
+        .find(|line| line.contains("(BOLDWRAPV27) Tj"))
+        .expect("wrapped body bold line should render");
+
+    assert!(
+        link_line.contains("95 Tz") && link_line.contains("(BODYLINKWRAPV27) Tj 100 Tz"),
+        "wrapped body link segment should use v27 seam compensation"
+    );
+    assert!(
+        italic_line.contains("97 Tz") && italic_line.contains("(ITALICWRAPV27) Tj 100 Tz"),
+        "wrapped body italic segment should use v27 seam compensation"
+    );
+    assert!(
+        bold_line.contains("95 Tz") && bold_line.contains("(BOLDWRAPV27) Tj 100 Tz"),
+        "wrapped body bold segment should use v27 seam compensation"
+    );
+    let (_, wrap_start_y) =
+        tm_position_for_segment_substring_v0(&pdf, "WRAPSTART").expect("wrapped paragraph start");
+    let (_, wrap_token_y) =
+        tm_position_for_segment_substring_v0(&pdf, "WRAPTOKENV27").expect("wrapped paragraph tail");
+    assert!(
+        wrap_start_y > wrap_token_y,
+        "fixture should wrap onto a later body line: wrap_start_y={wrap_start_y}, wrap_token_y={wrap_token_y}"
+    );
+}
+
 fn pdf_renderer_centers_title_block_lines_within_epsilon_v0() {
     let demo_text = b"Centering Accuracy Title\nAlice Bob\n2026-03-05\n\nBody line.";
     let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept demo text");


### PR DESCRIPTION
Closes #485

## Summary
- polish wrapped body seam spacing in the acceptance sweep without widening feature scope
- keep single-line renderer seam contracts stable while tightening wrapped-body emission and annotation advancement
- add focused renderer coverage for the wrapped-body acceptance path
