### PR TITLE
pdf fidelity bundle v51: final acceptance sweep v25

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
@@ -210,6 +210,11 @@ fn trailing_space_bounded_seam_trim_pt_v30(
         {
             (segment.advance_pt * 0.06).min(font_size_pt * 1.4)
         } else if matches!(profile, SegmentEmitProfileV0::WrappedAlignedV28)
+            && matches!(next_segment.style, PdfTextStyleV0::Bold)
+            && segment.advance_pt >= 70.0
+        {
+            (segment.advance_pt * 0.045).min(font_size_pt * 1.0)
+        } else if matches!(profile, SegmentEmitProfileV0::WrappedAlignedV28)
             && segment.advance_pt >= 95.0
         {
             (segment.advance_pt * 0.05).min(font_size_pt * 1.2)

--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
@@ -3241,6 +3241,40 @@ fn pdf_renderer_wrapped_centered_bold_pre_style_gap_is_tightened_v50() {
 }
 
 #[test]
+fn pdf_renderer_wrapped_centered_medium_bold_pre_style_gap_is_tightened_v51() {
+    let xdv = write_dvi_v2_text_page_with_layout_and_wrap_v0(
+        b"\n^ CENTER preface {core words} trail words words WRAPCENTERMED tail.",
+        65_536,
+        786_432,
+        30,
+    )
+    .expect("writer should accept wrapped centered medium bold text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let (_, prefix_y) = tm_position_for_segment_substring_v0(&pdf, "CENTER")
+        .expect("centered medium bold prefix y");
+    let (_, wrap_y) = tm_position_for_segment_substring_v0(&pdf, "WRAPCENTERMED")
+        .expect("centered medium bold wrap y");
+    let rendered = rendered_text_for_line_containing_needle_v0(&pdf, "CENTER")
+        .expect("centered medium bold rendered text");
+    let max_tm_gap =
+        max_tm_gap_pt_for_line_containing_v0(&pdf, "core words").expect("centered medium bold tm gap");
+
+    assert!(
+        rendered == "CENTER preface core words",
+        "wrapped centered medium bold line should preserve stable spacing: {rendered}"
+    );
+    assert!(
+        max_tm_gap <= 120.0,
+        "wrapped centered medium bold pre-style seam should stay tightened: tm_gap={max_tm_gap}"
+    );
+    assert!(
+        prefix_y > wrap_y,
+        "centered medium bold fixture should still wrap after the tightened seam: prefix_y={prefix_y}, wrap_y={wrap_y}"
+    );
+}
+
+#[test]
 fn pdf_renderer_wrapped_quote_and_list_styled_seams_use_v29_profile() {
     let xdv = write_dvi_v2_text_page_v0(
         b"\n- LISTSTART alpha alpha alpha alpha alpha alpha alpha [LISTITALICV29] beta beta beta beta beta beta LISTWRAPV29.\n\n> QUOTESTART gamma gamma gamma gamma gamma gamma gamma {QUOTEBOLDV29} delta delta delta delta delta QUOTEWRAPV29.",


### PR DESCRIPTION
Closes #534

Renderer/layout polish only.

- tighten medium wrapped-centered bold pre-style seam gaps
- add focused regression coverage for wrapped-centered medium bold seam spacing
- keep all 4 hard gates green