### PR TITLE
pdf fidelity bundle v110: final acceptance sweep v84

### DIFF
--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
@@ -4566,6 +4566,25 @@ fn pdf_renderer_wrapped_right_medium_plain_medium_tier_gap_is_tightened_v108() {
 }
 
 #[test]
+fn pdf_renderer_wrapped_right_medium_plain_medium_tier_gap_is_tightened_v110() {
+    let xdv = write_dvi_v2_text_page_with_layout_and_wrap_v0(
+        b"\n| RIGHT preface core words trail words words WRAPRIGHTMEDPLAIN tail.",
+        65_536,
+        786_432,
+        30,
+    )
+    .expect("writer should accept wrapped right medium plain text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let actual_gap = max_tm_gap_pt_for_line_containing_v0(&pdf, "core words")
+        .expect("right medium plain tighter tm gap");
+    assert!(
+        actual_gap <= 101.0,
+        "wrapped right medium plain seam should stay slightly tighter after v110: actual_gap={actual_gap}"
+    );
+}
+
+#[test]
 fn pdf_renderer_wrapped_quote_and_list_styled_seams_use_v29_profile() {
     let xdv = write_dvi_v2_text_page_v0(
         b"\n- LISTSTART alpha alpha alpha alpha alpha alpha alpha [LISTITALICV29] beta beta beta beta beta beta LISTWRAPV29.\n\n> QUOTESTART gamma gamma gamma gamma gamma gamma gamma {QUOTEBOLDV29} delta delta delta delta delta QUOTEWRAPV29.",


### PR DESCRIPTION
Closes #652

## Summary
- tighten the wrapped right medium plain spacing seam in the renderer regression ladder
- add a focused regression for the next remaining visible roughness slice
- keep scope limited to renderer/layout fidelity polish with all hard gates green