### PR TITLE
pdf fidelity bundle v29: final acceptance sweep v3

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
@@ -747,7 +747,7 @@ fn build_page_content_stream_v0(
                 current_flow_kind == BodyFlowKindV0::Paragraph
                     && !previous_rendered_line_was_empty
                     && matches!(last_non_empty_flow_kind, Some(BodyFlowKindV0::Paragraph));
-            let next_line_unprefixed_alignment_continuation_v28 = lines
+            let next_line_unprefixed_continuation_v0 = lines
                 .get(line_index + 1)
                 .filter(|next_line| !next_line.glyphs.is_empty())
                 .map(|next_line| {
@@ -762,11 +762,20 @@ fn build_page_content_stream_v0(
             let wrapped_centered_alignment_v28 = !display_math_line
                 && (center_prefixed || centered_continuation)
                 && (centered_continuation
-                    || (!next_raw_line_is_empty && next_line_unprefixed_alignment_continuation_v28));
+                    || (!next_raw_line_is_empty && next_line_unprefixed_continuation_v0));
             let wrapped_right_alignment_v28 = right_continuation
                 || (right_prefixed
                     && !next_raw_line_is_empty
-                    && next_line_unprefixed_alignment_continuation_v28);
+                    && next_line_unprefixed_continuation_v0);
+            let wrapped_quote_or_list_v29 = quote_continuation
+                || list_continuation
+                || (((quote_prefix_advance_pt.is_some()
+                    || matches!(
+                        list_prefix.map(|prefix| prefix.kind),
+                        Some(ListPrefixKindV0::Itemize | ListPrefixKindV0::Enumerate)
+                    ))
+                    && !next_raw_line_is_empty)
+                    && next_line_unprefixed_continuation_v0);
             let emit_profile = if current_flow_kind == BodyFlowKindV0::Paragraph {
                 if line_contains_inline_math_placeholder_token_v15(&render_segments) {
                     SegmentEmitProfileV0::BodyProseInlineMathV15
@@ -775,6 +784,8 @@ fn build_page_content_stream_v0(
                 } else {
                     SegmentEmitProfileV0::BodyProseV13
                 }
+            } else if wrapped_quote_or_list_v29 {
+                SegmentEmitProfileV0::WrappedIndentedV29
             } else if wrapped_centered_alignment_v28 || wrapped_right_alignment_v28 {
                 SegmentEmitProfileV0::WrappedAlignedV28
             } else {

--- a/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
@@ -11,6 +11,7 @@ enum SegmentEmitProfileV0 {
     BodyProseV13,
     BodyWrappedProseV27,
     WrappedAlignedV28,
+    WrappedIndentedV29,
     FootnoteProseV26,
     BodyProseInlineMathV15,
 }
@@ -62,6 +63,20 @@ fn wrapped_aligned_style_scale_percent_v28(segment: &PdfRenderSegmentV0) -> u8 {
     }
 }
 
+fn wrapped_indented_style_scale_percent_v29(segment: &PdfRenderSegmentV0) -> u8 {
+    if segment.superscript {
+        return 100;
+    }
+    if !segment.bytes.iter().any(|byte| byte.is_ascii_alphabetic()) {
+        return 100;
+    }
+    match segment.style {
+        PdfTextStyleV0::Regular => 100,
+        PdfTextStyleV0::Italic => BODY_PROSE_ITALIC_SCALE_PERCENT_V13,
+        PdfTextStyleV0::Bold => BODY_PROSE_BOLD_SCALE_PERCENT_V13,
+    }
+}
+
 fn body_prose_style_scale_percent_v13(segment: &PdfRenderSegmentV0) -> u8 {
     if segment.superscript || segment.is_link {
         return 100;
@@ -89,6 +104,9 @@ fn style_scale_percent_for_profile_v0(
         SegmentEmitProfileV0::WrappedAlignedV28 => {
             wrapped_aligned_style_scale_percent_v28(segment)
         }
+        SegmentEmitProfileV0::WrappedIndentedV29 => {
+            wrapped_indented_style_scale_percent_v29(segment)
+        }
         SegmentEmitProfileV0::FootnoteProseV26 => footnote_prose_style_scale_percent_v26(segment),
         SegmentEmitProfileV0::BodyProseInlineMathV15 => {
             if segment.superscript || segment.is_link {
@@ -115,6 +133,7 @@ fn render_advance_pt_for_segment_with_profile_v0(
         SegmentEmitProfileV0::FootnoteProseV26
             | SegmentEmitProfileV0::BodyWrappedProseV27
             | SegmentEmitProfileV0::WrappedAlignedV28
+            | SegmentEmitProfileV0::WrappedIndentedV29
     ) {
         return segment.advance_pt;
     }

--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
@@ -2840,3 +2840,47 @@ fn pdf_renderer_right_alignment_keeps_wrapped_continuation_right_v1() {
         "wrapped right styled segment should use v28 seam compensation"
     );
 }
+
+#[test]
+fn pdf_renderer_wrapped_quote_and_list_styled_seams_use_v29_profile() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"\n- LISTSTART alpha alpha alpha alpha alpha alpha alpha [LISTITALICV29] beta beta beta beta beta beta LISTWRAPV29.\n\n> QUOTESTART gamma gamma gamma gamma gamma gamma gamma {QUOTEBOLDV29} delta delta delta delta delta QUOTEWRAPV29.",
+    )
+    .expect("writer should accept wrapped quote/list text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    let list_line = pdf_text
+        .lines()
+        .find(|line| line.contains("(LISTITALICV29) Tj"))
+        .expect("wrapped list styled line should render");
+    let quote_line = pdf_text
+        .lines()
+        .find(|line| line.contains("(QUOTEBOLDV29) Tj"))
+        .expect("wrapped quote styled line should render");
+
+    assert!(
+        list_line.contains("97 Tz") && list_line.contains("(LISTITALICV29) Tj 100 Tz"),
+        "wrapped list styled segment should use v29 seam compensation"
+    );
+    assert!(
+        quote_line.contains("95 Tz") && quote_line.contains("(QUOTEBOLDV29) Tj 100 Tz"),
+        "wrapped quote styled segment should use v29 seam compensation"
+    );
+
+    let (_, list_start_y) =
+        tm_position_for_segment_substring_v0(&pdf, "LISTSTART").expect("wrapped list start");
+    let (_, list_wrap_y) =
+        tm_position_for_segment_substring_v0(&pdf, "LISTWRAPV29").expect("wrapped list wrap");
+    let (_, quote_start_y) =
+        tm_position_for_segment_substring_v0(&pdf, "QUOTESTART").expect("wrapped quote start");
+    let (_, quote_wrap_y) =
+        tm_position_for_segment_substring_v0(&pdf, "QUOTEWRAPV29").expect("wrapped quote wrap");
+    assert!(
+        list_start_y > list_wrap_y,
+        "list fixture should wrap onto a later line: list_start_y={list_start_y}, list_wrap_y={list_wrap_y}"
+    );
+    assert!(
+        quote_start_y > quote_wrap_y,
+        "quote fixture should wrap onto a later line: quote_start_y={quote_start_y}, quote_wrap_y={quote_wrap_y}"
+    );
+}


### PR DESCRIPTION
Closes #489

## Summary
- polish wrapped indented quote/list seam spacing without expanding renderer scope
- apply rendered seam-aware advances only to wrapped quote/list lines while preserving existing indent and transition invariants
- add focused renderer coverage for wrapped indented seam compensation
