### PR TITLE
pdf fidelity bundle v31: final acceptance sweep v5

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
@@ -767,15 +767,7 @@ fn build_page_content_stream_v0(
                 || (right_prefixed
                     && !next_raw_line_is_empty
                     && next_line_unprefixed_continuation_v0);
-            let wrapped_quote_or_list_v29 = quote_continuation
-                || list_continuation
-                || (((quote_prefix_advance_pt.is_some()
-                    || matches!(
-                        list_prefix.map(|prefix| prefix.kind),
-                        Some(ListPrefixKindV0::Itemize | ListPrefixKindV0::Enumerate)
-                    ))
-                    && !next_raw_line_is_empty)
-                    && next_line_unprefixed_continuation_v0);
+            let indented_quote_or_list_v31 = quote_line || list_line;
             let emit_profile = if current_flow_kind == BodyFlowKindV0::Paragraph {
                 if line_contains_inline_math_placeholder_token_v15(&render_segments) {
                     SegmentEmitProfileV0::BodyProseInlineMathV15
@@ -784,7 +776,7 @@ fn build_page_content_stream_v0(
                 } else {
                     SegmentEmitProfileV0::BodyProseV13
                 }
-            } else if wrapped_quote_or_list_v29 {
+            } else if indented_quote_or_list_v31 {
                 SegmentEmitProfileV0::WrappedIndentedV29
             } else if wrapped_centered_alignment_v28 || wrapped_right_alignment_v28 {
                 SegmentEmitProfileV0::WrappedAlignedV28

--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
@@ -2883,3 +2883,30 @@ fn pdf_renderer_wrapped_quote_and_list_styled_seams_use_v29_profile() {
         "quote fixture should wrap onto a later line: quote_start_y={quote_start_y}, quote_wrap_y={quote_wrap_y}"
     );
 }
+
+#[test]
+fn pdf_renderer_single_line_quote_and_list_styled_seams_use_v31_profile() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"\n- LISTLINEV31 alpha [LISTITALICV31] tail.\n\n> QUOTELINEV31 beta {QUOTEBOLDV31} tail.",
+    )
+    .expect("writer should accept single-line quote/list text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    let list_line = pdf_text
+        .lines()
+        .find(|line| line.contains("(LISTITALICV31) Tj"))
+        .expect("single-line list styled segment should render");
+    let quote_line = pdf_text
+        .lines()
+        .find(|line| line.contains("(QUOTEBOLDV31) Tj"))
+        .expect("single-line quote styled segment should render");
+
+    assert!(
+        list_line.contains("97 Tz") && list_line.contains("(LISTITALICV31) Tj 100 Tz"),
+        "single-line list styled segment should use indented seam compensation"
+    );
+    assert!(
+        quote_line.contains("95 Tz") && quote_line.contains("(QUOTEBOLDV31) Tj 100 Tz"),
+        "single-line quote styled segment should use indented seam compensation"
+    );
+}


### PR DESCRIPTION
Closes #493

## Summary
- apply the v31 indented seam profile to single-line quote and list lines
- keep the renderer change narrow to mixed-surface layout polish only
- add focused renderer coverage for single-line quote/list styled seams

## Proof
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml
- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12
- ./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25