### PR TITLE
pdf fidelity bundle v28: final acceptance sweep v2

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
@@ -747,9 +747,42 @@ fn build_page_content_stream_v0(
                 current_flow_kind == BodyFlowKindV0::Paragraph
                     && !previous_rendered_line_was_empty
                     && matches!(last_non_empty_flow_kind, Some(BodyFlowKindV0::Paragraph));
+            let next_line_unprefixed_alignment_continuation_v28 = lines
+                .get(line_index + 1)
+                .filter(|next_line| !next_line.glyphs.is_empty())
+                .map(|next_line| {
+                    detect_quote_prefix_advance_pt_v0(&next_line.glyphs).is_none()
+                        && !has_center_prefix_v0(&next_line.glyphs)
+                        && !has_right_prefix_v0(&next_line.glyphs)
+                        && !has_noindent_prefix_v0(&next_line.glyphs)
+                        && detect_heading_prefix_v0(&next_line.glyphs).is_none()
+                        && detect_list_prefix_v0(&next_line.glyphs).is_none()
+                })
+                .unwrap_or(false);
+            let wrapped_centered_alignment_v28 = !display_math_line
+                && (center_prefixed || centered_continuation)
+                && (centered_continuation
+                    || (!next_raw_line_is_empty && next_line_unprefixed_alignment_continuation_v28));
+            let wrapped_right_alignment_v28 = right_continuation
+                || (right_prefixed
+                    && !next_raw_line_is_empty
+                    && next_line_unprefixed_alignment_continuation_v28);
+            let emit_profile = if current_flow_kind == BodyFlowKindV0::Paragraph {
+                if line_contains_inline_math_placeholder_token_v15(&render_segments) {
+                    SegmentEmitProfileV0::BodyProseInlineMathV15
+                } else if flowing_line_continues_next_v27 || flowing_line_continues_from_previous_v27 {
+                    SegmentEmitProfileV0::BodyWrappedProseV27
+                } else {
+                    SegmentEmitProfileV0::BodyProseV13
+                }
+            } else if wrapped_centered_alignment_v28 || wrapped_right_alignment_v28 {
+                SegmentEmitProfileV0::WrappedAlignedV28
+            } else {
+                SegmentEmitProfileV0::Default
+            };
             let line_width_pt: f32 = render_segments
                 .iter()
-                .map(|segment| segment.advance_pt)
+                .map(|segment| render_advance_pt_for_segment_with_profile_v0(segment, emit_profile))
                 .sum();
             let line_x = if in_title_block {
                 active_inline_alignment = None;
@@ -892,17 +925,6 @@ fn build_page_content_stream_v0(
                 || heading_centered
                 || center_prefixed
                 || centered_continuation;
-            let emit_profile = if current_flow_kind == BodyFlowKindV0::Paragraph {
-                if line_contains_inline_math_placeholder_token_v15(&render_segments) {
-                    SegmentEmitProfileV0::BodyProseInlineMathV15
-                } else if flowing_line_continues_next_v27 || flowing_line_continues_from_previous_v27 {
-                    SegmentEmitProfileV0::BodyWrappedProseV27
-                } else {
-                    SegmentEmitProfileV0::BodyProseV13
-                }
-            } else {
-                SegmentEmitProfileV0::Default
-            };
             let annotation_profile = if bibliography_line {
                 AnnotationRectProfileV0::BibliographyV14
             } else if centered_or_heading_context {

--- a/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
@@ -10,6 +10,7 @@ enum SegmentEmitProfileV0 {
     Default,
     BodyProseV13,
     BodyWrappedProseV27,
+    WrappedAlignedV28,
     FootnoteProseV26,
     BodyProseInlineMathV15,
 }
@@ -47,6 +48,20 @@ fn wrapped_body_prose_style_scale_percent_v27(segment: &PdfRenderSegmentV0) -> u
     }
 }
 
+fn wrapped_aligned_style_scale_percent_v28(segment: &PdfRenderSegmentV0) -> u8 {
+    if segment.superscript {
+        return 100;
+    }
+    if !segment.bytes.iter().any(|byte| byte.is_ascii_alphabetic()) {
+        return 100;
+    }
+    match segment.style {
+        PdfTextStyleV0::Regular => 100,
+        PdfTextStyleV0::Italic => BODY_PROSE_ITALIC_SCALE_PERCENT_V13,
+        PdfTextStyleV0::Bold => BODY_PROSE_BOLD_SCALE_PERCENT_V13,
+    }
+}
+
 fn body_prose_style_scale_percent_v13(segment: &PdfRenderSegmentV0) -> u8 {
     if segment.superscript || segment.is_link {
         return 100;
@@ -71,6 +86,9 @@ fn style_scale_percent_for_profile_v0(
         SegmentEmitProfileV0::BodyWrappedProseV27 => {
             wrapped_body_prose_style_scale_percent_v27(segment)
         }
+        SegmentEmitProfileV0::WrappedAlignedV28 => {
+            wrapped_aligned_style_scale_percent_v28(segment)
+        }
         SegmentEmitProfileV0::FootnoteProseV26 => footnote_prose_style_scale_percent_v26(segment),
         SegmentEmitProfileV0::BodyProseInlineMathV15 => {
             if segment.superscript || segment.is_link {
@@ -94,7 +112,9 @@ fn render_advance_pt_for_segment_with_profile_v0(
 ) -> f32 {
     if !matches!(
         profile,
-        SegmentEmitProfileV0::FootnoteProseV26 | SegmentEmitProfileV0::BodyWrappedProseV27
+        SegmentEmitProfileV0::FootnoteProseV26
+            | SegmentEmitProfileV0::BodyWrappedProseV27
+            | SegmentEmitProfileV0::WrappedAlignedV28
     ) {
         return segment.advance_pt;
     }

--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
@@ -86,6 +86,10 @@ fn segment_width_pt_v0(segment: &[u8]) -> f32 {
     line.width_sp as f32 / 65_536.0
 }
 
+fn scaled_segment_width_pt_v0(segment: &[u8], scale_percent: u8) -> f32 {
+    segment_width_pt_v0(segment) * (scale_percent as f32 / 100.0)
+}
+
 fn decode_pdf_text_segments_from_line_v0(line: &str) -> Option<String> {
     let mut out = Vec::<u8>::new();
     let bytes = line.as_bytes();
@@ -970,6 +974,7 @@ fn pdf_renderer_wrapped_body_paragraph_styled_seams_track_scaled_advances_v27() 
     );
 }
 
+#[test]
 fn pdf_renderer_centers_title_block_lines_within_epsilon_v0() {
     let demo_text = b"Centering Accuracy Title\nAlice Bob\n2026-03-05\n\nBody line.";
     let xdv = write_dvi_v2_text_page_v0(demo_text).expect("writer should accept demo text");
@@ -2747,10 +2752,10 @@ fn pdf_renderer_center_alignment_keeps_wrapped_continuation_centered_v1() {
     )
     .expect("writer should accept wrapped centered text");
     let layout = parse_dvi_v2_text_page_to_layout_v0(&xdv, 786_432).expect("layout parse");
-    let expected_start_x = expected_center_x_pt_v0(
-        layout_render_width_for_substring_v0(&layout, b"CENTERSTART")
-            .expect("center start width"),
-    );
+    let expected_start_width_pt =
+        segment_width_pt_v0(b"CENTERSTART alpha ") + scaled_segment_width_pt_v0(b"mid", 97);
+    let expected_start_x =
+        (612.0 - expected_start_width_pt) / 2.0;
     let expected_wrap_x = expected_center_x_pt_v0(
         layout_render_width_for_substring_v0(&layout, b"WRAPCENTER").expect("center wrap width"),
     );
@@ -2776,6 +2781,15 @@ fn pdf_renderer_center_alignment_keeps_wrapped_continuation_centered_v1() {
         rendered == "CENTERSTART alpha mid",
         "center wrapped style boundaries should retain stable spacing: {rendered}"
     );
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    let centered_line = pdf_text
+        .lines()
+        .find(|line| line.contains("(mid) Tj"))
+        .expect("center wrapped styled segment should render");
+    assert!(
+        centered_line.contains("97 Tz") && centered_line.contains("(mid) Tj 100 Tz"),
+        "wrapped centered styled segment should use v28 seam compensation"
+    );
 }
 
 #[test]
@@ -2788,10 +2802,9 @@ fn pdf_renderer_right_alignment_keeps_wrapped_continuation_right_v1() {
     )
     .expect("writer should accept wrapped right-aligned text");
     let layout = parse_dvi_v2_text_page_to_layout_v0(&xdv, 786_432).expect("layout parse");
-    let expected_start_x = expected_right_x_pt_v0(
-        layout_render_width_for_substring_v0(&layout, b"RIGHTSTART")
-            .expect("right start width"),
-    );
+    let expected_start_width_pt =
+        segment_width_pt_v0(b"RIGHTSTART edge, ") + scaled_segment_width_pt_v0(b"core", 97);
+    let expected_start_x = 540.0 - expected_start_width_pt;
     let expected_wrap_x = expected_right_x_pt_v0(
         layout_render_width_for_substring_v0(&layout, b"WRAPRIGHT").expect("right wrap width"),
     );
@@ -2816,5 +2829,14 @@ fn pdf_renderer_right_alignment_keeps_wrapped_continuation_right_v1() {
     assert!(
         rendered == "RIGHTSTART edge, core",
         "right wrapped style boundaries should retain stable spacing: {rendered}"
+    );
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    let right_line = pdf_text
+        .lines()
+        .find(|line| line.contains("(core) Tj"))
+        .expect("right wrapped styled segment should render");
+    assert!(
+        right_line.contains("97 Tz") && right_line.contains("(core) Tj 100 Tz"),
+        "wrapped right styled segment should use v28 seam compensation"
     );
 }


### PR DESCRIPTION
Closes #487

## Summary
- polish wrapped centered and right-aligned line placement without expanding renderer scope
- use rendered seam-aware advances when placing wrapped aligned lines while preserving single-line drift contracts
- add focused coverage for wrapped centered/right placement and style-boundary compensation
