### PR TITLE
fix: tighten wrapped aligned seam bundle v112

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
@@ -262,12 +262,12 @@ fn trailing_space_bounded_seam_trim_pt_v30(
             && matches!(next_segment.style, PdfTextStyleV0::Italic)
             && segment.advance_pt >= 14.0
         {
-            font_size_pt * 0.04
+            font_size_pt * 0.05
         } else if matches!(profile, SegmentEmitProfileV0::WrappedAlignedV28)
             && matches!(next_segment.style, PdfTextStyleV0::Italic)
             && segment.advance_pt >= 12.0
         {
-            font_size_pt * 0.03
+            font_size_pt * 0.04
         } else if matches!(profile, SegmentEmitProfileV0::WrappedAlignedV28)
             && matches!(next_segment.style, PdfTextStyleV0::Regular)
             && segment.advance_pt >= 70.0

--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0/wrapped_alignment.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0/wrapped_alignment.rs
@@ -1839,30 +1839,30 @@ fn pdf_renderer_wrapped_right_medium_plain_medium_tier_gap_is_tightened_v133() {
 }
 
 #[test]
-fn pdf_renderer_wrapped_aligned_plain_bundle_short_and_medium_gaps_are_tightened_v709() {
+fn pdf_renderer_wrapped_aligned_plain_bundle_short_and_medium_gaps_are_tightened_v711() {
     let cases = [
         (
             b"\n^ CENTERSTART edge, [core] trail words words words words WRAPCENTER tail.".as_slice(),
             "core",
-            14.65f32,
+            14.55f32,
             "centered short plain bundled tm gap",
         ),
         (
             b"\n| RIGHTSTART edge, [core] trail words words words words WRAPRIGHT tail.".as_slice(),
             "core",
-            13.15f32,
+            13.05f32,
             "right short plain bundled tm gap",
         ),
         (
             b"\n^ CENTER preface [core words] trail words words WRAPCENTERMED tail.".as_slice(),
             "core words",
-            12.15f32,
+            12.05f32,
             "centered medium plain bundled tm gap",
         ),
         (
             b"\n| RIGHT preface [core words] trail words words WRAPRIGHTMED tail.".as_slice(),
             "core words",
-            10.72f32,
+            10.62f32,
             "right medium plain bundled tm gap",
         ),
     ];
@@ -1876,13 +1876,13 @@ fn pdf_renderer_wrapped_aligned_plain_bundle_short_and_medium_gaps_are_tightened
             .expect("bundled wrapped aligned plain tm gap");
         assert!(
             actual_gap <= max_gap_pt,
-            "{label} should stay tightened in the v709 bundle: actual_gap={actual_gap}, max_gap_pt={max_gap_pt}"
+            "{label} should stay tightened in the v711 bundle: actual_gap={actual_gap}, max_gap_pt={max_gap_pt}"
         );
     }
 }
 
 #[test]
-fn pdf_renderer_wrapped_aligned_plain_center_right_medium_continuity_stays_coherent_v709() {
+fn pdf_renderer_wrapped_aligned_plain_center_right_medium_continuity_stays_coherent_v711() {
     let center_xdv = write_dvi_v2_text_page_with_layout_and_wrap_v0(
         b"\n^ preface [core words] trail words words WRAPALIGNPLAINBUNDLE tail.",
         65_536,
@@ -1905,7 +1905,7 @@ fn pdf_renderer_wrapped_aligned_plain_center_right_medium_continuity_stays_coher
     let right_gap = max_tm_gap_pt_for_line_containing_v0(&right_pdf, "core words")
         .expect("right continuity tm gap");
     assert!(
-        center_gap <= 9.72 && right_gap <= 9.72,
+        center_gap <= 9.71 && right_gap <= 9.71,
         "bundled aligned plain medium continuity gaps should both stay tightened: center_gap={center_gap}, right_gap={right_gap}"
     );
     assert!(


### PR DESCRIPTION
Closes #711

- tighten wrapped aligned centered/right short+medium plain seam bounds as one bundle
- keep centered/right medium continuity coherent in modular wrapped alignment coverage
- preserve renderer/layout-only scope and proof pins