### PR TITLE
pdf fidelity bundle v127: final acceptance sweep v101

### DIFF
--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0.rs
@@ -4889,6 +4889,25 @@ fn pdf_renderer_wrapped_right_medium_plain_medium_tier_gap_is_tightened_v126() {
 }
 
 #[test]
+fn pdf_renderer_wrapped_right_medium_plain_medium_tier_gap_is_tightened_v127() {
+    let xdv = write_dvi_v2_text_page_with_layout_and_wrap_v0(
+        b"\n| RIGHT preface core words trail words words WRAPRIGHTMEDPLAIN tail.",
+        65_536,
+        786_432,
+        30,
+    )
+    .expect("writer should accept wrapped right medium plain text");
+    let pdf = render_dvi_v2_text_page_to_pdf_v0(&xdv).expect("pdf render");
+
+    let actual_gap = max_tm_gap_pt_for_line_containing_v0(&pdf, "core words")
+        .expect("right medium plain tighter tm gap");
+    assert!(
+        actual_gap <= 94.5,
+        "wrapped right medium plain seam should stay slightly tighter after v127: actual_gap={actual_gap}"
+    );
+}
+
+#[test]
 fn pdf_renderer_wrapped_quote_and_list_styled_seams_use_v29_profile() {
     let xdv = write_dvi_v2_text_page_v0(
         b"\n- LISTSTART alpha alpha alpha alpha alpha alpha alpha [LISTITALICV29] beta beta beta beta beta beta LISTWRAPV29.\n\n> QUOTESTART gamma gamma gamma gamma gamma gamma gamma {QUOTEBOLDV29} delta delta delta delta delta QUOTEWRAPV29.",


### PR DESCRIPTION
Closes #687

- tighten one remaining renderer/layout roughness slice in the live proof PDF
- keep scope strictly within renderer/layout polish
- keep all 4 hard gates green