### PR TITLE
pdf fidelity bundle v122: final acceptance sweep v96

### DIFF
--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
@@ -4794,6 +4794,25 @@ fn pdf_renderer_wrapped_right_medium_plain_medium_tier_gap_is_tightened_v121() {
 }
 
 #[test]
+fn pdf_renderer_wrapped_right_medium_plain_medium_tier_gap_is_tightened_v122() {
+    let xdv = write_dvi_v2_text_page_with_layout_and_wrap_v0(
+        b"\n| RIGHT preface core words trail words words WRAPRIGHTMEDPLAIN tail.",
+        65_536,
+        786_432,
+        30,
+    )
+    .expect("writer should accept wrapped right medium plain text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let actual_gap = max_tm_gap_pt_for_line_containing_v0(&pdf, "core words")
+        .expect("right medium plain tighter tm gap");
+    assert!(
+        actual_gap <= 97.0,
+        "wrapped right medium plain seam should stay slightly tighter after v122: actual_gap={actual_gap}"
+    );
+}
+
+#[test]
 fn pdf_renderer_wrapped_quote_and_list_styled_seams_use_v29_profile() {
     let xdv = write_dvi_v2_text_page_v0(
         b"\n- LISTSTART alpha alpha alpha alpha alpha alpha alpha [LISTITALICV29] beta beta beta beta beta beta LISTWRAPV29.\n\n> QUOTESTART gamma gamma gamma gamma gamma gamma gamma {QUOTEBOLDV29} delta delta delta delta delta QUOTEWRAPV29.",


### PR DESCRIPTION
Closes #676

- tighten one remaining renderer/layout roughness slice in the live proof PDF
- keep scope strictly within renderer/layout polish
- keep all 4 hard gates green