### PR TITLE
pdf fidelity bundle v56: final acceptance sweep v30

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
@@ -220,6 +220,11 @@ fn trailing_space_bounded_seam_trim_pt_v30(
         {
             (segment.advance_pt * 0.045).min(font_size_pt * 1.0)
         } else if matches!(profile, SegmentEmitProfileV0::WrappedAlignedV28)
+            && matches!(next_segment.style, PdfTextStyleV0::Bold)
+            && segment.advance_pt >= 55.0
+        {
+            (segment.advance_pt * 0.035).min(font_size_pt * 0.85)
+        } else if matches!(profile, SegmentEmitProfileV0::WrappedAlignedV28)
             && matches!(next_segment.style, PdfTextStyleV0::Italic)
             && segment.advance_pt >= 70.0
         {

--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
@@ -3411,6 +3411,40 @@ fn pdf_renderer_wrapped_centered_short_pre_style_gap_is_tightened_v55() {
 }
 
 #[test]
+fn pdf_renderer_wrapped_right_short_bold_pre_style_gap_is_tightened_v56() {
+    let xdv = write_dvi_v2_text_page_with_layout_and_wrap_v0(
+        b"\n| RIGHT {core words} trail words words WRAPRIGHTSHORT tail.",
+        65_536,
+        786_432,
+        30,
+    )
+    .expect("writer should accept wrapped right short bold text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let (_, prefix_y) =
+        tm_position_for_segment_substring_v0(&pdf, "RIGHT").expect("right short bold prefix y");
+    let (_, wrap_y) = tm_position_for_segment_substring_v0(&pdf, "WRAPRIGHTSHORT")
+        .expect("right short bold wrap y");
+    let rendered = rendered_text_for_line_containing_needle_v0(&pdf, "RIGHT")
+        .expect("right short bold rendered text");
+    let max_tm_gap = max_tm_gap_pt_for_line_containing_v0(&pdf, "core words")
+        .expect("right short bold tm gap");
+
+    assert!(
+        rendered == "RIGHT core words trail",
+        "wrapped right short bold line should preserve stable spacing: {rendered}"
+    );
+    assert!(
+        max_tm_gap <= 106.0,
+        "wrapped right short bold pre-style seam should stay tightened: tm_gap={max_tm_gap}"
+    );
+    assert!(
+        prefix_y > wrap_y,
+        "right short bold fixture should still wrap after the tightened seam: prefix_y={prefix_y}, wrap_y={wrap_y}"
+    );
+}
+
+#[test]
 fn pdf_renderer_wrapped_quote_and_list_styled_seams_use_v29_profile() {
     let xdv = write_dvi_v2_text_page_v0(
         b"\n- LISTSTART alpha alpha alpha alpha alpha alpha alpha [LISTITALICV29] beta beta beta beta beta beta LISTWRAPV29.\n\n> QUOTESTART gamma gamma gamma gamma gamma gamma gamma {QUOTEBOLDV29} delta delta delta delta delta QUOTEWRAPV29.",


### PR DESCRIPTION
Closes #544

Renderer/layout polish only.

- tighten wrapped-right short bold pre-style seam gaps
- add focused regression coverage for wrapped-right short bold seam spacing
- keep all 4 hard gates green