### PR TITLE
fix: pdf fidelity bundle v205 milestone closure sweep v59

### DIFF
--- a/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
+++ b/crates/carreltex-xdv/src/pdf_v0/text_emit_v0.rs
@@ -58,8 +58,8 @@ fn wrapped_aligned_style_scale_percent_v28(segment: &PdfRenderSegmentV0) -> u8 {
     }
     match segment.style {
         PdfTextStyleV0::Regular => 100,
-        PdfTextStyleV0::Italic => 40,
-        PdfTextStyleV0::Bold => 38,
+        PdfTextStyleV0::Italic => 39,
+        PdfTextStyleV0::Bold => 37,
     }
 }
 

--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0/alignment_core.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0/alignment_core.rs
@@ -253,7 +253,7 @@ fn pdf_renderer_center_alignment_keeps_wrapped_continuation_centered_v1() {
     .expect("writer should accept wrapped centered text");
     let layout = parse_dvi_v2_text_page_to_layout_v0(&xdv, 786_432).expect("layout parse");
     let expected_start_width_pt =
-        segment_width_pt_v0(b"CENTERSTART alpha ") + scaled_segment_width_pt_v0(b"mid", 40);
+        segment_width_pt_v0(b"CENTERSTART alpha ") + scaled_segment_width_pt_v0(b"mid", 39);
     let expected_start_x =
         (612.0 - expected_start_width_pt) / 2.0;
     let expected_wrap_x = expected_center_x_pt_v0(
@@ -287,7 +287,7 @@ fn pdf_renderer_center_alignment_keeps_wrapped_continuation_centered_v1() {
         .find(|line| line.contains("(mid) Tj"))
         .expect("center wrapped styled segment should render");
     assert!(
-        centered_line.contains("40 Tz") && centered_line.contains("(mid) Tj 100 Tz"),
+        centered_line.contains("39 Tz") && centered_line.contains("(mid) Tj 100 Tz"),
         "wrapped centered styled segment should use v28 seam compensation"
     );
 }
@@ -303,7 +303,7 @@ fn pdf_renderer_right_alignment_keeps_wrapped_continuation_right_v1() {
     .expect("writer should accept wrapped right-aligned text");
     let layout = parse_dvi_v2_text_page_to_layout_v0(&xdv, 786_432).expect("layout parse");
     let expected_start_width_pt =
-        segment_width_pt_v0(b"RIGHTSTART edge, ") + scaled_segment_width_pt_v0(b"core", 40);
+        segment_width_pt_v0(b"RIGHTSTART edge, ") + scaled_segment_width_pt_v0(b"core", 39);
     let expected_start_x = 540.0 - expected_start_width_pt;
     let expected_wrap_x = expected_right_x_pt_v0(
         layout_render_width_for_substring_v0(&layout, b"WRAPRIGHT").expect("right wrap width"),
@@ -336,7 +336,7 @@ fn pdf_renderer_right_alignment_keeps_wrapped_continuation_right_v1() {
         .find(|line| line.contains("(core) Tj"))
         .expect("right wrapped styled segment should render");
     assert!(
-        right_line.contains("40 Tz") && right_line.contains("(core) Tj 100 Tz"),
+        right_line.contains("39 Tz") && right_line.contains("(core) Tj 100 Tz"),
         "wrapped right styled segment should use v28 seam compensation"
     );
 }

--- a/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0/wrapped_alignment.rs
+++ b/crates/carreltex-xdv/src/tests/pdf_layout_and_alignment_v0/wrapped_alignment.rs
@@ -1839,7 +1839,7 @@ fn pdf_renderer_wrapped_right_medium_plain_medium_tier_gap_is_tightened_v133() {
 }
 
 #[test]
-fn pdf_renderer_wrapped_aligned_plain_bundle_short_and_medium_gaps_are_tightened_v843() {
+fn pdf_renderer_wrapped_aligned_plain_bundle_short_and_medium_gaps_are_tightened_v845() {
     let cases = [
         (
             b"\n^ CENTERSTART edge, [core] trail words words words words WRAPCENTER tail.".as_slice(),
@@ -1876,13 +1876,13 @@ fn pdf_renderer_wrapped_aligned_plain_bundle_short_and_medium_gaps_are_tightened
             .expect("bundled wrapped aligned plain tm gap");
         assert!(
             actual_gap <= max_gap_pt,
-            "{label} should stay tightened in the v843 bundle: actual_gap={actual_gap}, max_gap_pt={max_gap_pt}"
+            "{label} should stay tightened in the v845 bundle: actual_gap={actual_gap}, max_gap_pt={max_gap_pt}"
         );
     }
 }
 
 #[test]
-fn pdf_renderer_wrapped_aligned_plain_center_right_medium_continuity_stays_coherent_v843() {
+fn pdf_renderer_wrapped_aligned_plain_center_right_medium_continuity_stays_coherent_v845() {
     let center_xdv = write_dvi_v2_text_page_with_layout_and_wrap_v0(
         b"\n^ preface [core words] trail words words WRAPALIGNPLAINBUNDLE tail.",
         65_536,
@@ -1915,7 +1915,7 @@ fn pdf_renderer_wrapped_aligned_plain_center_right_medium_continuity_stays_coher
 }
 
 #[test]
-fn pdf_renderer_wrapped_aligned_plain_acceptance_surface_stays_coherent_v843() {
+fn pdf_renderer_wrapped_aligned_plain_acceptance_surface_stays_coherent_v845() {
     let xdv = write_dvi_v2_text_page_with_layout_and_wrap_v0(
         b"\n^ CENTERSTART edge, [CSHORTCORE] trail words words words words WRAPCENTERACCEPTSHORT tail.\n\n| RIGHTSTART edge, [RSHORTCORE] trail words words words words WRAPRIGHTACCEPTSHORT tail.\n\n^ CENTER preface [CMEDCORE] trail words words WRAPCENTERACCEPTMED tail.\n\n| RIGHT preface [RMEDCORE] trail words words WRAPRIGHTACCEPTMED tail.",
         65_536,


### PR DESCRIPTION
Closes #845

- bundled renderer/layout polish only
- grouped wrapped-alignment / continuity cleanup from the current live PDF
- all 4 hard gates PASS