### PR TITLE
pdf fidelity bundle v32: final acceptance sweep v6

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/content_stream_and_pdf_v0.rs
@@ -776,7 +776,7 @@ fn build_page_content_stream_v0(
                 } else {
                     SegmentEmitProfileV0::BodyProseV13
                 }
-            } else if indented_quote_or_list_v31 {
+            } else if bibliography_line || indented_quote_or_list_v31 {
                 SegmentEmitProfileV0::WrappedIndentedV29
             } else if wrapped_centered_alignment_v28 || wrapped_right_alignment_v28 {
                 SegmentEmitProfileV0::WrappedAlignedV28

--- a/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
@@ -64,7 +64,7 @@ fn wrapped_aligned_style_scale_percent_v28(segment: &PdfRenderSegmentV0) -> u8 {
 }
 
 fn wrapped_indented_style_scale_percent_v29(segment: &PdfRenderSegmentV0) -> u8 {
-    if segment.superscript {
+    if segment.superscript || segment.is_link {
         return 100;
     }
     if !segment.bytes.iter().any(|byte| byte.is_ascii_alphabetic()) {
@@ -159,7 +159,7 @@ fn trailing_space_bounded_seam_trim_pt_v30(
     ) {
         return 0.0;
     }
-    if segment.superscript || matches!(segment.style, PdfTextStyleV0::Regular) {
+    if segment.superscript || segment.is_link || matches!(segment.style, PdfTextStyleV0::Regular) {
         return 0.0;
     }
     let Some(next_segment) = next_segment else {

--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
@@ -2118,6 +2118,33 @@ fn pdf_renderer_bibliography_entries_use_hanging_indent_and_stable_rhythm_v14() 
 }
 
 #[test]
+fn pdf_renderer_bibliography_styled_seams_use_indented_profile_v32() {
+    let xdv = write_dvi_v2_text_page_v0(
+        b"@S {References}\n\n[1] BIBSTART [ITALICBIBV32] with {BOLDBIBV32} tail.",
+    )
+    .expect("writer should accept bibliography seam text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+    let pdf_text = String::from_utf8_lossy(&pdf);
+    let italic_line = pdf_text
+        .lines()
+        .find(|line| line.contains("(ITALICBIBV32) Tj"))
+        .expect("bibliography italic line should render");
+    let bold_line = pdf_text
+        .lines()
+        .find(|line| line.contains("(BOLDBIBV32) Tj"))
+        .expect("bibliography bold line should render");
+
+    assert!(
+        italic_line.contains("97 Tz") && italic_line.contains("(ITALICBIBV32) Tj 100 Tz"),
+        "bibliography italic seam should use indented seam compensation"
+    );
+    assert!(
+        bold_line.contains("95 Tz") && bold_line.contains("(BOLDBIBV32) Tj 100 Tz"),
+        "bibliography bold seam should use indented seam compensation"
+    );
+}
+
+#[test]
 fn pdf_renderer_body_to_bibliography_opening_gap_is_tightened_v17() {
     let xdv = write_dvi_v2_text_page_v0(
         b"~ Body before references.\n\n@S {References}\n\n[1] ALPHASTART alpha source text.",


### PR DESCRIPTION
Closes #495

## Summary
- route bibliography lines through the indented seam profile for mixed-surface polish
- preserve bibliography link geometry by excluding link runs from indented seam scaling and trim
- add focused bibliography seam coverage alongside the existing mixed-surface invariants

## Proof
- cargo test --manifest-path crates/carreltex-engine/Cargo.toml typeset_minimal_v0_tests
- cargo test --manifest-path crates/carreltex-xdv/Cargo.toml
- ./scripts/proof_wasm_typeset_minimal_v0.sh out | tail -n 12
- ./scripts/proof_wasm_fixture_gallery_v0.sh out | tail -n 25